### PR TITLE
Fix Arcus watch update labeling and cancellation filtering

### DIFF
--- a/Journal.md
+++ b/Journal.md
@@ -54,6 +54,23 @@ Essential for periodic refresh and notification relevance when the app is not fo
 
 ## 5) The Journey
 
+### 2026-03-24: The case of the watch that was updated but refused to say so
+
+Bug-shaped problem:
+After the Arcus watch migration, the detail screen checked for `"UPDATE"` while the live payloads and preview fixtures said `"Update"`. That meant revised watches walked into the UI wearing an update badge invisibility cloak. At the same time, the repo was trusting every decoded Arcus payload with valid timestamps, even though the contract already says alerts can arrive in `Cancelled` state.
+
+What changed:
+- Added a case-insensitive `isUpdateMessage` helper in `/Users/justin/Code/project-arcus/SkyAware/Sources/Models/Watches/WatchRowDTO.swift`.
+- Updated `/Users/justin/Code/project-arcus/SkyAware/Sources/Features/Alert/WatchDetailView.swift` to use that helper instead of a hard-coded uppercase comparison.
+- Hardened `/Users/justin/Code/project-arcus/SkyAware/Sources/Repos/WatchRepo.swift` to skip non-active and cancel-type Arcus payloads before they ever hit persistence.
+- Added regression coverage in `/Users/justin/Code/project-arcus/SkyAware/Tests/UnitTests/WatchRowDTOTests.swift` and `/Users/justin/Code/project-arcus/SkyAware/Tests/UnitTests/WatchRepoRefreshTests.swift`.
+
+Aha moment:
+String casing bugs are the software equivalent of a fake mustache. The data is technically the same person, but the guard at the door still says, "Never seen them before." Normalizing the message type at the edge keeps display code from playing guess-the-capitalization.
+
+Gotcha:
+Time-window checks are necessary, but not sufficient. If an upstream system sends a cancellation with a still-future `ends` value, date math alone will happily keep a dead alert shambling around the app like a weather zombie.
+
 ### 2026-03-20: Added an on-device cache eject button for network debugging
 
 Bug-shaped problem:

--- a/SkyAware/Sources/Features/Alert/WatchDetailView.swift
+++ b/SkyAware/Sources/Features/Alert/WatchDetailView.swift
@@ -34,7 +34,7 @@ struct WatchDetailView: View {
                 issued: watch.issued,
                 validStart: watch.issued,
                 validEnd: watch.validEnd,
-                subtitle: watch.messageType == "UPDATE" ? "Updated" : nil,
+                subtitle: watch.isUpdateMessage ? "Updated" : nil,
                 inZone: false,
                 sender: watch.sender
             )

