### PR TITLE
Data refresh flow updates

### DIFF
--- a/SkyAware/Sources/App/HomeView.swift
+++ b/SkyAware/Sources/App/HomeView.swift
@@ -6,38 +6,100 @@
 //
 
 import SwiftUI
-import SwiftData
 import CoreLocation
+import OSLog
 
 struct HomeView: View {
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.dependencies) private var dependencies
-
-    #warning("TODO: Remove swift data and call the repo properly")
-    @Query private var mesos: [MD]
-    @Query private var watches: [Watch]
     
+    private let logger = Logger.homeView
+    
+    // MARK: Local handles
+    private var sync: any SpcSyncing { dependencies.spcSync }
+    private var locSvc: LocationClient { dependencies.locationClient }
+    private var svc: any SpcRiskQuerying { dependencies.spcRisk }
+    private var outlookSvc: any SpcOutlookQuerying { dependencies.spcOutlook }
+    private var nwsSvc: any NwsRiskQuerying { dependencies.nwsRisk  }
+    private var nwsSync: any NwsSyncing { dependencies.nwsSync }
+
+    // MARK: State
+    // Header State
+    @State private var snap: LocationSnapshot?
+    
+    // Badge State
+    @State private var stormRisk: StormRiskLevel?
+    @State private var severeRisk: SevereWeatherThreat?
+    
+    // Alert State
+    @State private var mesos: [MdDTO] = []
+    @State private var watches: [WatchRowDTO] = []
+    
+    // Refresh State
+    @State private var lastRefreshKey: RefreshKey?
+    
+    // Outlook State
+    @State private var outlooks: [ConvectiveOutlookDTO] = []
+    @State private var outlook: ConvectiveOutlookDTO?
+
+    init(
+        initialSnap: LocationSnapshot? = nil,
+        initialStormRisk: StormRiskLevel? = nil,
+        initialSevereRisk: SevereWeatherThreat? = nil,
+        initialMesos: [MdDTO] = [],
+        initialWatches: [WatchRowDTO] = [],
+        initialOutlooks: [ConvectiveOutlookDTO] = [],
+        initialOutlook: ConvectiveOutlookDTO? = nil
+    ) {
+        _snap = State(initialValue: initialSnap)
+        _stormRisk = State(initialValue: initialStormRisk)
+        _severeRisk = State(initialValue: initialSevereRisk)
+        _mesos = State(initialValue: initialMesos)
+        _watches = State(initialValue: initialWatches)
+        _outlook = State(initialValue: initialOutlook)
+        _outlooks = State(initialValue: initialOutlooks)
+    }
+
     var body: some View {
         ZStack {
             Color(.skyAwareBackground).ignoresSafeArea()
             TabView {
                 NavigationStack {
-                    SummaryView()
+                    ScrollView {
+                        SummaryView(
+                            snap: snap,
+                            stormRisk: stormRisk,
+                            severeRisk: severeRisk,
+                            mesos: mesos,
+                            watches: watches,
+                            outlook: outlook
+                        )
                         .toolbar(.hidden, for: .navigationBar)
                         .background(.skyAwareBackground)
+                    }
+                    .scrollContentBackground(.hidden)
+                    .background(Color.skyAwareBackground.ignoresSafeArea())
+                    .refreshable {
+                        lastRefreshKey = nil
+                        await refresh(for: snap)
+                    }
                 }
                 .tabItem { Label("Today", systemImage: "clock.arrow.trianglehead.clockwise.rotate.90.path.dotted")
 //                    "clock.arrow.trianglehead.2.counterclockwise.rotate.90") //gauge.with.needle.fill
                 }
                 
                 NavigationStack {
-                    AlertView()
+                    AlertView(mesos: mesos, watches: watches)
                         .navigationTitle("Active Alerts")
                         .navigationBarTitleDisplayMode(.inline)
             //            .toolbarBackground(.visible, for: .navigationBar)      // <- non-translucent
                         .toolbarBackground(.skyAwareBackground, for: .navigationBar)
                         .scrollContentBackground(.hidden)
                         .background(.skyAwareBackground)
+                        .refreshable {
+                            logger.debug("refreshing alerts")
+                            await refresh(for: snap)
+                        }
                 }
                 .tabItem { Label("Alerts", systemImage: "exclamationmark.triangle") }//umbrella
                     .badge(mesos.count + watches.count)
@@ -48,12 +110,17 @@ struct HomeView: View {
                     .tabItem { Label("Map", systemImage: "map") }
                 
                 NavigationStack {
-                    ConvectiveOutlookView()
+                    ConvectiveOutlookView(dtos: outlooks)
                         .navigationTitle("Convective Outlooks")
                         .navigationBarTitleDisplayMode(.inline)
                         .toolbarBackground(.skyAwareBackground, for: .navigationBar)
                         .scrollContentBackground(.hidden)
                         .background(.skyAwareBackground)
+                        .refreshable {
+                            logger.debug("refreshing outlooks")
+                            await sync.syncTextProducts()
+                            await refreshOutlooks()
+                        }
                 }
                 .tabItem { Label("Outlooks", systemImage: "list.clipboard.fill") }
                 
@@ -72,14 +139,104 @@ struct HomeView: View {
         }
         .transition(.opacity)
         .tint(.skyAwareAccent)
-        .task {
+        .task(id: scenePhase) {
+            if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" { return }
             dependencies.locationManager.checkLocationAuthorization(isActive: true)
             dependencies.locationManager.updateMode(for: scenePhase)
+            guard scenePhase == .active else { return }
+            
+            // Whenever a location snapshot hits, refresh the data with
+            // the newest location.
+            let stream = await locSvc.updates()
+            for await s in stream {
+                if Task.isCancelled { break }
+                await MainActor.run { snap = s }
+                await refresh(for: s)
+            }
+        }
+    }
+    
+    /// Refreshes outlook plus location-scoped data together
+    private func refresh(for snap: LocationSnapshot?) async {
+        guard let snap else {
+            logger.warning("No location snapshot, skipping refresh")
+            return
+        }
+        guard shouldRefresh(for: snap) else {
+            logger.info("Refresh denied, no change detected")
+            return
+        }
+
+        logger.info("Refreshing summary data")
+        
+        await sync.syncTextProducts() // This was moved from app init (SkyAwareApp), if timing is an issue, may need to put it back
+        await refreshOutlooks()
+        await nwsSync.sync(for: snap.coordinates)
+        await refreshRisk(for: snap.coordinates)
+    }
+    
+    private func refreshOutlooks() async {
+        do {
+            let dtos = try await outlookSvc.getConvectiveOutlooks()
+            let latest = dtos.max(by: { $0.published < $1.published })
+            if Task.isCancelled { return }
+            await MainActor.run {
+                self.outlooks = dtos
+                self.outlook = latest
+            }
+        } catch {
+            // Swallow for now; consider logging
+        }
+    }
+    
+    private func shouldRefresh(for snap: LocationSnapshot) -> Bool {
+        let key = RefreshKey(coord: snap.coordinates, timestamp: snap.timestamp)
+        guard key != lastRefreshKey else { return false } // skip placemark-only or repeated initial yield
+        lastRefreshKey = key
+        return true
+    }
+    
+    private func refreshRisk(for coord: CLLocationCoordinate2D) async {
+        async let stormResult = capture { try await svc.getStormRisk(for: coord) }
+        async let severeResult = capture { try await svc.getSevereRisk(for: coord) }
+        async let mesosResult = capture { try await svc.getActiveMesos(at: .now, for: coord) }
+        async let watchResult = capture { try await nwsSvc.getActiveWatches(for: coord) }
+        
+        let (storm, severe, mesos, watch) = await (stormResult, severeResult, mesosResult, watchResult)
+        if Task.isCancelled { return }
+        
+        await MainActor.run {
+            if case let .success(value) = storm { self.stormRisk = value }
+            if case let .success(value) = severe { self.severeRisk = value }
+            if case let .success(value) = mesos { self.mesos = value }
+            if case let .success(value) = watch { self.watches = value }
+        }
+    }
+    
+    private func capture<T>(_ operation: @Sendable () async throws -> T) async -> Result<T, Error> {
+        do {
+            return .success(try await operation())
+        } catch {
+            return .failure(error)
         }
     }
 }
 
 // MARK: Preview
 #Preview("Home") {
-    HomeView()
+    HomeView(
+        initialSnap: .init(
+            coordinates: .init(latitude: 39.75, longitude: -104.44),
+            timestamp: .now,
+            accuracy: 20,
+            placemarkSummary: "Bennett, CO"
+        ),
+        initialStormRisk: .slight,
+        initialSevereRisk: .tornado(probability: 0.10),
+        initialMesos: MD.sampleDiscussionDTOs,
+        initialWatches: Watch.sampleWatchRows,
+        initialOutlooks: ConvectiveOutlook.sampleOutlookDtos,
+        initialOutlook: ConvectiveOutlook.sampleOutlookDtos.first
+    )
+    .environment(\.dependencies, Dependencies.unconfigured)
 }

--- a/SkyAware/Sources/Features/Alert/AlertRowView.swift
+++ b/SkyAware/Sources/Features/Alert/AlertRowView.swift
@@ -75,7 +75,7 @@ struct AlertRowView: View {
 }
 
 #Preview {
-    AlertRowView(alert: MD.sampleDiscussions.first!)
-    AlertRowView(alert: Watch.sampleWatches.last!)
-    AlertRowView(alert: Watch.sampleWatches[0])
+    AlertRowView(alert: MD.sampleDiscussionDTOs.first!)
+    AlertRowView(alert: Watch.sampleWatchRows.last!)
+    AlertRowView(alert: Watch.sampleWatchRows[0])
 }

--- a/SkyAware/Sources/Features/Alert/AlertView.swift
+++ b/SkyAware/Sources/Features/Alert/AlertView.swift
@@ -6,19 +6,15 @@
 //
 
 import SwiftUI
-import SwiftData
 
 struct AlertView: View {
-    @Environment(\.modelContext) private var modelContext
+    let mesos: [MdDTO]
+    let watches: [WatchRowDTO]
+    
+    @State private var selectedWatch: WatchRowDTO?
+    @State private var selectedMeso: MdDTO?
     
     private let scale: Double = 0.9
-    
-    // TODO: These need to come from the parent
-    @Query private var mesos: [MD]
-    @Query private var watches: [Watch]
-    
-    @State private var selectedWatch: Watch?
-    @State private var selectedMeso: MD?
     
     var body: some View {
         List {
@@ -47,12 +43,12 @@ struct AlertView: View {
                                 }
                                 .padding(.horizontal)
                         }
-                        .onDelete(perform: { indexSet in
-                            indexSet.forEach { index in
-                                let watch = watches[index]
-                                modelContext.delete(watch)
-                            }
-                        })
+//                        .onDelete(perform: { indexSet in
+//                            indexSet.forEach { index in
+//                                let watch = watches[index]
+//                                modelContext.delete(watch)
+//                            }
+//                        })
                     }
                 }
                 
@@ -73,22 +69,13 @@ struct AlertView: View {
                                 }
                                 .padding(.horizontal)
                         }
