### PR TITLE
Fix stale Arcus watches after cancellation updates

### DIFF
--- a/Journal.md
+++ b/Journal.md
@@ -54,6 +54,21 @@ Essential for periodic refresh and notification relevance when the app is not fo
 
 ## 5) The Journey
 
+### 2026-03-25: The cancelled watch that politely refused to leave
+
+Bug-shaped problem:
+Yesterday's Arcus fix got halfway to the finish line. We stopped *inserting* cancelled payloads, which is good, but `WatchRepo.refresh` still had the memory of an elephant and the delete instincts of a goldfish. If a watch was already stored from an earlier active revision, a later `Cancel` payload would be ignored instead of evicting the old record. Result: a dead watch could keep haunting the app until its original `ends` time expired.
+
+What changed:
+- Updated [/Users/justin/.codex/worktrees/08ad/project-arcus/SkyAware/Sources/Repos/WatchRepo.swift](/Users/justin/.codex/worktrees/08ad/project-arcus/SkyAware/Sources/Repos/WatchRepo.swift) so refreshes first identify Arcus payloads that should no longer persist, delete matching stored watches by series id, and only then upsert the still-active ones.
+- Extended [/Users/justin/.codex/worktrees/08ad/project-arcus/SkyAware/Tests/UnitTests/WatchRepoRefreshTests.swift](/Users/justin/.codex/worktrees/08ad/project-arcus/SkyAware/Tests/UnitTests/WatchRepoRefreshTests.swift) with a regression case that starts with a persisted active watch, feeds in a cancellation revision, and proves the repo no longer returns that watch as active.
+
+Aha moment:
+Filtering and reconciliation are cousins, not twins. "Don't add the bad thing" sounds right until you remember the bad thing might already be sitting in your database eating snacks.
+
+Gotcha:
+Any feature that treats `refresh` like a full truth sync needs to think in both directions: what's new to insert, and what is now false enough to delete. Otherwise stale data gets nine lives for free.
+
 ### 2026-03-24: The case of the watch that was updated but refused to say so
 
 Bug-shaped problem:

--- a/SkyAware/Sources/Repos/WatchRepo.swift
+++ b/SkyAware/Sources/Repos/WatchRepo.swift
@@ -43,6 +43,16 @@ actor WatchRepo {
             logger.error("Unable to parse Arcus watch data")
             throw ArcusError.parsingError
         }
+
+        let retiredWatchIDs = Set(
+            decoded
+                .filter { shouldPersist($0) == false }
+                .map { "\($0.id)" }
+        )
+
+        if retiredWatchIDs.isEmpty == false {
+            try deleteWatches(withIDs: retiredWatchIDs)
+        }
         
         let watches = decoded
             .compactMap { makeWatch(from: $0) }
@@ -69,17 +79,28 @@ actor WatchRepo {
     }
     
     // MARK: Translator
