### PR TITLE
Update timeout doc comment

### DIFF
--- a/SkyAware/Sources/Utilities/Core/Timeout.swift
+++ b/SkyAware/Sources/Utilities/Core/Timeout.swift
@@ -11,7 +11,7 @@ import Foundation
 /// - Parameters:
 ///   - timeout: seconds to wait
 ///   - task: the closure with a task to perform
-/// - Throws: OtherError.TimeoutError
+/// - Throws: ``OtherErrors.timeoutError`` if the task does not complete before the timeout elapses
 /// - Returns: T
 func withTimeout<T: Sendable>(
     timeout: Double,


### PR DESCRIPTION
## Summary
- correct the timeout helper documentation to reference `OtherErrors.timeoutError`
- clarify when the timeout error is thrown

## Testing
- not run (doc-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69595410e2fc832a9242e657f12eb1d5)