### PR TITLE
Surface severe-risk alert tags and add remote notification plumbing

### DIFF
--- a/Resources/PreviewContent/WatchSamples.swift
+++ b/Resources/PreviewContent/WatchSamples.swift
@@ -133,7 +133,7 @@ extension Watch {
         WatchRowDTO(
             id: "urn:oid:2.49.0.1.840.0.cfc6c16f6a710f26ac1510695362885161a510a0.002.1",
             messageId: "urn:oid:2.49.0.1.840.0.cfc6c16f6a710f26ac1510695362885161a510a0.002.1",
-            title: "Tornado Watch",
+            title: "Tornado Warning",
             headline: "Tornado Watch issued November 25 at 4:20PM CST until November 25 at 6:00PM CST by NWS Mobile AL",
             issued: ISO8601DateFormatter().date(from: "2025-11-25T22:20:00Z")!,   // 4:20 PM CST
             expires: ISO8601DateFormatter().date(from: "2025-11-26T00:00:00Z")!,  // 6:00 PM CST
@@ -146,7 +146,16 @@ extension Watch {
             description: "TORNADO WATCH 641 REMAINS VALID UNTIL 6 PM CST THIS EVENING FOR\nTHE FOLLOWING AREAS\n\nIN ALABAMA THIS WATCH INCLUDES 7 COUNTIES\n\nIN SOUTH CENTRAL ALABAMA\n\nBUTLER                CONECUH               CRENSHAW\nMONROE                WILCOX\n\nIN SOUTHWEST ALABAMA\n\nCLARKE                WASHINGTON\n\nTHIS INCLUDES THE CITIES OF BRANTLEY, CAMDEN, CHATOM, EVERGREEN,\nGREENVILLE, GROVE HILL, HOMEWOOD, JACKSON, LUVERNE, MILLRY,\nMONROEVILLE, PINE HILL, AND THOMASVILLE.",
             instruction: nil,
             response: "Monitor",
-            areaSummary: "Butler; Clarke; Conecuh; Crenshaw; Monroe; Washington; Wilcox (AL)"
+            areaSummary: "Butler; Clarke; Conecuh; Crenshaw; Monroe; Washington; Wilcox (AL)",
+            tornadoDetection: "OBSERVED",
+            tornadoDamageThreat: "",
+            maxWindGust: "",
+            maxHailSize: "",
+            windThreat: "",
+            hailThreat: "",
+            thunderstormDamageThreat: "",
+            flashFloodDetection: "",
+            flashFloodDamageThreat: ""
         ),
         WatchRowDTO(
             id: "urn:oid:2.49.0.1.840.0.9b1e1a6b7c0f4f0f3b90c08d8d22e7a4e4d0a123.001.1",
@@ -164,14 +173,23 @@ extension Watch {
             description: "TORNADO WATCH 641 REMAINS VALID UNTIL 6 PM CST THIS EVENING FOR\nTHE FOLLOWING AREAS\n\nIN ALABAMA THIS WATCH INCLUDES 7 COUNTIES\n\nIN SOUTH CENTRAL ALABAMA\n\nBUTLER                CONECUH               CRENSHAW\nMONROE                WILCOX\n\nIN SOUTHWEST ALABAMA\n\nCLARKE                WASHINGTON\n\nTHIS INCLUDES THE CITIES OF BRANTLEY, CAMDEN, CHATOM, EVERGREEN,\nGREENVILLE, GROVE HILL, HOMEWOOD, JACKSON, LUVERNE, MILLRY,\nMONROEVILLE, PINE HILL, AND THOMASVILLE.",
             instruction: nil,
             response: "Monitor",
-            areaSummary: "Sedgwick; Butler; Harvey (KS)"
+            areaSummary: "Sedgwick; Butler; Harvey (KS)",
+            tornadoDetection: "",
+            tornadoDamageThreat: "",
+            maxWindGust: "",
+            maxHailSize: "",
+            windThreat: "",
+            hailThreat: "",
+            thunderstormDamageThreat: "",
+            flashFloodDetection: "",
+            flashFloodDamageThreat: ""
             
         ),
         WatchRowDTO(
             id: "urn:oid:2.49.0.1.840.0.2f6a9c1c0b5e44d6a9d3a33a9b7d8a0d88aa77bb.001.1",
             messageId: "urn:oid:2.49.0.1.840.0.2f6a9c1c0b5e44d6a9d3a33a9b7d8a0d88aa77bb.001.1",
-            title: "Tornado Watch",
-            headline: "Tornado Watch issued November 25 at 4:20PM CST until November 25 at 6:00PM CST by NWS Mobile AL",
+            title: "Tornado Warning",
+            headline: "Tornado Warning issued November 25 at 4:20PM CST until November 25 at 6:00PM CST by NWS Mobile AL",
             issued: ISO8601DateFormatter().date(from: "2025-05-06T20:10:00Z")!,   // ~3:10 PM CDT
             expires: ISO8601DateFormatter().date(from: "2025-05-07T01:00:00Z")!,  // ~8:00 PM CDT
             ends: ISO8601DateFormatter().date(from: "2025-11-26T00:23:00Z")!,  // 5:00 PM CST,
@@ -183,13 +201,22 @@ extension Watch {
             description: "TORNADO WATCH 641 REMAINS VALID UNTIL 6 PM CST THIS EVENING FOR\nTHE FOLLOWING AREAS\n\nIN ALABAMA THIS WATCH INCLUDES 7 COUNTIES\n\nIN SOUTH CENTRAL ALABAMA\n\nBUTLER                CONECUH               CRENSHAW\nMONROE                WILCOX\n\nIN SOUTHWEST ALABAMA\n\nCLARKE                WASHINGTON\n\nTHIS INCLUDES THE CITIES OF BRANTLEY, CAMDEN, CHATOM, EVERGREEN,\nGREENVILLE, GROVE HILL, HOMEWOOD, JACKSON, LUVERNE, MILLRY,\nMONROEVILLE, PINE HILL, AND THOMASVILLE.",
             instruction: nil,
             response: "Monitor",
-            areaSummary: "Cleveland; McClain; Oklahoma; Pottawatomie (OK)"
+            areaSummary: "Cleveland; McClain; Oklahoma; Pottawatomie (OK)",
+            tornadoDetection: "OBSERVED",
+            tornadoDamageThreat: "",
+            maxWindGust: "",
+            maxHailSize: "",
+            windThreat: "",
+            hailThreat: "",
+            thunderstormDamageThreat: "",
+            flashFloodDetection: "",
+            flashFloodDamageThreat: ""
             
         ),
         WatchRowDTO(
             id: "urn:oid:2.49.0.1.840.0.6a7e1d3c9c2e4b4ab06e2d5b5e6f7a8b9c0d1e2f.001.1",
             messageId: "urn:oid:2.49.0.1.840.0.6a7e1d3c9c2e4b4ab06e2d5b5e6f7a8b9c0d1e2f.001.1",
-            title: "Severe Thunderstorm Watch",
+            title: "Severe Thunderstorm Warning",
             headline: "Severe T-Storm Watch issued November 25 at 4:20PM CST until November 25 at 6:00PM CST by NWS Mobile AL",
             issued: ISO8601DateFormatter().date(from: "2025-08-12T21:30:00Z")!,   // ~4:30 PM CDT
             expires: ISO8601DateFormatter().date(from: "2025-08-13T02:00:00Z")!,  // ~9:00 PM CDT
@@ -202,13 +229,22 @@ extension Watch {
             description: "TORNADO WATCH 641 REMAINS VALID UNTIL 6 PM CST THIS EVENING FOR\nTHE FOLLOWING AREAS\n\nIN ALABAMA THIS WATCH INCLUDES 7 COUNTIES\n\nIN SOUTH CENTRAL ALABAMA\n\nBUTLER                CONECUH               CRENSHAW\nMONROE                WILCOX\n\nIN SOUTHWEST ALABAMA\n\nCLARKE                WASHINGTON\n\nTHIS INCLUDES THE CITIES OF BRANTLEY, CAMDEN, CHATOM, EVERGREEN,\nGREENVILLE, GROVE HILL, HOMEWOOD, JACKSON, LUVERNE, MILLRY,\nMONROEVILLE, PINE HILL, AND THOMASVILLE.",
             instruction: nil,
             response: "Monitor",
-            areaSummary: "Douglas; Sarpy; Cass (NE) / Pottawattamie (IA)"
+            areaSummary: "Douglas; Sarpy; Cass (NE) / Pottawattamie (IA)",
+            tornadoDetection: "POSSIBLE",
+            tornadoDamageThreat: "",
+            maxWindGust: "60",
+            maxHailSize: "1.34",
+            windThreat: "",
+            hailThreat: "",
+            thunderstormDamageThreat: "CONSIDERABLE",
+            flashFloodDetection: "",
+            flashFloodDamageThreat: ""
             
         ),
         WatchRowDTO(
             id: "urn:oid:2.49.0.1.840.0.0d1c2b3a4e5f60718293a4b5c6d7e8f901234567.001.1",
             messageId: "urn:oid:2.49.0.1.840.0.0d1c2b3a4e5f60718293a4b5c6d7e8f901234567.001.1",
-            title: "Tornado Watch",
+            title: "Tornado Warning",
             headline: "Tornado Watch issued November 25 at 4:20PM CST until November 25 at 6:00PM CST by NWS Mobile AL",
             issued: ISO8601DateFormatter().date(from: "2025-09-27T23:45:00Z")!,   // ~6:45 PM CDT
             expires: ISO8601DateFormatter().date(from: "2025-09-28T04:00:00Z")!,  // ~11:00 PM CDT
@@ -221,7 +257,16 @@ extension Watch {
             description: "TORNADO WATCH 641 REMAINS VALID UNTIL 6 PM CST THIS EVENING FOR\nTHE FOLLOWING AREAS\n\nIN ALABAMA THIS WATCH INCLUDES 7 COUNTIES\n\nIN SOUTH CENTRAL ALABAMA\n\nBUTLER                CONECUH               CRENSHAW\nMONROE                WILCOX\n\nIN SOUTHWEST ALABAMA\n\nCLARKE                WASHINGTON\n\nTHIS INCLUDES THE CITIES OF BRANTLEY, CAMDEN, CHATOM, EVERGREEN,\nGREENVILLE, GROVE HILL, HOMEWOOD, JACKSON, LUVERNE, MILLRY,\nMONROEVILLE, PINE HILL, AND THOMASVILLE.",
             instruction: "Take shelter in an interior room of your home. If you are in a mobile home seek shelter in a storm shelter.",
             response: "Monitor",
-            areaSummary: "Johnson; Wyandotte; Jackson (KS/MO metro)"
+            areaSummary: "Johnson; Wyandotte; Jackson (KS/MO metro)",
+            tornadoDetection: "OBSERVED",
+            tornadoDamageThreat: "",
+            maxWindGust: "",
+            maxHailSize: "",
+            windThreat: "",
+            hailThreat: "",
+            thunderstormDamageThreat: "",
+            flashFloodDetection: "",
+            flashFloodDamageThreat: ""
         )
     ]
     
@@ -252,7 +297,16 @@ extension Watch {
                 sender: "w-nws.webmaster@noaa.gov",
                 instruction: "Take shelter in an interior room. Avoid windows. If in a mobile home, move to a sturdier shelter.",
                 response: "Monitor",
-                cells: []
+                cells: [],
+                tornadoDetection: "OBSERVED", // RADAR-INDICATED, OBSERVED
+                tornadoDamageThreat: "", // CONSIDERABLE, CATASTROPHIC
+                maxWindGust: "", // NA
+                maxHailSize: "", // NA
+                windThreat: "", // NA
+                hailThreat: "", // NA
+                thunderstormDamageThreat: "", // NA
+                flashFloodDetection: "", // NA
+                flashFloodDamageThreat: "" // NA
             ),
 
             // Severe Thunderstorm Watch (afternoon CDT)
@@ -278,7 +332,16 @@ extension Watch {
                 sender: "w-nws.webmaster@noaa.gov",
                 instruction: "Be prepared to seek sturdy shelter if warnings are issued. Secure outdoor objects.",
                 response: "Monitor",
-                cells: []
+                cells: [],
+                tornadoDetection: "POSSIBLE", // POSSIBLE
+                tornadoDamageThreat: "", // NA
+                maxWindGust: "", // 60 mph
+                maxHailSize: "", // 1.25 in
+                windThreat: "", // RADAR-INDICATED, OBSERVED
+                hailThreat: "", // RADAR-INDICATED, OBSERVED
+                thunderstormDamageThreat: "", // CONSIDERABLE, DESTRUCTIVE
+                flashFloodDetection: "",
+                flashFloodDamageThreat: ""
             ),
 
             // Tornado Watch (spring outbreak window)
@@ -304,7 +367,16 @@ extension Watch {
                 sender: "w-nws.webmaster@noaa.gov",
                 instruction: "Review your shelter plan now. Have multiple ways to receive warnings.",
                 response: "Shelter",
-                cells: []
+                cells: [],
+                tornadoDetection: "RADAR-INDICATED",
+                tornadoDamageThreat: "",
+                maxWindGust: "",
+                maxHailSize: "",
+                windThreat: "",
+                hailThreat: "",
+                thunderstormDamageThreat: "",
+                flashFloodDetection: "",
+                flashFloodDamageThreat: ""
             ),
 
             // Severe Thunderstorm Watch (late summer)
@@ -330,7 +402,16 @@ extension Watch {
                 sender: "w-nws.webmaster@noaa.gov",
                 instruction: "Stay weather-aware this evening. If a warning is issued, move indoors away from windows.",
                 response: "Monitor",
-                cells: [] 
+                cells: [],
+                tornadoDetection: "",
+                tornadoDamageThreat: "",
+                maxWindGust: "",
+                maxHailSize: "",
+                windThreat: "",
+                hailThreat: "",
+                thunderstormDamageThreat: "",
+                flashFloodDetection: "",
+                flashFloodDamageThreat: ""
             )
         ]
     }

--- a/Resources/PreviewContent/WatchSamples.swift
+++ b/Resources/PreviewContent/WatchSamples.swift
@@ -298,7 +298,7 @@ extension Watch {
                 instruction: "Take shelter in an interior room. Avoid windows. If in a mobile home, move to a sturdier shelter.",
                 response: "Monitor",
                 cells: [],
-                tornadoDetection: "OBSERVED", // RADAR-INDICATED, OBSERVED
+                tornadoDetection: "OBSERVED", // RADAR INDICATED, OBSERVED
                 tornadoDamageThreat: "", // CONSIDERABLE, CATASTROPHIC
                 maxWindGust: "", // NA
                 maxHailSize: "", // NA
@@ -337,8 +337,8 @@ extension Watch {
                 tornadoDamageThreat: "", // NA
                 maxWindGust: "", // 60 mph
                 maxHailSize: "", // 1.25 in
-                windThreat: "", // RADAR-INDICATED, OBSERVED
-                hailThreat: "", // RADAR-INDICATED, OBSERVED
+                windThreat: "", // RADAR INDICATED, OBSERVED
+                hailThreat: "", // RADAR INDICATED, OBSERVED
                 thunderstormDamageThreat: "", // CONSIDERABLE, DESTRUCTIVE
                 flashFloodDetection: "",
                 flashFloodDamageThreat: ""
@@ -368,7 +368,7 @@ extension Watch {
                 instruction: "Review your shelter plan now. Have multiple ways to receive warnings.",
                 response: "Shelter",
                 cells: [],
-                tornadoDetection: "RADAR-INDICATED",
+                tornadoDetection: "RADAR INDICATED",
                 tornadoDamageThreat: "",
                 maxWindGust: "",
                 maxHailSize: "",

--- a/SkyAware.xcodeproj/project.pbxproj
+++ b/SkyAware.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 				D0F000042F50000100AA1001 /* release */,
 				D095EFA42E16F5690074F867 /* Products */,
 				4FF60265E384AB8FC83C01FB /* Frameworks */,
+				D0A2DAD02F89472C005FF329 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -247,6 +248,14 @@
 				D095EFBC2E16F56A0074F867 /* SkyAwareUITests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		D0A2DAD02F89472C005FF329 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				D0F000062F50000100AA1001 /* Sources/AGENTS.md */,
+			);
+			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -368,7 +377,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D0AFC5F22F412BAB001F331A /* AGENTS.md in Resources */,
+				D0AFC5F22F412BAB001F331A /* Sources/AGENTS.md in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/App/SkyAwareAppDelegate.swift
+++ b/Sources/App/SkyAwareAppDelegate.swift
@@ -5,10 +5,11 @@
 //  Created by Codex on 2/22/26.
 //
 
+import OSLog
 import UIKit
 import UserNotifications
-import OSLog
 
+@MainActor
 final class SkyAwareAppDelegate: NSObject, UIApplicationDelegate {
     private let logger = Logger.notificationsRemote
 
@@ -17,6 +18,7 @@ final class SkyAwareAppDelegate: NSObject, UIApplicationDelegate {
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         UNUserNotificationCenter.current().delegate = self
+        application.registerForRemoteNotifications()
         return true
     }
 
@@ -24,9 +26,7 @@ final class SkyAwareAppDelegate: NSObject, UIApplicationDelegate {
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
-        Task { @MainActor in
-            RemoteNotificationRegistrar.shared.storeDeviceToken(deviceToken)
-        }
+        RemoteNotificationRegistrar.shared.storeDeviceToken(deviceToken)
     }
 
     func application(
@@ -35,9 +35,44 @@ final class SkyAwareAppDelegate: NSObject, UIApplicationDelegate {
     ) {
         logger.error("APNs registration failed: \(error.localizedDescription, privacy: .public)")
     }
+    
+    func application(
+            _ application: UIApplication,
+            didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+            fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+        ) {
+            Task {
+                do {
+                    // Parse your app-specific payload.
+                    guard
+                        let eventKey = userInfo["eventKey"] as? String,
+                        let revision = userInfo["revision"] as? Int
+                    else {
+                        completionHandler(.noData)
+                        return
+                    }
+
+                    // Call the same refresh/sync pipeline you would use elsewhere.
+                    let didUpdate = try await refreshEventState(eventKey: eventKey, revision: revision)
+
+                    completionHandler(didUpdate ? .newData : .noData)
+                } catch {
+                    completionHandler(.failed)
+                }
+            }
+        }
+    
+    private func refreshEventState(eventKey: String, revision: Int) async throws -> Bool {
+        // Example:
+        // 1. Fetch canonical/latest event details from your backend or source URL
+        // 2. Update local persistence
+        // 3. Return true if local state changed
+        logger.notice("Refresh triggered from Arcus-Signal")
+        return true
+    }
 }
 
-extension SkyAwareAppDelegate: @preconcurrency UNUserNotificationCenterDelegate {
+extension SkyAwareAppDelegate: @MainActor UNUserNotificationCenterDelegate {
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,

--- a/Sources/Features/Alert/AlertProtocol.swift
+++ b/Sources/Features/Alert/AlertProtocol.swift
@@ -14,6 +14,7 @@ protocol AlertItem: Identifiable, Hashable {
     var issued: Date { get }
     var link: URL { get }
     var alertType: AlertType { get }
+    var severeRiskTags: String? { get }
 }
 
 enum AlertType: Codable {

--- a/Sources/Features/Alert/AlertRowView.swift
+++ b/Sources/Features/Alert/AlertRowView.swift
@@ -39,6 +39,14 @@ struct AlertRowView: View {
                 Text("Issued \(relativeDate(alert.issued))")
                     .font(.caption.weight(.medium))
                     .foregroundColor(.secondary)
+                
+//                if alert.alertType == .watch {
+                    if let sevTags = alert.severeRiskTags {
+                        Text(sevTags)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(Color.tornadoRed)
+                    }
+//                }
             }
             Spacer()
 
@@ -76,4 +84,5 @@ struct AlertRowView: View {
         AlertRowView(alert: sample)
     }
     AlertRowView(alert: Watch.sampleWatchRows.last ?? Watch.sampleWatchRows[0])
+    AlertRowView(alert: Watch.sampleWatchRows[3])
 }

--- a/Sources/Features/Alert/WatchDetailView.swift
+++ b/Sources/Features/Alert/WatchDetailView.swift
@@ -58,6 +58,9 @@ struct WatchDetailView: View {
                 LazyVStack(alignment: .leading, spacing: sectionSpacing) {
                     headerCard
 
+                    if let severeRiskTags = watch.severeRiskTags {
+                        detailSection(title: "Severe Risk Tags", text: severeRiskTags, areTags: true)
+                    }
                     detailSection(title: "Areas Affected", text: watch.areaSummary)
                     detailSection(title: "Full Description", text: watch.description)
                 }
@@ -186,14 +189,14 @@ struct WatchDetailView: View {
         }
     }
 
-    private func detailSection(title: String, text: String) -> some View {
+    private func detailSection(title: String, text: String, areTags: Bool = false) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(title)
                 .font(.headline)
                 .frame(maxWidth: .infinity, alignment: .leading)
             Text(text)
-                .font(.callout.monospaced())
-                .foregroundStyle(.secondary)
+                .font(areTags ? .subheadline.weight(.semibold)  : .callout.monospaced())
+                .foregroundStyle(areTags ? Color.tornadoRed  : .secondary)
         }
         .padding()
         .cardBackground(cornerRadius: SkyAwareRadius.content, shadowOpacity: 0.1, shadowRadius: 12, shadowY: 6)
@@ -216,7 +219,7 @@ struct WatchDetailView: View {
 #Preview("Severe Thunderstorm Watch") {
     NavigationStack {
         ScrollView {
-            WatchDetailView(watch: Watch.sampleWatchRows[1], layout: .full)
+            WatchDetailView(watch: Watch.sampleWatchRows[3], layout: .full)
                 .navigationTitle("Weather Watch")
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbarBackground(.skyAwareBackground, for: .navigationBar)

--- a/Sources/Features/MesoscaleDiscussion/Components.swift
+++ b/Sources/Features/MesoscaleDiscussion/Components.swift
@@ -29,10 +29,10 @@ struct InZonePill: View {
             .font(.caption.weight(.semibold))
             .padding(.vertical, 4)
             .padding(.horizontal, 10)
-            .skyAwareChip(
-                cornerRadius: SkyAwareRadius.tile,
-                tint: inZone ? .green.opacity(0.14) : .white.opacity(0.08)
-            )
+//            .skyAwareChip(
+//                cornerRadius: SkyAwareRadius.tile,
+//                tint: inZone ? .green.opacity(0.14) : .white.opacity(0.08)
+//            )
     }
 }
 

--- a/Sources/Features/Summary/ActiveAlertSummaryView.swift
+++ b/Sources/Features/Summary/ActiveAlertSummaryView.swift
@@ -31,7 +31,7 @@ struct ActiveAlertSummaryView: View {
         ActiveAlertSection(
             label: "Watches",
             items: sortedWatches,
-            limit: 3,
+            limit: 2,
             onSelect: {
                 selectedWatchDetent = .medium
                 selectedWatch = $0
@@ -43,7 +43,7 @@ struct ActiveAlertSummaryView: View {
         ActiveAlertSection(
             label: "Mesos",
             items: sortedMesos,
-            limit: 3,
+            limit: 2,
             onSelect: {
                 selectedMesoDetent = .medium
                 selectedMeso = $0
@@ -169,27 +169,40 @@ private struct ActiveAlertSection<Item: Identifiable, Row: View>: View {
     let limit: Int
     let onSelect: (Item) -> Void
     @ViewBuilder let row: (Item) -> Row
+    @State private var isExpanded = false
     
     var body: some View {
         if !items.isEmpty {
-            let visibleItems = items.prefix(limit)
+            let visibleItems = isExpanded ? items : Array(items.prefix(limit))
             
             Text(label)
                 .font(.caption2.weight(.medium))
                 .foregroundStyle(.secondary)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 5)
-                .skyAwareChip(cornerRadius: SkyAwareRadius.chip, tint: .white.opacity(0.09))
+//                .skyAwareChip(cornerRadius: SkyAwareRadius.chip, tint: .white.opacity(0.09))
             
             ForEach(visibleItems) { item in
                 Button { onSelect(item) } label: { row(item) }
                     .buttonStyle(.plain)
             }
             
-            if items.count > visibleItems.count {
-                Text("Showing \(visibleItems.count) of \(items.count) \(label.lowercased())")
-                    .font(.footnote.weight(.medium))
+            if items.count > limit {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.24)) {
+                        isExpanded.toggle()
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        Text(isExpanded ? "Show less" : "See all (\(items.count - visibleItems.count) more)")
+                        Image(systemName: isExpanded ? "arrow.up" : "arrow.right")
+                            .font(.caption.weight(.semibold))
+                    }
+                    .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.secondary)
+                    .padding(.vertical, 6)
+                }
+                .buttonStyle(.plain)
             }
         }
     }
@@ -203,26 +216,37 @@ private struct MesoRowView: View {
             let (icon, color) = styleForType(.mesoscale, "")
             Image(systemName: icon)
                 .foregroundStyle(color)
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Meso \(meso.number.formatted(.number.grouping(.never)))")
-                    .font(.subheadline.weight(.semibold))
+
+            VStack(alignment: .leading) {
+                HStack {
+                    Text("Meso \(meso.number.formatted(.number.grouping(.never)))")
+                        .font(.subheadline.weight(.semibold))
+                    Spacer()
+                    VStack(alignment: .trailing) {
+                        Text("Ends \(meso.validEnd, style: .time)")
+                            .monospacedDigit()
+                            .font(.caption)
+                    }
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                }
+                
+                if meso.watchProbability >= 20 {
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text("Watch \(Int(meso.watchProbability))%")
+                                .monospacedDigit()
+                                .font(.caption.weight(.semibold))
+                        }
+                        Spacer()
+                    }
+                }
             }
-            
-            Spacer()
-            VStack(alignment: .trailing) {
-                Text("Watch \(Int(meso.watchProbability))%")
-                    .monospacedDigit()
-                    .font(.caption.weight(.semibold))
-                Text("Ends \(meso.validEnd, style: .time)")
-                    .monospacedDigit()
-                    .font(.caption)
-            }
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 6)
-            .skyAwareChip(cornerRadius: SkyAwareRadius.chip, tint: color.opacity(0.16))
+
         }
         .padding(.vertical, 3)
+//            .skyAwareChip(cornerRadius: SkyAwareRadius.chip, tint: color.opacity(0.16))
     }
 }
 
@@ -239,22 +263,35 @@ private struct WatchRowView: View {
             let (icon, color) = styleForType(.watch, watch.title)
             Image(systemName: icon)
                 .foregroundStyle(color)
-            VStack(alignment: .leading, spacing: 2) {
-                Text("\(watch.title)")
-                    .font(.subheadline.weight(.semibold))
+
+            VStack(alignment: .leading) {
+                HStack {
+                    Text("\(watch.title)")
+                        .font(.subheadline.weight(.semibold))
+                    Spacer()
+                    VStack(alignment: .trailing) {
+                        let txt = buildDisplay(watch: watch)
+                        Text("Until \(txt) \(watch.validEnd, style: .time)")
+                            .monospacedDigit()
+                            .font(.caption.weight(.semibold))
+                    }
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+//                    .skyAwareChip(cornerRadius: SkyAwareRadius.chip, tint: color.opacity(0.16))
+                }
+                if let sevTags = watch.SevereRiskTags {
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(sevTags)
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(Color.tornadoRed)
+                                .lineLimit(2)
+                        }
+                        Spacer()
+                    }
+                }
             }
-            
-            Spacer()
-            VStack(alignment: .trailing) {
-                let txt = buildDisplay(watch: watch)
-                Text("Until \(txt) \(watch.validEnd, style: .time)")
-                    .monospacedDigit()
-                    .font(.caption.weight(.semibold))
-            }
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 6)
-            .skyAwareChip(cornerRadius: SkyAwareRadius.chip, tint: color.opacity(0.16))
         }
         .padding(.vertical, 3)
     }

--- a/Sources/Models/Meso/MdDTO.swift
+++ b/Sources/Models/Meso/MdDTO.swift
@@ -21,7 +21,7 @@ struct MdDTO: Sendable, Identifiable, Hashable, AlertItem {
     let areasAffected: String   // locations affected by the meso
     let summary: String         // description / CDATA
     let concerning: String?     // e.g. "Severe potential... Watch unlikely"
-    
+    let severeRiskTags: String? = nil
     let watchProbability: Double
     let threats: MDThreats?
     let coordinates: [Coordinate2D]

--- a/Sources/Models/Watches/DeviceAlertPayload.swift
+++ b/Sources/Models/Watches/DeviceAlertPayload.swift
@@ -12,6 +12,7 @@ public enum DeviceAlertPayloadError: Error, Sendable {
     case invalidGeometryJSON
 }
 
+// TODO: Package this logic to share between SkyAware and Arcus-Signal
 public struct DeviceAlertPayload: Sendable, Codable {
     // MARK: Identity
     let id: UUID // Series Id
@@ -49,4 +50,16 @@ public struct DeviceAlertPayload: Sendable, Codable {
     // Arcus can return cell-only matches without UGC metadata.
     let ugc: [String]?
     var h3Cells: [Int64]?
+    
+    // CAP Params
+    let tornadoDetection: String?
+    let tornadoDamageThreat: String?
+    let maxWindGust: String?
+    let maxHailSize: String?
+    let windThreat: String?
+    let hailThreat: String?
+    let thunderstormDamageThreat: String?
+    let flashFloodDetection: String?
+    let flashFloodDamageThreat: String?
+
 }

--- a/Sources/Models/Watches/Watch.swift
+++ b/Sources/Models/Watches/Watch.swift
@@ -70,6 +70,15 @@ final class Watch {
     var instruction: String?
     var response: String?
     var h3Cells: [Int64] = []
+    var tornadoDetection: String?
+    var tornadoDamageThreat: String?
+    var maxWindGust: String?
+    var maxHailSize: String?
+    var windThreat: String?
+    var hailThreat: String?
+    var thunderstormDamageThreat: String?
+    var flashFloodDetection: String?
+    var flashFloodDamageThreat: String?
     
     init(
         nwsId: String,
@@ -92,7 +101,16 @@ final class Watch {
         sender: String?,
         instruction: String?,
         response: String?,
-        cells: [Int64]
+        cells: [Int64],
+        tornadoDetection: String?,
+        tornadoDamageThreat: String?,
+        maxWindGust: String?,
+        maxHailSize: String?,
+        windThreat: String?,
+        hailThreat: String?,
+        thunderstormDamageThreat: String?,
+        flashFloodDetection: String?,
+        flashFloodDamageThreat: String?
     ) {
         self.nwsId = nwsId
         self.messageId = messageId
@@ -115,5 +133,14 @@ final class Watch {
         self.instruction = instruction
         self.response = response
         self.h3Cells = cells
+        self.tornadoDetection = tornadoDetection
+        self.tornadoDamageThreat = tornadoDamageThreat
+        self.maxWindGust = maxWindGust
+        self.maxHailSize = maxHailSize
+        self.windThreat = windThreat
+        self.hailThreat = hailThreat
+        self.thunderstormDamageThreat = thunderstormDamageThreat
+        self.flashFloodDetection = flashFloodDetection
+        self.flashFloodDamageThreat = flashFloodDamageThreat
     }
 }

--- a/Sources/Models/Watches/WatchRowDTO.swift
+++ b/Sources/Models/Watches/WatchRowDTO.swift
@@ -115,7 +115,11 @@ struct WatchRowDTO: Identifiable, Sendable, Hashable {
             return nil
         }
         
-        return tags.joined(separator: "\n")
+        if tags.count > 0 {
+            return tags.joined(separator: "\n")
+        } else {
+            return nil
+        }
     }
 }
 
@@ -212,7 +216,7 @@ extension WatchRowDTO {
         case "observed":
             return "Observed tornado"
         case "radar indicated":
-            return "Radar-indicated tornado"
+            return "Radar indicated tornado"
         case "possible":
             return "Tornado possible"
         default:
@@ -225,7 +229,7 @@ extension WatchRowDTO {
         case "observed":
             return "Observed flooding"
         case "radar indicated":
-            return "Radar-indicated flooding"
+            return "Radar indicated flooding"
         default:
             return nil
         }
@@ -236,7 +240,7 @@ extension WatchRowDTO {
         case "observed":
             return "Observed \(noun)"
         case "radar indicated":
-            return "Radar-indicated \(noun)"
+            return "Radar indicated \(noun)"
         default:
             return nil
         }

--- a/Sources/Models/Watches/WatchRowDTO.swift
+++ b/Sources/Models/Watches/WatchRowDTO.swift
@@ -15,6 +15,7 @@ extension WatchRowDTO: AlertItem {
     nonisolated var validEnd: Date       {self.ends}      // Valid end
     nonisolated var summary: String      {self.description}      // description / CDATA
     nonisolated var alertType: AlertType { AlertType.watch }      // Type of alert to conform to alert item
+    nonisolated var severeRiskTags: String?       {self.SevereRiskTags}
     nonisolated var isUpdateMessage: Bool {
         messageType.trimmingCharacters(in: .whitespacesAndNewlines)
             .localizedCaseInsensitiveCompare("update") == .orderedSame
@@ -51,6 +52,71 @@ struct WatchRowDTO: Identifiable, Sendable, Hashable {
     
     // Geography (shortened / display-ready)
     let areaSummary: String     // e.g. "South Central Alabama"
+    
+    // CAP Params
+    let tornadoDetection: String?
+    let tornadoDamageThreat: String?
+    let maxWindGust: String?
+    let maxHailSize: String?
+    let windThreat: String?
+    let hailThreat: String?
+    let thunderstormDamageThreat: String?
+    let flashFloodDetection: String?
+    let flashFloodDamageThreat: String?
+    
+    var SevereRiskTags: String? {
+        // TODO: Package this logic to share between SkyAware and Arcus-Signal
+        var tags: [String] = []
+        switch title.lowercased() {
+        case "severe thunderstorm warning":
+            if normalizedCategory(tornadoDetection) == "possible" {
+                tags.append("Tornado possible")
+            }
+
+            if let damageThreat = severeThunderstormDamageThreatTag(thunderstormDamageThreat) {
+                tags.append(damageThreat)
+            }
+
+            if let windGust = windGustTag(maxWindGust) {
+                tags.append(windGust)
+            }
+
+            if let hailSize = hailSizeTag(maxHailSize) {
+                tags.append(hailSize)
+            }
+
+            if let hailThreat = hazardThreatTag(hailThreat, noun: "severe hail") {
+                tags.append(hailThreat)
+            }
+
+            if let windThreat = hazardThreatTag(windThreat, noun: "severe winds") {
+                tags.append(windThreat)
+            }
+
+        case "tornado warning":
+            if let detection = tornadoDetectionTag(tornadoDetection) {
+                tags.append(detection)
+            }
+
+            if let damageThreat = tornadoDamageThreatTag(tornadoDamageThreat) {
+                tags.append(damageThreat)
+            }
+
+        case "flash flood warning":
+            if let detection = floodDetectionTag(flashFloodDetection) {
+                tags.append(detection)
+            }
+
+            if let damageThreat = flashFloodDamageThreatTag(flashFloodDamageThreat) {
+                tags.append(damageThreat)
+            }
+
+        default:
+            return nil
+        }
+        
+        return tags.joined(separator: "\n")
+    }
 }
 
 extension WatchRowDTO {
@@ -71,5 +137,135 @@ extension WatchRowDTO {
         self.response = watch.response
         self.sender = watch.sender
         self.description = watch.watchDescription
+        self.tornadoDetection = watch.tornadoDetection
+        self.tornadoDamageThreat = watch.tornadoDamageThreat
+        self.maxWindGust = watch.maxWindGust
+        self.maxHailSize = watch.maxHailSize
+        self.windThreat = watch.windThreat
+        self.hailThreat = watch.hailThreat
+        self.thunderstormDamageThreat = watch.thunderstormDamageThreat
+        self.flashFloodDetection = watch.flashFloodDetection
+        self.flashFloodDamageThreat = watch.flashFloodDamageThreat
     }
+    
+    // MARK: CAP Severe Tag Parsing
+    private func trimmedNonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              trimmed.isEmpty == false else {
+            return nil
+        }
+
+        return trimmed
+    }
+
+    private func normalizedCategory(_ value: String?) -> String? {
+        guard let trimmed = trimmedNonEmpty(value) else {
+            return nil
+        }
+
+        let normalized = trimmed.normalizedLowercased
+        guard normalized.isEmpty == false,
+              normalized != "none",
+              normalized != "unknown",
+              normalized != "n/a" else {
+            return nil
+        }
+
+        return normalized
+    }
+
+    private func severeThunderstormDamageThreatTag(_ value: String?) -> String? {
+        switch normalizedCategory(value) {
+        case "considerable":
+            return "Considerable damage possible"
+        case "destructive":
+            return "Destructive winds possible"
+        default:
+            return nil
+        }
+    }
+
+    private func tornadoDamageThreatTag(_ value: String?) -> String? {
+        switch normalizedCategory(value) {
+        case "considerable":
+            return "Considerable tornado damage possible"
+        case "catastrophic":
+            return "Catastrophic tornado damage possible"
+        default:
+            return nil
+        }
+    }
+
+    private func flashFloodDamageThreatTag(_ value: String?) -> String? {
+        switch normalizedCategory(value) {
+        case "considerable":
+            return "Considerable flash flooding possible"
+        case "catastrophic":
+            return "Catastrophic flash flooding possible"
+        default:
+            return nil
+        }
+    }
+
+    private func tornadoDetectionTag(_ value: String?) -> String? {
+        switch normalizedCategory(value) {
+        case "observed":
+            return "Observed tornado"
+        case "radar indicated":
+            return "Radar-indicated tornado"
+        case "possible":
+            return "Tornado possible"
+        default:
+            return nil
+        }
+    }
+
+    private func floodDetectionTag(_ value: String?) -> String? {
+        switch normalizedCategory(value) {
+        case "observed":
+            return "Observed flooding"
+        case "radar indicated":
+            return "Radar-indicated flooding"
+        default:
+            return nil
+        }
+    }
+
+    private func hazardThreatTag(_ value: String?, noun: String) -> String? {
+        switch normalizedCategory(value) {
+        case "observed":
+            return "Observed \(noun)"
+        case "radar indicated":
+            return "Radar-indicated \(noun)"
+        default:
+            return nil
+        }
+    }
+
+    private func windGustTag(_ value: String?) -> String? {
+        guard let trimmed = trimmedNonEmpty(value) else {
+            return nil
+        }
+
+        let normalized = trimmed.normalizedLowercased
+        if normalized.contains("mph") {
+            return "Wind gusts up to \(trimmed)"
+        }
+
+        return "Wind gusts up to \(trimmed) mph"
+    }
+
+    private func hailSizeTag(_ value: String?) -> String? {
+        guard let trimmed = trimmedNonEmpty(value) else {
+            return nil
+        }
+
+        let normalized = trimmed.normalizedLowercased
+        if normalized.contains("inch") || normalized.contains("in.") || normalized.contains("\"") {
+            return "Hail up to \(trimmed)"
+        }
+
+        return "Hail up to \(trimmed) in"
+    }
+
 }

--- a/Sources/Repos/WatchRepo.swift
+++ b/Sources/Repos/WatchRepo.swift
@@ -116,7 +116,16 @@ actor WatchRepo {
             sender: item.senderName,
             instruction: item.instructions,
             response: item.response,
-            cells: item.h3Cells ?? []
+            cells: item.h3Cells ?? [],
+            tornadoDetection: item.tornadoDetection,
+            tornadoDamageThreat: item.tornadoDamageThreat,
+            maxWindGust: item.maxWindGust,
+            maxHailSize: item.maxHailSize,
+            windThreat: item.windThreat,
+            hailThreat: item.hailThreat,
+            thunderstormDamageThreat: item.thunderstormDamageThreat,
+            flashFloodDetection: item.flashFloodDetection,
+            flashFloodDamageThreat: item.flashFloodDamageThreat
         )
     }
     

--- a/Sources/Utilities/Core/SpcProductHeader.swift
+++ b/Sources/Utilities/Core/SpcProductHeader.swift
@@ -47,7 +47,7 @@ struct SpcProductHeader: View {
                     .minimumScaleFactor(0.85)
                 
                 Spacer()
-                InZonePill(inZone: inZone) // The sheet view is filtered, alters and full are not
+//                InZonePill(inZone: inZone) // The sheet view is filtered, alters and full are not
             }
             if let subtitle {
                 Text(subtitle)
@@ -75,8 +75,17 @@ struct SpcProductHeader: View {
     }
 }
 
-#Preview("Full") {
-    SpcProductHeader(title: "Mesoscale Discussion", issued: MD.sampleDiscussionDTOs[1].issued, validStart: MD.sampleDiscussionDTOs[1].validStart, validEnd: MD.sampleDiscussionDTOs[1].validEnd, subtitle: "MD 1913", inZone: false, sender: "NWS Boulder CO")
+#Preview("Full MD") {
+    HStack{
+        SpcProductHeader(title: "Mesoscale Discussion", issued: MD.sampleDiscussionDTOs[1].issued, validStart: MD.sampleDiscussionDTOs[1].validStart, validEnd: MD.sampleDiscussionDTOs[1].validEnd, subtitle: "MD 1913", inZone: false, sender: "NWS Boulder CO")
+    }.padding(11)
+}
+
+#Preview("Full Warning") {
+    let watch = Watch.sampleWatchRows[3]
+    HStack{
+        SpcProductHeader(title: "Severe Thunderstorm Warning", issued: watch.issued, validStart: watch.validStart, validEnd: watch.validEnd, subtitle: "SUBTITLE", inZone: false, sender: "NWS Boulder CO")
+    }.padding(11)
 }
 
 #Preview("No subtitle") {

--- a/Sources/Utilities/Extensions/ext+String.swift
+++ b/Sources/Utilities/Extensions/ext+String.swift
@@ -139,4 +139,8 @@ extension String {
         formatter.timeZone = .utc // TimeZone(secondsFromGMT: 0)
         return formatter.date(from: date)
     }
+    
+    var normalizedLowercased: String {
+        trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
 }


### PR DESCRIPTION
# Summary
This branch surfaces CAP severe-risk metadata in the alert UI, carries the new payload fields through the watch models, and adds an initial remote-notification entry point for refreshing event state. It also adjusts the active alert summary presentation and updates previews/sample data to match the new display.

# What Changed
- Added CAP severe-risk fields to device alert payloads, watch persistence, and watch row DTOs, including tag generation for tornado, severe thunderstorm, and flash flood warning metadata.
- Exposed severe-risk tags through the shared alert protocol and displayed them in alert rows, watch detail, and watch summary rows when supported data is present.
- Updated the active alert summary to show fewer items by default and added an expand/collapse control for viewing the full list.
- Registered the app for remote notifications at launch and added a stubbed background remote-notification handler that parses `eventKey` and `revision` before calling a refresh hook.
- Refreshed preview/sample content and related project references to support the new UI states.

# User Impact
Users can see more explicit severe-weather context, such as tornado detection and damage-threat tags, directly in supported alert rows and watch detail screens. The alert summary also becomes more compact by default while still letting users expand to the full list. The remote-notification work is internal plumbing for now because the refresh implementation is still stubbed.

# Testing
- Not run in this workflow.
- No existing test logs or validation artifacts were found in the committed branch evidence.

# Notes
- The worktree contains an untracked `Sources/App/HomeRefreshV2/` directory that is intentionally excluded from this PR.
- The remote-notification refresh path currently logs the trigger and returns success, but does not yet fetch or persist updated event state.

closes #107 