-    private func makeWatch(from item: DeviceAlertPayload) -> Watch? {
+    private func shouldPersist(_ item: DeviceAlertPayload) -> Bool {
         let state = item.state.trimmingCharacters(in: .whitespacesAndNewlines)
         let messageType = item.messageType.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard state.localizedCaseInsensitiveCompare("active") == .orderedSame else {
             logger.debug("Skipping Arcus alert with non-active state: \(state, privacy: .public)")
-            return nil
+            return false
         }
 
         guard messageType.localizedCaseInsensitiveCompare("cancel") != .orderedSame else {
             logger.debug("Skipping Arcus alert with cancel message type")
+            return false
+        }
+
+        return true
+    }
+
+    private func makeWatch(from item: DeviceAlertPayload) -> Watch? {
+        let state = item.state.trimmingCharacters(in: .whitespacesAndNewlines)
+        let messageType = item.messageType.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard shouldPersist(item) else {
             return nil
         }
 
@@ -124,6 +145,19 @@ actor WatchRepo {
     private func upsert(_ items: [Watch]) throws {
         for item in items {
             modelContext.insert(item)
+        }
+        try modelContext.save()
+    }
+
+    private func deleteWatches(withIDs ids: Set<String>) throws {
+        guard ids.isEmpty == false else { return }
+
+        let doomed = try modelContext.fetch(allWatchesDescriptor()).filter { ids.contains($0.nwsId) }
+        guard doomed.isEmpty == false else { return }
+
+        logger.debug("Removing \(doomed.count, privacy: .public) retired Arcus watch\(doomed.count > 1 ? "es" : "", privacy: .public)")
+        for watch in doomed {
+            modelContext.delete(watch)
         }
         try modelContext.save()
     }

--- a/SkyAware/Tests/UnitTests/WatchRepoRefreshTests.swift
+++ b/SkyAware/Tests/UnitTests/WatchRepoRefreshTests.swift
@@ -23,6 +23,41 @@ struct WatchRepoRefreshTests {
         repo = WatchRepo(modelContainer: container)
     }
 
+    private func insertStoredWatch(
+        id: String = "123e4567-e89b-12d3-a456-426614174000",
+        countyCode: String = "COC031",
+        cell: Int64 = 613725958748241919,
+        now: Date
+    ) throws {
+        let context = ModelContext(container)
+        context.insert(
+            Watch(
+                nwsId: id,
+                messageId: "urn:alert:test",
+                areaDesc: "Denver Metro",
+                ugcZones: [countyCode],
+                sent: now.addingTimeInterval(-3600),
+                effective: now.addingTimeInterval(-3600),
+                onset: now.addingTimeInterval(-3600),
+                expires: now.addingTimeInterval(3600),
+                ends: now.addingTimeInterval(3600),
+                status: "Active",
+                messageType: "Alert",
+                severity: "Extreme",
+                certainty: "Observed",
+                urgency: "Immediate",
+                event: "Tornado Watch",
+                headline: "Test headline",
+                watchDescription: "Test description",
+                sender: "NWS Test",
+                instruction: "Test instructions",
+                response: "Monitor",
+                cells: [cell]
+            )
+        )
+        try context.save()
+    }
+
     @Test("Skips cancelled Arcus alerts even if timing fields are still active")
     func skipsCancelledPayloads() async throws {
         let now = ISO8601DateFormatter().date(from: "2026-03-24T12:00:00Z")!
@@ -60,6 +95,60 @@ struct WatchRepoRefreshTests {
 
         try await repo.refresh(
             using: StubArcusClient(payload: Data(json.utf8)),
+            for: "COC031",
+            and: "COZ245",
+            in: 613725958748241919
+        )
+
+        let hits = try await repo.active(
+            countyCode: "COC031",
+            fireZone: "COZ245",
+            cell: 613725958748241919,
+            on: now
+        )
+
+        #expect(hits.isEmpty)
+    }
+
+    @Test("Cancelled Arcus revisions remove an already-persisted watch")
+    func cancelledPayloadRemovesStoredWatch() async throws {
+        let now = ISO8601DateFormatter().date(from: "2026-03-24T12:00:00Z")!
+        try insertStoredWatch(now: now)
+
+        let cancelledRevision = """
+        [
+          {
+            "id": "123e4567-e89b-12d3-a456-426614174000",
+            "event": "Tornado Watch",
+            "currentRevisionUrn": "urn:alert:test",
+            "currentRevisionSent": "2026-03-24T11:30:00Z",
+            "messageType": "Cancel",
+            "state": "Cancelled",
+            "created": "2026-03-24T11:00:00Z",
+            "updated": "2026-03-24T11:30:00Z",
+            "lastSeenActive": "2026-03-24T11:25:00Z",
+            "sent": "2026-03-24T11:30:00Z",
+            "effective": "2026-03-24T11:30:00Z",
+            "onset": "2026-03-24T11:30:00Z",
+            "expires": "2026-03-24T13:00:00Z",
+            "ends": "2026-03-24T13:00:00Z",
+            "severity": "Extreme",
+            "urgency": "Immediate",
+            "certainty": "Observed",
+            "areaDesc": "Denver Metro",
+            "senderName": "NWS Test",
+            "headline": "Cancellation headline",
+            "description": "Cancellation description",
+            "instructions": "Cancellation instructions",
+            "response": "Monitor",
+            "ugc": ["COC031"],
+            "h3Cells": [613725958748241919]
+          }
+        ]
+        """
+
+        try await repo.refresh(
+            using: StubArcusClient(payload: Data(cancelledRevision.utf8)),
             for: "COC031",
             and: "COZ245",
             in: 613725958748241919


### PR DESCRIPTION
## Summary
- Remove persisted watches when Arcus sends a cancelled or otherwise non-persistable revision for an existing series ID
- Keep the watch refresh path focused by reusing shared persistence checks before upserting active payloads
- Add regression coverage for the case where a previously stored active watch later receives a cancellation update
- Document the bug and fix in the learning journal

## Testing
- Not run (not requested)