### PR TITLE
Location Snapshot bug fix

### DIFF
--- a/Journal.md
+++ b/Journal.md
@@ -509,3 +509,4 @@ A tiny token-formatting test catches easy-to-miss backend integration bugs early
 - I would define a typed `AppSettings` key registry early instead of raw string keys scattered across files.
 - I would add a lightweight diagnostics panel for permission status + APNs token from day one.
 - I would establish one canonical "notifications bootstrap" path at app launch to avoid behavior fragmentation across onboarding, settings, and background flows.
+- **Bug squash (empty-token location push retries)**: location snapshot uploads were attempted even when APNs token storage was still empty, creating guaranteed-invalid payloads and unnecessary retry noise. `LocationSnapshotPusher.enqueue` now trims/guards token presence and skips upload until registration provides a real token, with unit coverage to prevent regressions.

--- a/SkyAware/Journal.md
+++ b/SkyAware/Journal.md
@@ -112,3 +112,4 @@ Think of the app as a restaurant kitchen. The **Providers** are your ingredient 
 - I’d add a small diagnostics surface in-app early so it’s obvious when background work is being throttled or suppressed.
 - I’d separate map data transforms into a dedicated mapper layer up front so polygon construction and caching are deterministic and testable outside SwiftUI.
 - I’d add a lightweight performance checklist early (render-path work, identity stability, async trigger fan-out, geometry feedback loops) and enforce it in review.
+- **Bug squash (empty-token location push retries)**: location snapshot uploads were attempted even when APNs token storage was still empty, creating guaranteed-invalid payloads and unnecessary retry noise. `LocationSnapshotPusher.enqueue` now trims/guards token presence and skips upload until registration provides a real token, with unit coverage to prevent regressions.

--- a/SkyAware/Sources/Providers/Location/LocationProvider.swift
+++ b/SkyAware/Sources/Providers/Location/LocationProvider.swift
@@ -172,6 +172,11 @@ actor LocationSnapshotPusher: LocationSnapshotPushing {
     func enqueue(_ snapshot: LocationSnapshot) async {
         let regionContext = await gridRegionContextProvider()
         let installationId = await installationIdProvider()
+        let apnsToken = apnsTokenProvider().trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !apnsToken.isEmpty else {
+            logger.debug("Skipping location snapshot upload; APNs token unavailable")
+            return
+        }
         let payload = LocationSnapshotPushPayload(
             capturedAt: snapshot.timestamp,
             locationAgeSeconds: Date().timeIntervalSince(snapshot.timestamp),
@@ -182,7 +187,7 @@ actor LocationSnapshotPusher: LocationSnapshotPushing {
             county: regionContext?.county,
             zone: regionContext?.zone,
             fireZone: regionContext?.fireZone,
-            apnsDeviceToken: apnsTokenProvider(),
+            apnsDeviceToken: apnsToken,
             installationId: installationId,
             source: "unknown",
             auth: {

--- a/SkyAware/Tests/UnitTests/LocationProviderTests.swift
+++ b/SkyAware/Tests/UnitTests/LocationProviderTests.swift
@@ -198,6 +198,30 @@ struct LocationProviderTests {
         #expect(payload.h3Cell == sampleH3Cell)
     }
 
+    @Test("snapshot pusher skips upload when APNs token is missing")
+    func snapshotPusher_skipsUploadWithoutApnsToken() async {
+        let uploader = MockSnapshotUploader()
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { " " },
+            installationIdProvider: { "install-abc-123" },
+            retryDelaysSeconds: [0]
+        )
+
+        let snap = LocationSnapshot(
+            coordinates: CLLocationCoordinate2D(latitude: 35.4676, longitude: -97.5164),
+            timestamp: Date(timeIntervalSince1970: 1_234_567),
+            accuracy: 42,
+            placemarkSummary: "OKC, OK",
+            h3Cell: sampleH3Cell
+        )
+
+        await pusher.enqueue(snap)
+
+        let payloads = await uploader.uploadedPayloads()
+        #expect(payloads.isEmpty)
+    }
+
     private func waitForSnapshots(
         from pusher: MockSnapshotPusher,
         timeoutMs: Int = 500,


### PR DESCRIPTION
**Bug squash (empty-token location push retries)**: location snapshot uploads were attempted even when APNs token storage was still empty, creating guaranteed-invalid payloads and unnecessary retry noise. `LocationSnapshotPusher.enqueue` now trims/guards token presence and skips upload until registration provides a real token, with unit coverage to prevent regressions.