-                        .onDelete(perform: { indexSet in
-                            indexSet.forEach { index in
-                                let meso = mesos[index]
-                                modelContext.delete(meso)
-                            }
-                        })
                     }
                 }
             }
         }
         .navigationDestination(item: $selectedWatch) { watch in
-            #warning("TODO: Need to get real DTOs here")
-            let tempDto = WatchRowDTO(from: watch)
-            
             ScrollView {
-                WatchDetailView(watch: tempDto, layout: .full)
+                WatchDetailView(watch: watch, layout: .full)
             }
             .navigationTitle("Weather Watch")
             .navigationBarTitleDisplayMode(.inline)
@@ -97,22 +84,8 @@ struct AlertView: View {
             .background(.skyAwareBackground)
         }
         .navigationDestination(item: $selectedMeso) { meso in
-            // TODO: Need to get a MdDTO here to pass to the discussion card.
-            #warning("TODO: Need to get real DTOs here")
-            let tempDto = MdDTO(number: meso.number,
-                                title: meso.title,
-                                link: meso.link,
-                                issued: meso.issued,
-                                validStart: meso.validStart,
-                                validEnd: meso.validEnd,
-                                areasAffected: meso.areasAffected,
-                                summary: meso.summary,
-                                watchProbability: meso.watchProbability,
-                                threats: meso.threats ?? nil,
-                                coordinates:meso.coordinates
-            )
             ScrollView {
-                MesoscaleDiscussionCard(meso: tempDto, layout: .full)
+                MesoscaleDiscussionCard(meso: meso, layout: .full)
 //                    .padding(.horizontal, 16)
 //                    .padding(.top, 16)
             }
@@ -123,24 +96,12 @@ struct AlertView: View {
             .background(.skyAwareBackground)
         }
         .contentMargins(.top, 0, for: .scrollContent)
-        .refreshable {
-            Task {
-                print("Refreshing Alerts")
-//                try await provider.fetchMesoDiscussions()
-//                try await provider.fetchWatches()
-            }
-        }
     }
 }
 
 #Preview {