--- a/SkyAware/Sources/Models/Watches/WatchRowDTO.swift
+++ b/SkyAware/Sources/Models/Watches/WatchRowDTO.swift
@@ -15,6 +15,10 @@ extension WatchRowDTO: AlertItem {
     nonisolated var validEnd: Date       {self.ends}      // Valid end
     nonisolated var summary: String      {self.description}      // description / CDATA
     nonisolated var alertType: AlertType { AlertType.watch }      // Type of alert to conform to alert item
+    nonisolated var isUpdateMessage: Bool {
+        messageType.trimmingCharacters(in: .whitespacesAndNewlines)
+            .localizedCaseInsensitiveCompare("update") == .orderedSame
+    }
 }
 
 struct WatchRowDTO: Identifiable, Sendable, Hashable {

--- a/SkyAware/Sources/Repos/WatchRepo.swift
+++ b/SkyAware/Sources/Repos/WatchRepo.swift
@@ -70,6 +70,19 @@ actor WatchRepo {
     
     // MARK: Translator
     private func makeWatch(from item: DeviceAlertPayload) -> Watch? {
+        let state = item.state.trimmingCharacters(in: .whitespacesAndNewlines)
+        let messageType = item.messageType.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard state.localizedCaseInsensitiveCompare("active") == .orderedSame else {
+            logger.debug("Skipping Arcus alert with non-active state: \(state, privacy: .public)")
+            return nil
+        }
+
+        guard messageType.localizedCaseInsensitiveCompare("cancel") != .orderedSame else {
+            logger.debug("Skipping Arcus alert with cancel message type")
+            return nil
+        }
+
         guard
             let sent             = item.sent,
             let effective        = item.effective,
@@ -92,8 +105,8 @@ actor WatchRepo {
             onset: onset,
             expires: expires,
             ends: ends,
-            status: "", // Deprecate
-            messageType: item.messageType,
+            status: state,
+            messageType: messageType,
             severity: item.severity,
             certainty: item.certainty,
             urgency: item.urgency,

--- a/SkyAware/Tests/UnitTests/WatchRepoRefreshTests.swift
+++ b/SkyAware/Tests/UnitTests/WatchRepoRefreshTests.swift
@@ -1,0 +1,77 @@
+import Testing
+@testable import SkyAware
+import SwiftData
+import Foundation
+
+private struct StubArcusClient: ArcusClient {
+    let payload: Data
+
+    func fetchActiveAlerts(for ugc: String, or fire: String, in cell: Int64?) async throws -> Data {
+        payload
+    }
+}
+
+@Suite("WatchRepo refresh()")
+struct WatchRepoRefreshTests {
+    let container: ModelContainer
+    let repo: WatchRepo
+
+    init() throws {
+        let schema = Schema([Watch.self])
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(for: schema, configurations: config)
+        repo = WatchRepo(modelContainer: container)
+    }
+
+    @Test("Skips cancelled Arcus alerts even if timing fields are still active")
+    func skipsCancelledPayloads() async throws {
+        let now = ISO8601DateFormatter().date(from: "2026-03-24T12:00:00Z")!
+        let json = """
+        [
+          {
+            "id": "123e4567-e89b-12d3-a456-426614174000",
+            "event": "Tornado Watch",
+            "currentRevisionUrn": "urn:alert:test",
+            "currentRevisionSent": "2026-03-24T11:00:00Z",
+            "messageType": "Cancel",
+            "state": "Cancelled",
+            "created": "2026-03-24T11:00:00Z",
+            "updated": "2026-03-24T11:00:00Z",
+            "lastSeenActive": "2026-03-24T11:00:00Z",
+            "sent": "2026-03-24T11:00:00Z",
+            "effective": "2026-03-24T11:00:00Z",
+            "onset": "2026-03-24T11:00:00Z",
+            "expires": "2026-03-24T13:00:00Z",
+            "ends": "2026-03-24T13:00:00Z",
+            "severity": "Extreme",
+            "urgency": "Immediate",
+            "certainty": "Observed",
+            "areaDesc": "Denver Metro",
+            "senderName": "NWS Test",
+            "headline": "Test headline",
+            "description": "Test description",
+            "instructions": "Test instructions",
+            "response": "Monitor",
+            "ugc": ["COC031"],
+            "h3Cells": [613725958748241919]
+          }
+        ]
+        """
+
+        try await repo.refresh(
+            using: StubArcusClient(payload: Data(json.utf8)),
+            for: "COC031",
+            and: "COZ245",
+            in: 613725958748241919
+        )
+
+        let hits = try await repo.active(
+            countyCode: "COC031",
+            fireZone: "COZ245",
+            cell: 613725958748241919,
+            on: now
+        )
+
+        #expect(hits.isEmpty)
+    }
+}

--- a/SkyAware/Tests/UnitTests/WatchRowDTOTests.swift
+++ b/SkyAware/Tests/UnitTests/WatchRowDTOTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import SkyAware
+import Foundation
+
+@Suite("WatchRowDTO")
+struct WatchRowDTOTests {
+    @Test("Recognizes update message types case-insensitively")
+    func recognizesUpdateMessageType() {
+        let now = Date()
+        let sut = WatchRowDTO(
+            id: "watch-1",
+            messageId: "urn:test",
+            title: "Tornado Watch",
+            headline: "Updated watch",
+            issued: now,
+            expires: now,
+            ends: now,
+            messageType: "Update",
+            sender: "NWS",
+            severity: "Extreme",
+            urgency: "Immediate",
+            certainty: "Observed",
+            description: "Test",
+            instruction: nil,
+            response: nil,
+            areaSummary: "Denver Metro"
+        )
+
+        #expect(sut.isUpdateMessage)
+    }
+}


### PR DESCRIPTION
## Summary
- Normalize Arcus watch message type handling so updated watches render the correct subtitle in the detail UI
- Skip cancelled and non-active Arcus alert payloads before persisting them to the watch repo
- Add focused regression tests for update message detection and cancelled alert filtering
- Document the bug and fix in `Journal.md`

## Testing
- Not run (not requested)