-    let preview = Preview(MD.self, Watch.self)
-    preview.addExamples(MD.sampleDiscussions)
-    preview.addExamples(Watch.sampleWatches)
-    
-    return NavigationStack {
-        AlertView()
-            .modelContainer(preview.container)
+    NavigationStack {
+        AlertView(mesos: MD.sampleDiscussionDTOs, watches: Watch.sampleWatchRows)
             .navigationTitle("Active Alerts")
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(.skyAwareBackground, for: .navigationBar)

--- a/SkyAware/Sources/Features/Summary/SummaryView.swift
+++ b/SkyAware/Sources/Features/Summary/SummaryView.swift
@@ -12,220 +12,92 @@ import OSLog
 struct SummaryView: View {
     // MARK: Environment
     @Environment(\.scenePhase) private var scenePhase
-    @Environment(\.dependencies) private var deps
     
     private let logger = Logger.summaryView
     
-    // MARK: Local handles
-    private var sync: any SpcSyncing { deps.spcSync }
-    private var locSvc: LocationClient { deps.locationClient }
-    private var svc: any SpcRiskQuerying { deps.spcRisk }
-    private var outlookSvc: any SpcOutlookQuerying { deps.spcOutlook }
-    private var nwsSvc: any NwsRiskQuerying { deps.nwsRisk  }
-    private var nwsSync: any NwsSyncing { deps.nwsSync }
-
-    // MARK: State
-    // Header State
-    @State private var snap: LocationSnapshot?
-    
-    // Badge State
-    @State private var stormRisk: StormRiskLevel?
-    @State private var severeRisk: SevereWeatherThreat?
-    
-    // Alert State
-    @State private var mesos: [MdDTO]
-    @State private var watches: [WatchRowDTO]
-    
-    // Refresh State
-    @State private var lastRefreshKey: RefreshKey?
-    
-    // Outlook State
-    @State private var outlook: ConvectiveOutlookDTO?
-    
-    init( // This is purely for Preview functionality.
-        initialStormRisk: StormRiskLevel? = nil,
-        initialSevereRisk: SevereWeatherThreat? = nil,
-        initialSnapshot: LocationSnapshot? = nil,
-        initialOutlook: ConvectiveOutlookDTO? = nil,
-        initialMesos: [MdDTO] = [],
-        initialWatches: [WatchRowDTO] = []
-    ) {
-        _stormRisk = State(initialValue: initialStormRisk)
-        _severeRisk = State(initialValue: initialSevereRisk)
-        _snap = State(initialValue: initialSnapshot)
-        _outlook = State(initialValue: initialOutlook)
-        _mesos = State(initialValue: initialMesos)
-        _watches = State(initialValue: initialWatches)
-    }
+    let snap: LocationSnapshot?
+    let stormRisk: StormRiskLevel?
+    let severeRisk: SevereWeatherThreat?
+    let mesos: [MdDTO]
+    let watches: [WatchRowDTO]
+    let outlook: ConvectiveOutlookDTO?
     
     var body: some View {
-        ScrollView {
-            VStack {
-                // Header
-                SummaryStatus(
-                    location: snap?.placemarkSummary ?? "Searching...",
-                    updatedAt: outlook?.published
-                )
-                .placeholder(outlook == nil || snap == nil)
-                
-                // Badges
-                HStack {
-                    StormRiskBadgeView(level: stormRisk ?? .allClear)
-                        .placeholder(stormRisk == nil)
-                    Spacer()
-                    SevereWeatherBadgeView(threat: severeRisk ?? .allClear)
-                        .placeholder(severeRisk == nil)
-                }
-                .padding(.vertical, 24)
-                
-                // Alerts
-                if !mesos.isEmpty || !watches.isEmpty {
-                    ActiveAlertSummaryView(
-                        mesos: mesos,
-                        watches: watches
-                    )
-                    .toolbar(.hidden, for: .navigationBar)
-                    .background(.skyAwareBackground)
-                    .padding(.bottom, 12)
-                }
-                
-                // Current Outlook
-                if let outlook {
-                    OutlookSummaryCard(outlook: outlook)
-                        .padding(.bottom, 12)
-                }
+        VStack {
+            // Header
+            SummaryStatus(
+                location: snap?.placemarkSummary ?? "Searching...",
+                updatedAt: outlook?.published
+            )
+            .placeholder(outlook == nil || snap == nil)
+            
+            // Badges
+            HStack {
+                StormRiskBadgeView(level: stormRisk ?? .allClear)
+                    .placeholder(stormRisk == nil)
                 Spacer()
+                SevereWeatherBadgeView(threat: severeRisk ?? .allClear)
+                    .placeholder(severeRisk == nil)
             }
-            .padding()
-        }
-        .scrollContentBackground(.hidden)
-        .background(Color.skyAwareBackground.ignoresSafeArea())
-        .task(id: scenePhase) {
-            if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" { return }
-            guard scenePhase == .active else { return }
+            .padding(.vertical, 24)
             
-            //            let initial = await locSvc.snapshot()
-            //            await MainActor.run { snap = initial }
-            //            await refresh(for: initial)
-            
-            // Whenever a location snapshot hits, refresh the data with
-            // the newest location.
-            let stream = await locSvc.updates()
-            for await s in stream {
-                if Task.isCancelled { break }
-                await MainActor.run { snap = s }
-                await refresh(for: s)
+            // Alerts
+            if !mesos.isEmpty || !watches.isEmpty {
+                ActiveAlertSummaryView(
+                    mesos: mesos,
+                    watches: watches
+                )
+                .toolbar(.hidden, for: .navigationBar)
+                .background(.skyAwareBackground)
+                .padding(.bottom, 12)
             }
+            
+            // Current Outlook
+            if let outlook {
+                OutlookSummaryCard(outlook: outlook)
+                    .padding(.bottom, 12)
+            }
+            Spacer()
         }
-        .refreshable {
-            lastRefreshKey = nil
-            await refresh(for: snap)
-        }
-    }
-    
-    /// Refreshes outlook plus location-scoped data together
-    private func refresh(for snap: LocationSnapshot?) async {
-        guard let snap else {
-            logger.warning("No location snapshot, skipping refresh")
-            return
-        }
-        guard shouldRefresh(for: snap) else {
-            logger.info("Refresh denied, no change detected")
-            return
-        }
-
-        logger.info("Refreshing summary data")
-        
-        await sync.syncTextProducts() // This was moved from app init (SkyAwareApp), if timing is an issue, may need to put it back
-        await refreshOutlook()
-        await nwsSync.sync(for: snap.coordinates)
-        await refreshRisk(for: snap.coordinates)
-    }
-    
-    private func refreshOutlook() async {
-        do {
-            let o = try await outlookSvc.getLatestConvectiveOutlook()
-            if Task.isCancelled { return }
-            await MainActor.run { self.outlook = o }
-        } catch {
-            // Swallow for now; consider logging
-        }
-    }
-    
-    private func shouldRefresh(for snap: LocationSnapshot) -> Bool {
-        let key = RefreshKey(coord: snap.coordinates, timestamp: snap.timestamp)
-        guard key != lastRefreshKey else { return false } // skip placemark-only or repeated initial yield
-        lastRefreshKey = key
-        return true
-    }
-    
-    private func refreshRisk(for coord: CLLocationCoordinate2D) async {
-        async let stormResult = capture { try await svc.getStormRisk(for: coord) }
-        async let severeResult = capture { try await svc.getSevereRisk(for: coord) }
-        async let mesosResult = capture { try await svc.getActiveMesos(at: .now, for: coord) }
-        async let watchResult = capture { try await nwsSvc.getActiveWatches(for: coord) }
-        
-        let (storm, severe, mesos, watch) = await (stormResult, severeResult, mesosResult, watchResult)
-        if Task.isCancelled { return }
-        
-        await MainActor.run {
-            if case let .success(value) = storm { self.stormRisk = value }
-            if case let .success(value) = severe { self.severeRisk = value }
-            if case let .success(value) = mesos { self.mesos = value }
-            if case let .success(value) = watch { self.watches = value }
-        }
-    }
-    
-    private func capture<T>(_ operation: @Sendable () async throws -> T) async -> Result<T, Error> {
-        do {
-            return .success(try await operation())
-        } catch {
-            return .failure(error)
-        }
+        .padding()
     }
 }
 
 // MARK: Previews
 #Preview("Summary – Slight + 10% Tornado") {
-    // Seed some sample Mesos so ActiveMesoSummaryView has content
-    let spcMock = MockSpcService(storm: .slight, severe: .tornado(probability: 0.10))
-    let mdPreview = Preview(MD.self, ConvectiveOutlook.self)
-    
-    mdPreview.addExamples(MD.sampleDiscussions)
-    mdPreview.addExamples(ConvectiveOutlook.sampleOutlooks)
-    
-    return NavigationStack {
+    NavigationStack {
         SummaryView(
-            initialStormRisk: .slight,
-            initialSevereRisk: .tornado(probability: 0.10),
-            initialSnapshot: .init(
+            snap: .init(
                 coordinates: .init(latitude: 39.75, longitude: -104.44),
                 timestamp: .now,
                 accuracy: 20,
                 placemarkSummary: "Bennett, CO"
             ),
-            initialOutlook: ConvectiveOutlook.sampleOutlookDtos.first!,
-            initialMesos: MD.sampleDiscussionDTOs,
-            initialWatches: Watch.sampleWatchRows
+            stormRisk: .slight,
+            severeRisk: .tornado(probability: 0.10),
+            mesos: MD.sampleDiscussionDTOs,
+            watches: Watch.sampleWatchRows,
+            outlook: ConvectiveOutlook.sampleOutlookDtos.first
         )
         .toolbar(.hidden, for: .navigationBar)
         .background(.skyAwareBackground)
-        .modelContainer(mdPreview.container)
     }
 }
 
 #Preview("Summary – Loading") {
-    // Seed some sample Mesos so ActiveMesoSummaryView has content
-    let spcMock = MockSpcService(storm: .slight, severe: .tornado(probability: 0.10))
-    
-    return NavigationStack {
+    NavigationStack {
         SummaryView(
-            initialSnapshot: .init(
+            snap: .init(
                 coordinates: .init(latitude: 39.75, longitude: -104.44),
                 timestamp: .now,
                 accuracy: 20,
                 placemarkSummary: "Bennett, CO"
-            )
+            ),
+            stormRisk: nil,
+            severeRisk: nil,
+            mesos: [],
+            watches: [],
+            outlook: nil
         )
         .toolbar(.hidden, for: .navigationBar)
         .background(.skyAwareBackground)

--- a/SkyAware/Sources/Models/Coordinate2D.swift
+++ b/SkyAware/Sources/Models/Coordinate2D.swift
@@ -8,7 +8,7 @@
 import Foundation
 import CoreLocation
 
-struct Coordinate2D: Sendable, Codable {
+struct Coordinate2D: Sendable, Codable, Hashable {
     let latitude: Double
     let longitude: Double
 

--- a/SkyAware/Sources/Models/Meso/MdDTO.swift
+++ b/SkyAware/Sources/Models/Meso/MdDTO.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 // DTO for transfering across actor boundaries
-struct MdDTO: Sendable, Identifiable {
+struct MdDTO: Sendable, Identifiable, Hashable, AlertItem {
+    let alertType: AlertType = .mesoscale
+    
     let id: UUID                // usually the GUID or derived from it
     let number: Int             // the MD number 1895
     let title: String           // e.g., "Day 1 Convective Outlook"

--- a/SkyAware/Sources/Models/Meso/MesoscaleDiscussion.swift
+++ b/SkyAware/Sources/Models/Meso/MesoscaleDiscussion.swift
@@ -10,7 +10,7 @@ import SwiftData
 import CoreLocation
 
 @Model
-final class MD: AlertItem {
+final class MD {
     var id: UUID                // usually the GUID or derived from it
     @Attribute(.unique) var number: Int             // the MD number 1895
     var title: String           // e.g., "Day 1 Convective Outlook"
@@ -85,7 +85,7 @@ final class MD: AlertItem {
     }
 }
 
-struct MDThreats: Sendable, Codable {
+struct MDThreats: Sendable, Codable, Hashable {
     var peakWindMPH: Int?            // e.g. 60
     var hailRangeInches: Double? // e.g. 1.5...2.5
     var tornadoStrength: String?     // e.g. "Brief / weak", "EF1+ possible", or nil

--- a/SkyAware/Sources/Models/Watches/Watch.swift
+++ b/SkyAware/Sources/Models/Watches/Watch.swift
@@ -15,17 +15,17 @@ extension Watch {
     nonisolated var isActive: Bool { true }
 }
 
-extension Watch: AlertItem {
-    // Alert Item - Derived
-    nonisolated var number: Int          {0}
-    nonisolated var title: String        {self.event}      // e.g., "Day 1 Convective Outlook"
-    nonisolated var link: URL            {URL(string:"\(self.nwsId)")!}      // link to full outlook page
-    nonisolated var issued: Date         {self.sent}      // pubDate
-    nonisolated var validStart: Date     {self.effective}      // Valid start
-    nonisolated var validEnd: Date       {self.ends}      // Valid end
-    nonisolated var summary: String      {self.watchDescription}      // description / CDATA
-    nonisolated var alertType: AlertType { AlertType.watch }      // Type of alert to conform to alert item
-}
+//extension Watch: AlertItem {
+//    // Alert Item - Derived
+//    nonisolated var number: Int          {0}
+//    nonisolated var title: String        {self.event}      // e.g., "Day 1 Convective Outlook"
+//    nonisolated var link: URL            {URL(string:"\(self.nwsId)")!}      // link to full outlook page
+//    nonisolated var issued: Date         {self.sent}      // pubDate
+//    nonisolated var validStart: Date     {self.effective}      // Valid start
+//    nonisolated var validEnd: Date       {self.ends}      // Valid end
+//    nonisolated var summary: String      {self.watchDescription}      // description / CDATA
+//    nonisolated var alertType: AlertType { AlertType.watch }      // Type of alert to conform to alert item
+//}
 
 @Model
 final class Watch {

--- a/SkyAware/Sources/Models/Watches/WatchRowDTO.swift
+++ b/SkyAware/Sources/Models/Watches/WatchRowDTO.swift
@@ -7,12 +7,17 @@
 
 import Foundation
 
-extension WatchRowDTO {
-    // Derived
+extension WatchRowDTO: AlertItem {
+    // Alert Item - Derived
+    nonisolated var number: Int          {0}
     nonisolated var link: URL { URL(string:"https://api.weather.gov/alerts/\(self.id)")! } // link to full page
+    nonisolated var validStart: Date     {self.issued}      // Valid start
+    nonisolated var validEnd: Date       {self.expires}      // Valid end
+    nonisolated var summary: String      {self.description}      // description / CDATA
+    nonisolated var alertType: AlertType { AlertType.watch }      // Type of alert to conform to alert item
 }
 
-struct WatchRowDTO: Identifiable, Sendable {
+struct WatchRowDTO: Identifiable, Sendable, Hashable {
     // Identity
     let id: String              // nwsId
     

--- a/SkyAware/Sources/Utilities/Extensions/Logger+Extension.swift
+++ b/SkyAware/Sources/Utilities/Extensions/Logger+Extension.swift
@@ -50,6 +50,7 @@ extension Logger {
     static let mainView = Logger(subsystem: subsystem, category: "MainView")
     static let mapping = Logger(subsystem: subsystem, category: "MappingView")
     static let summaryView = Logger(subsystem: subsystem, category: "SummaryView")
+    static let homeView = Logger(subsystem: subsystem, category: "HomeView")
     
     // MARK: Notification
     static let notifications = Logger(subsystem: subsystem, category: "NotificationManager")


### PR DESCRIPTION
- HomeView now owns location-scoped state (snapshot, risks, alerts, outlooks) and pushes it down to Summary/Alerts/Outlooks, with pull-to-refresh wiring

- SummaryView becomes a pure presentational view and previews are updated to feed explicit sample inputs

- AlertView now accepts DTOs, removes SwiftData queries/deletes, and previews use DTO samples; AlertRowView previews updated to DTOs

- ConvectiveOutlookView takes preloaded DTOs and preview uses sample data

- DTO/model tweaks: MdDTO now conforms to AlertItem/Hashable, WatchRowDTO conforms to AlertItem/Hashable, Coordinate2D is Hashable, MDThreats is Hashable, and Watch’s AlertItem conformance is removed

- Added a homeView logger category for HomeView diagnostics

@codex review