### PR TITLE
Improve adaptive layouts for large Dynamic Type sizes

### DIFF
--- a/Sources/Features/Alert/AlertView.swift
+++ b/Sources/Features/Alert/AlertView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct AlertView: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     let mesos: [MdDTO]
     let watches: [WatchRowDTO]
     let focusedWatchRequest: RemoteAlertFocusRequest?
@@ -44,6 +46,10 @@ struct AlertView: View {
     
     private var totalAlertCount: Int {
         watches.count + mesos.count
+    }
+
+    private var adaptiveLayout: SkyAwareAdaptiveLayout {
+        SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize)
     }
     
     private var activeLocalAlertLabel: String {
@@ -208,16 +214,21 @@ struct AlertView: View {
         @ViewBuilder content: () -> Content
     ) -> some View {
         VStack(alignment: .leading, spacing: 12) {
-            HStack {
+            if adaptiveLayout.usesAccessibilityLayout {
                 Label(title, systemImage: symbol)
                     .font(.headline.weight(.semibold))
-                Spacer()
-                Text(subtitle)
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 5)
-                    .skyAwareChip(cornerRadius: SkyAwareRadius.chip, tint: .white.opacity(0.08))
+            } else {
+                HStack {
+                    Label(title, systemImage: symbol)
+                        .font(.headline.weight(.semibold))
+                    Spacer()
+                    Text(subtitle)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .skyAwareChip(cornerRadius: SkyAwareRadius.chip, tint: .white.opacity(0.08))
+                }
             }
             
             content()

--- a/Sources/Features/Alert/WatchDetailView.swift
+++ b/Sources/Features/Alert/WatchDetailView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct WatchDetailView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     let watch: WatchRowDTO
     let layout: DetailLayout
@@ -44,6 +45,10 @@ struct WatchDetailView: View {
         guard let description = trimmedDescription else { return nil }
         guard let lead = summaryLead else { return description }
         return description.localizedCaseInsensitiveCompare(lead) == .orderedSame ? nil : description
+    }
+
+    private var adaptiveLayout: SkyAwareAdaptiveLayout {
+        SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize)
     }
 
     init(watch: WatchRowDTO, layout: DetailLayout, isExpanded: Bool = true) {
@@ -97,13 +102,23 @@ struct WatchDetailView: View {
     }
 
     private var chips: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
-                StatusChip(kind: .severity(watch.severity))
-                StatusChip(kind: .certainty(watch.certainty))
-                StatusChip(kind: .urgency(watch.urgency))
+        Group {
+            if adaptiveLayout.usesAccessibilityLayout {
+                VStack(alignment: .leading, spacing: 8) {
+                    StatusChip(kind: .severity(watch.severity))
+                    StatusChip(kind: .certainty(watch.certainty))
+                    StatusChip(kind: .urgency(watch.urgency))
+                }
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        StatusChip(kind: .severity(watch.severity))
+                        StatusChip(kind: .certainty(watch.certainty))
+                        StatusChip(kind: .urgency(watch.urgency))
+                    }
+                    .padding(.vertical, 2)
+                }
             }
-            .padding(.vertical, 2)
         }
     }
 

--- a/Sources/Features/Badges/AtmosphereRailView.swift
+++ b/Sources/Features/Badges/AtmosphereRailView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct AtmosphereRailView: View {
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var activeTip: AtmosphereTip?
     let weather: SummaryWeather?
     var isOffline: Bool = false
@@ -112,6 +113,10 @@ struct AtmosphereRailView: View {
         GridItem(.flexible(), spacing: 2, alignment: .leading)
     ]
 
+    private var adaptiveLayout: SkyAwareAdaptiveLayout {
+        SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize)
+    }
+
     private var atmosphereBackground: LinearGradient {
         // Intentionally non-semantic: instrumentation, not risk.
         let colors: [Color] = colorScheme == .dark
@@ -145,7 +150,7 @@ struct AtmosphereRailView: View {
 
                     Text(atmosphereSummary)
                         .formatSummaryText(for: colorScheme)
-                        .lineLimit(1)
+                        .lineLimit(adaptiveLayout.usesVerticalMetricRows ? 2 : 1)
 
                     Divider()
                         .overlay(colorScheme == .dark ? .white.opacity(0.22) : .black.opacity(0.14))
@@ -175,7 +180,11 @@ struct AtmosphereRailView: View {
 
     @ViewBuilder
     private var metricGrid: some View {
-        metricGridContent
+        if adaptiveLayout.usesVerticalMetricRows {
+            metricRowsContent
+        } else {
+            metricGridContent
+        }
     }
 
     private var metricGridContent: some View {
@@ -183,11 +192,25 @@ struct AtmosphereRailView: View {
             ForEach(metrics) { metric in
                 AtmosphereMetricTile(
                     metric: metric,
-                    activeTip: $activeTip
+                    activeTip: $activeTip,
+                    usesVerticalRowLayout: false
                 )
             }
         }
         .padding(.horizontal, 4)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var metricRowsContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(metrics) { metric in
+                AtmosphereMetricTile(
+                    metric: metric,
+                    activeTip: $activeTip,
+                    usesVerticalRowLayout: true
+                )
+            }
+        }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
@@ -275,6 +298,7 @@ private struct DewPointTipView: View {
 private struct AtmosphereMetricTile: View {
     let metric: AtmosphereMetric
     @Binding var activeTip: AtmosphereTip?
+    let usesVerticalRowLayout: Bool
     @Environment(\.colorScheme) private var colorScheme
 
     private var isDewPoint: Bool {
@@ -283,39 +307,63 @@ private struct AtmosphereMetricTile: View {
 
     private var tileContent: some View {
         VStack(alignment: .leading, spacing: 2) {
-            HStack(spacing: 6) {
-                Image(systemName: metric.symbol)
-                    .symbolRenderingMode(.monochrome)
-                    .font(.caption.weight(.semibold))
-                    .imageScale(.medium)
-                    .frame(width: 24, height: 18, alignment: .leading)
-                    .padding(.leading, 2)
-                    .layoutPriority(1)
-
+            if usesVerticalRowLayout {
                 Text(metric.title)
-                    .font(.footnote.weight(.semibold))
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.85)
-                    .layoutPriority(0)
-            }
-            .foregroundStyle(.secondary)
-
-            Text(metric.value)
-                .font(.callout.weight(isDewPoint ? .bold : .semibold))
-                .foregroundStyle(
-                    isDewPoint
-                    ? Color.orange.opacity(colorScheme == .dark ? 0.75 : 0.70)
-                    : .primary
-                )
-                .monospacedDigit()
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-
-            if let detail = metric.detail {
-                Text(detail)
-                    .font(.caption2)
+                    .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
+                    .lineLimit(2)
+
+                Text(metric.value)
+                    .font(.body.weight(isDewPoint ? .bold : .semibold))
+                    .foregroundStyle(
+                        isDewPoint
+                        ? Color.orange.opacity(colorScheme == .dark ? 0.75 : 0.70)
+                        : .primary
+                    )
+                    .monospacedDigit()
+                    .lineLimit(2)
+
+                if let detail = metric.detail {
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            } else {
+                HStack(spacing: 6) {
+                    Image(systemName: metric.symbol)
+                        .symbolRenderingMode(.monochrome)
+                        .font(.caption.weight(.semibold))
+                        .imageScale(.medium)
+                        .frame(width: 24, height: 18, alignment: .leading)
+                        .padding(.leading, 2)
+                        .layoutPriority(1)
+
+                    Text(metric.title)
+                        .font(.footnote.weight(.semibold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.85)
+                        .layoutPriority(0)
+                }
+                .foregroundStyle(.secondary)
+
+                Text(metric.value)
+                    .font(.callout.weight(isDewPoint ? .bold : .semibold))
+                    .foregroundStyle(
+                        isDewPoint
+                        ? Color.orange.opacity(colorScheme == .dark ? 0.75 : 0.70)
+                        : .primary
+                    )
+                    .monospacedDigit()
                     .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+
+                if let detail = metric.detail {
+                    Text(detail)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
             }
         }
     }
@@ -349,13 +397,13 @@ private struct AtmosphereMetricTile: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.leading, 6)
                 .padding(.trailing, 4)
-                .padding(.vertical, 6)
+                .padding(.vertical, usesVerticalRowLayout ? 8 : 6)
             } else {
                 tileContent
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.leading, 6)
                     .padding(.trailing, 4)
-                    .padding(.vertical, 6)
+                    .padding(.vertical, usesVerticalRowLayout ? 8 : 6)
             }
         }
     }

--- a/Sources/Features/Badges/AtmosphereRailView.swift
+++ b/Sources/Features/Badges/AtmosphereRailView.swift
@@ -409,36 +409,60 @@ private struct AtmosphereMetricTile: View {
     }
 }
 
-#Preview {
-    VStack {
-        AtmosphereRailView(weather: .init(
-            temperature: Measurement(value: 37.0, unit: .fahrenheit),
-            symbolName: "sun.max",
-            conditionText: "test",
-            asOf: .now,
-            dewPoint: Measurement(value: 45.0, unit: .fahrenheit),
-            humidity: 0.15,
-            windSpeed: .init(value: 15.0, unit: .milesPerHour),
-            windGust: nil,
-            windDirection: "NNW",
-            pressure: .init(value: 29.95, unit: .inchesOfMercury),
-            pressureTrend: "climbing"
-        ))
+#Preview("Atmosphere - Normal Grid") {
+    AtmosphereRailView(weather: AtmosphereRailPreviewData.unstable)
+}
 
-        AtmosphereRailView(weather: nil)
+#Preview("Atmosphere - XXXL Grid") {
+    AtmosphereRailView(weather: AtmosphereRailPreviewData.unstable)
+        .environment(\.dynamicTypeSize, .xxxLarge)
+}
 
-        AtmosphereRailView(weather: .init(
-            temperature: Measurement(value: 48.0, unit: .fahrenheit),
-            symbolName: "cloud.drizzle",
-            conditionText: "Scattered showers",
-            asOf: .now,
-            dewPoint: Measurement(value: 43.0, unit: .fahrenheit),
-            humidity: 0.82,
-            windSpeed: .init(value: 8.0, unit: .milesPerHour),
-            windGust: nil,
-            windDirection: "SE",
-            pressure: .init(value: 29.58, unit: .inchesOfMercury),
-            pressureTrend: "falling"
-        ))
-    }
+#Preview("Atmosphere - AX1 Vertical Rows") {
+    AtmosphereRailView(weather: AtmosphereRailPreviewData.unstable)
+        .environment(\.dynamicTypeSize, .accessibility1)
+}
+
+#Preview("Atmosphere - AX3 Vertical Rows Small iPhone") {
+    AtmosphereRailView(weather: AtmosphereRailPreviewData.steady)
+        .environment(\.dynamicTypeSize, .accessibility3)
+        .frame(width: 320)
+}
+
+#Preview("Atmosphere - Dew Point Tip Content") {
+    DewPointTipView(
+        currentValue: "68°F",
+        dewPointF: 68
+    )
+    .padding()
+}
+
+private enum AtmosphereRailPreviewData {
+    static let unstable = SummaryWeather(
+        temperature: Measurement(value: 82.0, unit: .fahrenheit),
+        symbolName: "cloud.bolt.rain.fill",
+        conditionText: "Hot, humid, unstable",
+        asOf: .now,
+        dewPoint: Measurement(value: 68.0, unit: .fahrenheit),
+        humidity: 0.72,
+        windSpeed: Measurement(value: 21.0, unit: .milesPerHour),
+        windGust: Measurement(value: 34.0, unit: .milesPerHour),
+        windDirection: "SSW",
+        pressure: Measurement(value: 29.74, unit: .inchesOfMercury),
+        pressureTrend: "falling"
+    )
+
+    static let steady = SummaryWeather(
+        temperature: Measurement(value: 48.0, unit: .fahrenheit),
+        symbolName: "cloud.sun.fill",
+        conditionText: "Cool and steady",
+        asOf: .now,
+        dewPoint: Measurement(value: 43.0, unit: .fahrenheit),
+        humidity: 0.56,
+        windSpeed: Measurement(value: 8.0, unit: .milesPerHour),
+        windGust: nil,
+        windDirection: "SE",
+        pressure: Measurement(value: 29.95, unit: .inchesOfMercury),
+        pressureTrend: "steady"
+    )
 }

--- a/Sources/Features/ConvectiveOutlookView/ConvectiveOutlookDetailView.swift
+++ b/Sources/Features/ConvectiveOutlookView/ConvectiveOutlookDetailView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct ConvectiveOutlookDetailView: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     let outlook: ConvectiveOutlookDTO
     
     private let sectionSpacing: CGFloat = 14
@@ -39,6 +41,10 @@ struct ConvectiveOutlookDetailView: View {
             return clean
         }
         return outlook.fullText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var adaptiveLayout: SkyAwareAdaptiveLayout {
+        SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize)
     }
     
     var body: some View {
@@ -78,9 +84,9 @@ struct ConvectiveOutlookDetailView: View {
             )
             
             Divider().opacity(0.12)
-            
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
+
+            if adaptiveLayout.usesAccessibilityLayout {
+                VStack(alignment: .leading, spacing: 8) {
                     OutlookMetaChip(title: "Published \(outlook.published.relativeDate())", icon: "clock.arrow.circlepath")
                     if let day = outlook.day {
                         OutlookMetaChip(title: "Day \(day)", icon: "calendar")
@@ -89,7 +95,19 @@ struct ConvectiveOutlookDetailView: View {
                         OutlookMetaChip(title: sentenceCaseRiskLevel(risk), icon: "exclamationmark.triangle")
                     }
                 }
-                .padding(.vertical, 2)
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        OutlookMetaChip(title: "Published \(outlook.published.relativeDate())", icon: "clock.arrow.circlepath")
+                        if let day = outlook.day {
+                            OutlookMetaChip(title: "Day \(day)", icon: "calendar")
+                        }
+                        if let risk = outlook.riskLevel?.trimmingCharacters(in: .whitespacesAndNewlines), !risk.isEmpty {
+                            OutlookMetaChip(title: sentenceCaseRiskLevel(risk), icon: "exclamationmark.triangle")
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
             }
             
             SpcProductFooter(link: outlook.link, validEnd: validUntilDate)
@@ -128,8 +146,14 @@ struct ConvectiveOutlookDetailView: View {
 }
 
 private struct OutlookMetaChip: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     let title: String
     let icon: String
+
+    private var adaptiveLayout: SkyAwareAdaptiveLayout {
+        SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize)
+    }
     
     var body: some View {
         HStack(spacing: 6) {
@@ -138,8 +162,9 @@ private struct OutlookMetaChip: View {
                 .foregroundStyle(.secondary)
             Text(title)
                 .font(.caption.weight(.semibold))
-                .lineLimit(1)
+                .lineLimit(adaptiveLayout.usesAccessibilityLayout ? 2 : 1)
         }
+        .frame(maxWidth: adaptiveLayout.usesAccessibilityLayout ? .infinity : nil, alignment: .leading)
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
         .skyAwareChip(cornerRadius: SkyAwareRadius.hero, tint: .white.opacity(0.10), interactive: true)

--- a/Sources/Features/ConvectiveOutlookView/ConvectiveOutlookView.swift
+++ b/Sources/Features/ConvectiveOutlookView/ConvectiveOutlookView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct ConvectiveOutlookView: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     let dtos: [ConvectiveOutlookDTO]
     let onRefresh: (() async -> Void)?
     
@@ -27,6 +29,10 @@ struct ConvectiveOutlookView: View {
 
     private var latestOutlook: ConvectiveOutlookDTO? {
         sortedOutlooks.first
+    }
+
+    private var adaptiveLayout: SkyAwareAdaptiveLayout {
+        SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize)
     }
 
     private var earlierOutlooks: [ConvectiveOutlookDTO] {
@@ -130,16 +136,21 @@ struct ConvectiveOutlookView: View {
         @ViewBuilder content: () -> Content
     ) -> some View {
         VStack(alignment: .leading, spacing: 12) {
-            HStack {
+            if adaptiveLayout.usesAccessibilityLayout {
                 Label(title, systemImage: symbol)
                     .font(.headline.weight(.semibold))
-                Spacer()
-                Text(subtitle)
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 5)
-                    .skyAwareChip(cornerRadius: SkyAwareRadius.chip, tint: .white.opacity(0.08))
+            } else {
+                HStack {
+                    Label(title, systemImage: symbol)
+                        .font(.headline.weight(.semibold))
+                    Spacer()
+                    Text(subtitle)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .skyAwareChip(cornerRadius: SkyAwareRadius.chip, tint: .white.opacity(0.08))
+                }
             }
 
             content()

--- a/Sources/Features/ConvectiveOutlookView/OutlookRowView.swift
+++ b/Sources/Features/ConvectiveOutlookView/OutlookRowView.swift
@@ -8,51 +8,68 @@
 import SwiftUI
 
 struct OutlookRowView: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     let outlook: ConvectiveOutlookDTO
     private static let titleRegex = try? NSRegularExpression(
         pattern: #"^SPC\s+\w+\s+\d{1,2},\s+\d{4}\s+(\d{4}) UTC (.+)$"#
     )
 
-    var body: some View {
-        HStack(alignment: .center, spacing: 12) {
-            Image(systemName: "pencil.and.list.clipboard")
-                .foregroundColor(.skyAwareAccent)
-                .font(.headline.weight(.semibold))
-                .frame(width: 40, height: 40)
-                .skyAwareChip(cornerRadius: SkyAwareRadius.iconChip, tint: Color.skyAwareAccent.opacity(0.18))
+    private var adaptiveLayout: SkyAwareAdaptiveLayout {
+        SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize)
+    }
 
-            if let day = simplifyOutlookTitle(outlook.title) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(day)
-                        .font(.headline.weight(.semibold))
-                        .lineLimit(2)
-                        .minimumScaleFactor(0.9)
-                    
-                    if let issued = outlook.issued{
-                        Text("\(issued.shorten()) • \(issued.relativeDate())")
-                            .font(.caption.weight(.medium))
-                            .foregroundColor(.secondary)
-                    }
+    var body: some View {
+        Group {
+            if adaptiveLayout.usesAccessibilityLayout {
+                VStack(alignment: .leading, spacing: 10) {
+                    titleBlock
+                    metadataLine
                 }
             } else {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(outlook.title)
+                HStack(alignment: .center, spacing: 12) {
+                    Image(systemName: "pencil.and.list.clipboard")
+                        .foregroundColor(.skyAwareAccent)
                         .font(.headline.weight(.semibold))
-                        .lineLimit(2)
-                    Text("Published \(outlook.published.relativeDate())")
-                        .font(.caption.weight(.medium))
-                        .foregroundColor(.secondary)
+                        .frame(width: 40, height: 40)
+                        .skyAwareChip(cornerRadius: SkyAwareRadius.iconChip, tint: Color.skyAwareAccent.opacity(0.18))
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        titleBlock
+                        metadataLine
+                    }
+
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.tertiary)
                 }
             }
-            Spacer()
-            Image(systemName: "chevron.right")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.tertiary)
         }
         .frame(maxWidth: .infinity, minHeight: 56, alignment: .leading)
         .padding(14)
         .cardBackground(cornerRadius: SkyAwareRadius.row, shadowOpacity: 0.04, shadowRadius: 4, shadowY: 1)
         .contentShape(Rectangle())
+    }
+
+    private var titleBlock: some View {
+        Text(simplifyOutlookTitle(outlook.title) ?? outlook.title)
+            .font(.headline.weight(.semibold))
+            .lineLimit(adaptiveLayout.usesAccessibilityLayout ? 3 : 2)
+            .minimumScaleFactor(adaptiveLayout.usesAccessibilityLayout ? 1 : 0.9)
+    }
+
+    private var metadataLine: some View {
+        Group {
+            if let issued = outlook.issued {
+                Text("\(issued.shorten()) • \(issued.relativeDate())")
+            } else {
+                Text("Published \(outlook.published.relativeDate())")
+            }
+        }
+        .font(.caption.weight(.medium))
+        .foregroundColor(.secondary)
+        .lineLimit(adaptiveLayout.usesAccessibilityLayout ? 2 : 1)
     }
 }
 

--- a/Sources/Features/Map/MapLegendView.swift
+++ b/Sources/Features/Map/MapLegendView.swift
@@ -64,7 +64,7 @@ struct MapLegend: View {
             }
         }
         .padding(16)
-        .frame(minWidth: 144, alignment: .leading)
+        .frame(minWidth: 144, maxWidth: 260, alignment: .leading)
         .fixedSize(horizontal: true, vertical: false)
         .cardBackground(
             cornerRadius: SkyAwareRadius.row,
@@ -72,6 +72,40 @@ struct MapLegend: View {
             shadowRadius: 8,
             shadowY: 3
         )
+    }
+}
+
+struct CompactMapLegendTrigger: View {
+    let label: String
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 8) {
+                Text(label)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(1)
+
+                Image(systemName: "chevron.up")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .frame(minHeight: 40)
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .skyAwareSurface(
+            cornerRadius: SkyAwareRadius.section,
+            tint: .skyAwareAccent.opacity(0.12),
+            interactive: true,
+            shadowOpacity: 0.14,
+            shadowRadius: 8,
+            shadowY: 4
+        )
+        .accessibilityLabel("Map legend")
+        .accessibilityHint("Opens the full map legend.")
     }
 }
 

--- a/Sources/Features/Map/MapScreenView.swift
+++ b/Sources/Features/Map/MapScreenView.swift
@@ -162,24 +162,7 @@ private struct MapScreenContent: View {
             )
         }
         .sheet(isPresented: $showsLegendSheet) {
-            NavigationStack {
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 12) {
-                        if showsWarningLegend {
-                            WarningLegend()
-                                .fixedSize(horizontal: false, vertical: false)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-
-                        MapLegend(state: scene.legendState)
-                            .fixedSize(horizontal: false, vertical: false)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .padding(16)
-                }
-                .navigationTitle("Legend")
-                .navigationBarTitleDisplayMode(.inline)
-            }
+            MapLegendSheet(showWarnings: showsWarningLegend, legendState: scene.legendState)
             .presentationDetents([.medium, .large])
         }
     }
@@ -265,20 +248,121 @@ private struct MapLayerButtonMorph: ViewModifier {
     }
 }
 
-#Preview {
-    MapScreenContentPreview()
+private struct MapLegendSheet: View {
+    let showWarnings: Bool
+    let legendState: MapLegendState
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    if showWarnings {
+                        WarningLegend()
+                            .fixedSize(horizontal: false, vertical: false)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    MapLegend(state: legendState)
+                        .fixedSize(horizontal: false, vertical: false)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .padding(16)
+            }
+            .navigationTitle("Legend")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
 }
 
 private struct MapScreenContentPreview: View {
     @Namespace private var layerNamespace
 
+    let legendState: MapLegendState
+    let selectedLayer: MapLayer
+
+    init(
+        legendState: MapLegendState = .empty(for: .categorical),
+        selectedLayer: MapLayer = .categorical
+    ) {
+        self.legendState = legendState
+        self.selectedLayer = selectedLayer
+    }
+
     var body: some View {
         MapScreenContent(
-            selected: .constant(.categorical),
+            selected: .constant(selectedLayer),
             showLayerPicker: .constant(false),
             showsWarningGeometry: .constant(true),
-            scene: MapLayerScene.placeholder(for: .categorical),
+            scene: MapLayerScene(
+                canvasState: MapCanvasState(overlays: [], overlayRevision: 0, initialCenterCoordinate: nil),
+                legendState: legendState
+            ),
             layerNamespace: layerNamespace
         )
     }
+}
+
+private enum MapScreenPreviewLegendState {
+    static let severeWithHatching = MapLegendState(
+        layer: .tornado,
+        severeItems: [
+            SevereLegendItem(id: "5%", probability: .percent(0.05), fillHex: nil, strokeHex: nil),
+            SevereLegendItem(id: "10%", probability: .percent(0.10), fillHex: nil, strokeHex: nil),
+            SevereLegendItem(id: "15%", probability: .percent(0.15), fillHex: nil, strokeHex: nil),
+            SevereLegendItem(id: "Sig 10%", probability: .significant(10), fillHex: nil, strokeHex: nil)
+        ],
+        fireItems: [],
+        showsHatchingExplanation: true
+    )
+
+    static let severeWithoutHatching = MapLegendState(
+        layer: .tornado,
+        severeItems: [
+            SevereLegendItem(id: "5%", probability: .percent(0.05), fillHex: nil, strokeHex: nil),
+            SevereLegendItem(id: "10%", probability: .percent(0.10), fillHex: nil, strokeHex: nil)
+        ],
+        fireItems: [],
+        showsHatchingExplanation: false
+    )
+}
+
+#Preview("Map Legend - Normal Inline") {
+    MapScreenContentPreview()
+        .environment(\.dynamicTypeSize, .large)
+}
+
+#Preview("Map Legend - XXXL Inline") {
+    MapScreenContentPreview()
+        .environment(\.dynamicTypeSize, .xxxLarge)
+}
+
+#Preview("Map Legend - AX1 Compact Trigger") {
+    MapScreenContentPreview(
+        legendState: MapScreenPreviewLegendState.severeWithHatching,
+        selectedLayer: .tornado
+    )
+    .environment(\.dynamicTypeSize, .accessibility1)
+}
+
+#Preview("Map Legend - AX3 Compact Trigger") {
+    MapScreenContentPreview(
+        legendState: MapScreenPreviewLegendState.severeWithHatching,
+        selectedLayer: .tornado
+    )
+    .environment(\.dynamicTypeSize, .accessibility3)
+}
+
+#Preview("Map Legend Sheet - AX3 Small iPhone") {
+    MapLegendSheet(
+        showWarnings: true,
+        legendState: MapScreenPreviewLegendState.severeWithHatching
+    )
+    .environment(\.dynamicTypeSize, .accessibility3)
+    .frame(width: 320, height: 568)
+}
+
+#Preview("Map Legend - No Hatching Rows") {
+    MapLegend(state: MapScreenPreviewLegendState.severeWithoutHatching)
+        .padding()
+        .background(.thinMaterial)
 }

--- a/Sources/Features/Map/MapScreenView.swift
+++ b/Sources/Features/Map/MapScreenView.swift
@@ -77,6 +77,7 @@ struct MapScreenView: View {
 
 private struct MapScreenContent: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     @Binding var selected: MapLayer
     @Binding var showLayerPicker: Bool
@@ -84,6 +85,12 @@ private struct MapScreenContent: View {
 
     let scene: MapLayerScene
     let layerNamespace: Namespace.ID
+
+    @State private var showsLegendSheet = false
+
+    private var adaptiveLayout: SkyAwareAdaptiveLayout {
+        SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize)
+    }
 
     var body: some View {
         ZStack {
@@ -131,22 +138,20 @@ private struct MapScreenContent: View {
             VStack {
                 Spacer()
                 HStack(alignment: .bottom, spacing: 10) {
-                    if showsWarningLegend {
+                    if showsWarningLegend && adaptiveLayout.mapLegendMode == .inline {
                         WarningLegend()
                             .transition(.opacity)
                     }
 
                     Spacer(minLength: 8)
 
-                    MapLegend(state: scene.legendState)
-                        .transition(.opacity)
-                        .animation(SkyAwareMotion.layerChange(reduceMotion), value: selected)
+                    mapLegendControl
                 }
                 .padding(.horizontal, 14)
                 .padding(.bottom, 14)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-            .allowsHitTesting(scene.legendState.allowsInteraction)
+            .allowsHitTesting(legendAllowsHitTesting)
         }
         .sheet(isPresented: $showLayerPicker) {
             LayerPickerSheet(
@@ -156,10 +161,60 @@ private struct MapScreenContent: View {
                 triggerNamespace: layerNamespace
             )
         }
+        .sheet(isPresented: $showsLegendSheet) {
+            NavigationStack {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 12) {
+                        if showsWarningLegend {
+                            WarningLegend()
+                                .fixedSize(horizontal: false, vertical: false)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+
+                        MapLegend(state: scene.legendState)
+                            .fixedSize(horizontal: false, vertical: false)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .padding(16)
+                }
+                .navigationTitle("Legend")
+                .navigationBarTitleDisplayMode(.inline)
+            }
+            .presentationDetents([.medium, .large])
+        }
     }
 
     private var showsWarningLegend: Bool {
         scene.canvasState.overlays.contains { $0.key.hasPrefix("warn|") }
+    }
+
+    @ViewBuilder
+    private var mapLegendControl: some View {
+        switch adaptiveLayout.mapLegendMode {
+        case .inline:
+            MapLegend(state: scene.legendState)
+                .transition(.opacity)
+                .animation(SkyAwareMotion.layerChange(reduceMotion), value: selected)
+        case .compactTrigger, .sheetOnly:
+            CompactMapLegendTrigger(label: compactLegendLabel) {
+                showsLegendSheet = true
+            }
+            .transition(.opacity)
+            .animation(SkyAwareMotion.layerChange(reduceMotion), value: selected)
+        }
+    }
+
+    private var compactLegendLabel: String {
+        "Legend · \(scene.legendState.layer.title)"
+    }
+
+    private var legendAllowsHitTesting: Bool {
+        switch adaptiveLayout.mapLegendMode {
+        case .inline:
+            return scene.legendState.allowsInteraction
+        case .compactTrigger, .sheetOnly:
+            return true
+        }
     }
 }
 

--- a/Sources/Features/Map/Picker.swift
+++ b/Sources/Features/Map/Picker.swift
@@ -75,6 +75,18 @@ struct LayerTile: View {
         SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize)
     }
 
+    private var displayTitle: String {
+        guard dynamicTypeSize == .xxxLarge else { return layer.title }
+        switch layer {
+        case .categorical:
+            return "Severe"
+        case .meso:
+            return "Meso"
+        default:
+            return layer.title
+        }
+    }
+
     private var tint: Color {
         switch layer {
         case .categorical: return .riskThunderstorm.opacity(0.20)
@@ -95,7 +107,7 @@ struct LayerTile: View {
                 if adaptiveLayout.usesAccessibilityLayout {
                     HStack(spacing: 12) {
                         layerIcon
-                        Text(layer.title)
+                        Text(displayTitle)
                             .font(.headline.weight(.semibold))
                             .foregroundStyle(.primary)
                             .multilineTextAlignment(.leading)
@@ -110,7 +122,7 @@ struct LayerTile: View {
                     VStack(spacing: 10) {
                         layerIcon
 
-                        Text(layer.title)
+                        Text(displayTitle)
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(.primary)
                             .multilineTextAlignment(.center)
@@ -122,7 +134,7 @@ struct LayerTile: View {
             }
             .padding(.vertical, 4)
             .accessibilityElement(children: .combine)
-            .accessibilityLabel(layer.title + (isSelected ? ", selected" : ""))
+            .accessibilityLabel(displayTitle + (isSelected ? ", selected" : ""))
         }
         .buttonStyle(.plain)
         .animation(SkyAwareMotion.layerChange(reduceMotion), value: isSelected)
@@ -170,6 +182,14 @@ struct LayerPickerSheet: View {
         SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize)
     }
 
+    private var isAccessibilityListLayout: Bool {
+        Self.usesAccessibilityListLayoutPolicy(dynamicTypeSize: dynamicTypeSize)
+    }
+
+    private var shouldShowWarningGeometryToggle: Bool {
+        Self.showsWarningGeometryTogglePolicy(dynamicTypeSize: dynamicTypeSize)
+    }
+
     var body: some View {
         VStack(spacing: 14) {
             HStack {
@@ -188,7 +208,7 @@ struct LayerPickerSheet: View {
             .padding()
 
             ScrollView {
-                if adaptiveLayout.usesAccessibilityLayout {
+                if isAccessibilityListLayout {
                     VStack(spacing: 10) {
                         ForEach(MapLayer.allCases) { layer in
                             LayerTile(layer: layer, isSelected: selection == layer) {
@@ -218,7 +238,7 @@ struct LayerPickerSheet: View {
                 .foregroundStyle(.secondary)
                 .padding(.bottom, 4)
 
-            if adaptiveLayout.usesAccessibilityLayout == false {
+            if shouldShowWarningGeometryToggle {
                 VStack(alignment: .leading, spacing: 8) {
                     Toggle("Show Active Alerts", isOn: $showsWarningGeometry)
                         .toggleStyle(.switch)
@@ -242,6 +262,14 @@ struct LayerPickerSheet: View {
             selection = layer
         }
         dismiss()
+    }
+
+    static func usesAccessibilityListLayoutPolicy(dynamicTypeSize: DynamicTypeSize) -> Bool {
+        SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize).usesAccessibilityLayout
+    }
+
+    static func showsWarningGeometryTogglePolicy(dynamicTypeSize: DynamicTypeSize) -> Bool {
+        SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize).usesAccessibilityLayout == false
     }
 }
 
@@ -314,10 +342,27 @@ struct MapWithLayerPickerDemo: View {
 
 // MARK: - Preview
 
-#Preview("Layer Picker Sheet") {
+#Preview("Layer Picker - Normal Grid") {
     LayerPickerSheet(selection: .constant(.categorical), showsWarningGeometry: .constant(true))
 }
 
-#Preview("In-Map Demo") {
-    MapWithLayerPickerDemo()
+#Preview("Layer Picker - XXXL Grid") {
+    LayerPickerSheet(selection: .constant(.categorical), showsWarningGeometry: .constant(true))
+        .environment(\.dynamicTypeSize, .xxxLarge)
+}
+
+#Preview("Layer Picker - AX1 Vertical List") {
+    LayerPickerSheet(selection: .constant(.categorical), showsWarningGeometry: .constant(true))
+        .environment(\.dynamicTypeSize, .accessibility1)
+}
+
+#Preview("Layer Picker - AX3 Vertical List") {
+    LayerPickerSheet(selection: .constant(.categorical), showsWarningGeometry: .constant(true))
+        .environment(\.dynamicTypeSize, .accessibility3)
+}
+
+#Preview("Layer Picker - AX3 Small iPhone") {
+    LayerPickerSheet(selection: .constant(.categorical), showsWarningGeometry: .constant(true))
+        .environment(\.dynamicTypeSize, .accessibility3)
+        .frame(width: 320, height: 568)
 }

--- a/Sources/Features/Map/Picker.swift
+++ b/Sources/Features/Map/Picker.swift
@@ -66,9 +66,14 @@ enum MapLayer: String, CaseIterable, Identifiable, Sendable {
 struct LayerTile: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var scheme
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     let layer: MapLayer
     let isSelected: Bool
     let action: () -> Void
+
+    private var adaptiveLayout: SkyAwareAdaptiveLayout {
+        SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize)
+    }
 
     private var tint: Color {
         switch layer {
@@ -86,33 +91,34 @@ struct LayerTile: View {
             action()
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
         }) {
-            VStack(spacing: 10) {
-                RoundedRectangle(cornerRadius: SkyAwareRadius.medium, style: .continuous)
-                    .fill(layer.gradient(for: scheme))
-                    .overlay(
-                        Image(systemName: layer.symbol).formatBadgeImage()
-                    )
-                    .frame(width: 74, height: 74)
-                    .skyAwareSurface(
-                        cornerRadius: SkyAwareRadius.medium,
-                        tint: tint,
-                        interactive: true,
-                        shadowOpacity: scheme == .dark ? 0.20 : 0.10,
-                        shadowRadius: 5,
-                        shadowY: 2
-                    )
-                    .overlay {
-                        RoundedRectangle(cornerRadius: SkyAwareRadius.medium, style: .continuous)
-                            .strokeBorder(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
-                    }
-                    .scaleEffect(isSelected ? 1.02 : 1)
+            Group {
+                if adaptiveLayout.usesAccessibilityLayout {
+                    HStack(spacing: 12) {
+                        layerIcon
+                        Text(layer.title)
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(.primary)
+                            .multilineTextAlignment(.leading)
+                            .lineLimit(3)
 
-                Text(layer.title)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.primary)
-                    .multilineTextAlignment(.center)
-                    .lineLimit(2)
-                    .frame(minHeight: 34, alignment: .top)
+                        Spacer(minLength: 8)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(12)
+                    .cardBackground(cornerRadius: SkyAwareRadius.row, shadowOpacity: 0.04, shadowRadius: 4, shadowY: 1)
+                } else {
+                    VStack(spacing: 10) {
+                        layerIcon
+
+                        Text(layer.title)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.primary)
+                            .multilineTextAlignment(.center)
+                            .lineLimit(2)
+                            .frame(minHeight: 34, alignment: .top)
+                    }
+                    .padding(.vertical, 4)
+                }
             }
             .padding(.vertical, 4)
             .accessibilityElement(children: .combine)
@@ -120,6 +126,28 @@ struct LayerTile: View {
         }
         .buttonStyle(.plain)
         .animation(SkyAwareMotion.layerChange(reduceMotion), value: isSelected)
+    }
+
+    private var layerIcon: some View {
+        RoundedRectangle(cornerRadius: SkyAwareRadius.medium, style: .continuous)
+            .fill(layer.gradient(for: scheme))
+            .overlay(
+                Image(systemName: layer.symbol).formatBadgeImage()
+            )
+            .frame(width: 74, height: 74)
+            .skyAwareSurface(
+                cornerRadius: SkyAwareRadius.medium,
+                tint: tint,
+                interactive: true,
+                shadowOpacity: scheme == .dark ? 0.20 : 0.10,
+                shadowRadius: 5,
+                shadowY: 2
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: SkyAwareRadius.medium, style: .continuous)
+                    .strokeBorder(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
+            }
+            .scaleEffect(isSelected ? 1.02 : 1)
     }
 }
 
@@ -134,8 +162,13 @@ struct LayerPickerSheet: View {
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     
     private let columns = [GridItem(.adaptive(minimum: 76, maximum: 96), spacing: 14)]
+
+    private var adaptiveLayout: SkyAwareAdaptiveLayout {
+        SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize)
+    }
 
     var body: some View {
         VStack(spacing: 14) {
@@ -155,16 +188,29 @@ struct LayerPickerSheet: View {
             .padding()
 
             ScrollView {
-                LazyVGrid(columns: columns, spacing: 16) {
-                    ForEach(MapLayer.allCases) { layer in
-                        LayerTile(layer: layer, isSelected: selection == layer) {
-                            toggle(layer)
+                if adaptiveLayout.usesAccessibilityLayout {
+                    VStack(spacing: 10) {
+                        ForEach(MapLayer.allCases) { layer in
+                            LayerTile(layer: layer, isSelected: selection == layer) {
+                                toggle(layer)
+                            }
                         }
                     }
+                    .padding(.horizontal)
+                    .padding(.top, 2)
+                    .padding(.bottom, 14)
+                } else {
+                    LazyVGrid(columns: columns, spacing: 16) {
+                        ForEach(MapLayer.allCases) { layer in
+                            LayerTile(layer: layer, isSelected: selection == layer) {
+                                toggle(layer)
+                            }
+                        }
+                    }
+                    .padding(.horizontal)
+                    .padding(.top, 2)
+                    .padding(.bottom, 14)
                 }
-                .padding(.horizontal)
-                .padding(.top, 2)
-                .padding(.bottom, 14)
             }
 
             Text("Choose a layer")
@@ -172,16 +218,18 @@ struct LayerPickerSheet: View {
                 .foregroundStyle(.secondary)
                 .padding(.bottom, 4)
 
-            VStack(alignment: .leading, spacing: 8) {
-                Toggle("Show Active Alerts", isOn: $showsWarningGeometry)
-                    .toggleStyle(.switch)
+            if adaptiveLayout.usesAccessibilityLayout == false {
+                VStack(alignment: .leading, spacing: 8) {
+                    Toggle("Show Active Alerts", isOn: $showsWarningGeometry)
+                        .toggleStyle(.switch)
 
-                Text("Show active alerts on the map.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
+                    Text("Show active alerts on the map.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal)
+                .padding(.bottom, 10)
             }
-            .padding(.horizontal)
-            .padding(.bottom, 10)
         }
         .padding(.top, 8)
         .background(Color(.skyAwareBackground).ignoresSafeArea())

--- a/Sources/Features/Settings/SettingsView.swift
+++ b/Sources/Features/Settings/SettingsView.swift
@@ -73,6 +73,11 @@ struct SettingsView: View {
         "disclaimerAcceptedVersion",
         store: UserDefaults.shared
     ) private var disclaimerVersion = 0
+
+    @AppStorage(
+        "mapWarningGeometryVisible",
+        store: UserDefaults.shared
+    ) private var mapWarningGeometryVisible: Bool = true
     
     // MARK: AI Settings
     @AppStorage("aiSummaryEnabled", store: UserDefaults.shared) private var aiSummariesEnabled: Bool = true
@@ -234,6 +239,16 @@ struct SettingsView: View {
                         }
                         .buttonStyle(.borderedProminent)
                         .font(.subheadline.weight(.semibold))
+                    }
+                }
+
+                sectionCard(title: "Map", symbol: "map", accent: .orange) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Toggle("Show Active Alerts on Map", isOn: $mapWarningGeometryVisible)
+                        Text("Controls whether active warning geometry is shown on the map.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
                     }
                 }
                 

--- a/Sources/Features/Summary/OutlookSummaryCard.swift
+++ b/Sources/Features/Summary/OutlookSummaryCard.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct OutlookSummaryCard: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     let outlook: ConvectiveOutlookDTO?
     let isLoading: Bool
     let isPending: Bool
@@ -40,40 +42,14 @@ struct OutlookSummaryCard: View {
         }
         return "A convective outlook summary will appear here once syncing is complete."
     }
+
+    private var adaptiveLayout: SkyAwareAdaptiveLayout {
+        SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize)
+    }
     
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            HStack(alignment: .center, spacing: 12) {
-                Label(titleText, systemImage: isPending ? "clock.arrow.circlepath" : "sun.max.fill")
-                    .sectionLabel()
-
-                Spacer(minLength: 12)
-
-                if let onBrowseAllOutlooks {
-                    Button {
-                        onBrowseAllOutlooks()
-                    } label: {
-                        HStack(spacing: 6) {
-                            Text("All Outlooks")
-                            Image(systemName: "arrow.right")
-                                .font(.caption.weight(.semibold))
-                        }
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
-                        .skyAwareChip(cornerRadius: SkyAwareRadius.chipCompact, tint: .white.opacity(0.10))
-                    }
-                    .buttonStyle(
-                        SkyAwarePressableButtonStyle(
-                            cornerRadius: SkyAwareRadius.chipCompact,
-                            pressedScale: 0.985,
-                            pressedOverlayOpacity: 0.08
-                        )
-                    )
-                    .accessibilityHint("Opens the full outlook list.")
-                }
-            }
+            headerRow
 
             Text(summaryText)
                 .font(.body)
@@ -102,6 +78,41 @@ struct OutlookSummaryCard: View {
         .navigationDestination(isPresented: $navigateToFull) {
             if let outlook {
                 ConvectiveOutlookDetailView(outlook: outlook)
+            }
+        }
+    }
+
+    private var headerRow: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Label(titleText, systemImage: isPending ? "clock.arrow.circlepath" : "sun.max.fill")
+                .sectionLabel()
+
+            Spacer(minLength: 12)
+
+            if adaptiveLayout.usesAccessibilityLayout == false,
+               let onBrowseAllOutlooks {
+                Button {
+                    onBrowseAllOutlooks()
+                } label: {
+                    HStack(spacing: 6) {
+                        Text("All Outlooks")
+                        Image(systemName: "arrow.right")
+                            .font(.caption.weight(.semibold))
+                    }
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .skyAwareChip(cornerRadius: SkyAwareRadius.chipCompact, tint: .white.opacity(0.10))
+                }
+                .buttonStyle(
+                    SkyAwarePressableButtonStyle(
+                        cornerRadius: SkyAwareRadius.chipCompact,
+                        pressedScale: 0.985,
+                        pressedOverlayOpacity: 0.08
+                    )
+                )
+                .accessibilityHint("Opens the full outlook list.")
             }
         }
     }

--- a/Sources/Features/Summary/OutlookView.swift
+++ b/Sources/Features/Summary/OutlookView.swift
@@ -10,14 +10,16 @@ import SwiftUI
 struct OutlookView: View {
     let outlook: ConvectiveOutlookDTO
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    private var adaptiveLayout: SkyAwareAdaptiveLayout {
+        SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize)
+    }
     
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                // Valid time
-                Text("Published: \(outlook.published, format: .dateTime)")
-                    .font(.subheadline)
-                    .foregroundColor(.gray)
+                publishedBlock
                 
                 // Full text with preserved formatting
 //                Text(parseOutlookText(outlook.fullText))
@@ -25,6 +27,7 @@ struct OutlookView: View {
                     .font(.body)
                     .foregroundColor(.primary)
                     .lineSpacing(6)
+                    .textSelection(.enabled)
             }
             .padding()
         }
@@ -39,6 +42,25 @@ struct OutlookView: View {
 //                .foregroundColor(.skyAwareAccent)
 //            }
 //        }
+    }
+
+    @ViewBuilder
+    private var publishedBlock: some View {
+        if adaptiveLayout.usesAccessibilityLayout {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Published")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text(outlook.published, format: .dateTime)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        } else {
+            Text("Published: \(outlook.published, format: .dateTime)")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
     }
     
     // Helper to parse section headers like "...SUMMARY..." and "...20z Update..."

--- a/Sources/Features/Summary/SummaryStatus.swift
+++ b/Sources/Features/Summary/SummaryStatus.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct SummaryStatus: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var showsOfflineExplanation = false
 
     let statusText: String
@@ -72,6 +73,10 @@ struct SummaryStatus: View {
 
     private var settledConditionOpacity: Double {
         1 - (0.55 * clampedCondenseProgress)
+    }
+
+    private var adaptiveLayout: SkyAwareAdaptiveLayout {
+        SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize)
     }
 
     var body: some View {
@@ -145,30 +150,41 @@ struct SummaryStatus: View {
     }
 
     private var contentRow: some View {
-        HStack(alignment: .top, spacing: contentSpacing) {
-            VStack(alignment: .leading, spacing: 4) {
-                Label(statusText, systemImage: "location.fill")
-                    .font(locationFont)
-                    .foregroundStyle(.primary)
-                    .contentTransition(.opacity)
-                    .lineLimit(clampedCondenseProgress > 0.55 ? 1 : 2)
-
-                SummaryStatusSecondaryLine(
-                    resolutionState: resolutionState
-                )
+        Group {
+            if adaptiveLayout.usesStackedHeroTiles {
+                VStack(alignment: .leading, spacing: 8) {
+                    statusContent
+                    weatherContent
+                }
+            } else {
+                HStack(alignment: .top, spacing: contentSpacing) {
+                    statusContent
+                    Spacer(minLength: 8)
+                    weatherContent
+                }
             }
-            .animation(SkyAwareMotion.message(reduceMotion), value: statusText)
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            Spacer(minLength: 8)
-
-            weatherContent
         }
+    }
+
+    private var statusContent: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Label(statusText, systemImage: "location.fill")
+                .font(locationFont)
+                .foregroundStyle(.primary)
+                .contentTransition(.opacity)
+                .lineLimit(clampedCondenseProgress > 0.55 ? 1 : 2)
+
+            SummaryStatusSecondaryLine(
+                resolutionState: resolutionState
+            )
+        }
+        .animation(SkyAwareMotion.message(reduceMotion), value: statusText)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     @ViewBuilder
     private var weatherContent: some View {
-        VStack(alignment: .trailing, spacing: 2) {
+        VStack(alignment: adaptiveLayout.usesStackedHeroTiles ? .leading : .trailing, spacing: 2) {
             HStack(spacing: 6) {
                 if let weather, let formattedTemperature {
                     Text(formattedTemperature)
@@ -187,13 +203,16 @@ struct SummaryStatus: View {
             }
             .font(.footnote)
             .opacity(settledConditionOpacity)
-            .multilineTextAlignment(.trailing)
+            .multilineTextAlignment(adaptiveLayout.usesStackedHeroTiles ? .leading : .trailing)
             .lineLimit(1)
-            .frame(minHeight: 18, alignment: .trailing)
+            .frame(minHeight: 18, alignment: adaptiveLayout.usesStackedHeroTiles ? .leading : .trailing)
         }
         .font(.subheadline.weight(.semibold))
         .foregroundStyle(.primary)
-        .frame(minWidth: 80 - (8 * clampedCondenseProgress), alignment: .trailing)
+        .frame(
+            minWidth: adaptiveLayout.usesStackedHeroTiles ? 0 : 80 - (8 * clampedCondenseProgress),
+            alignment: adaptiveLayout.usesStackedHeroTiles ? .leading : .trailing
+        )
         .contentTransition(.opacity)
         .animation(SkyAwareMotion.message(reduceMotion), value: formattedTemperature)
         .animation(SkyAwareMotion.message(reduceMotion), value: weather?.symbolName)

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -421,38 +421,90 @@ private extension AnyTransition {
 // MARK: Previews
 #Preview("Summary – Slight + 10% Tornado") {
     NavigationStack {
-        SummaryView(
-            snap: .init(
-                coordinates: .init(latitude: 39.75, longitude: -104.44),
-                timestamp: .now,
-                accuracy: 20,
-                placemarkSummary: "Bennett, CO"
-            ),
+        SummaryPreviewContent(
             stormRisk: .slight,
             severeRisk: .tornado(probability: 0.10),
-            fireRisk: .extreme,
-            mesos: MD.sampleDiscussionDTOs,
-            watches: Watch.sampleWatchRows,
-            outlook: ConvectiveOutlook.sampleOutlookDtos.first,
-            weather: nil,
-            readinessState: .ready,
-            resolutionState: SummaryResolutionState(),
-            showsOfflineToken: false,
-            headerCondenseProgress: 0,
-            locationReliabilityRailState: .init(
-                onOpen: {},
-                onDismiss: {}
-            ),
-            onOpenMapLayer: { _ in },
-            onOpenAlerts: {},
-            onOpenOutlooks: {}
+            weather: SummaryPreviewData.weather
         )
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary Hero Cards – XXXL Horizontal") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .moderate,
+            severeRisk: .hail(probability: 0.30),
+            weather: SummaryPreviewData.weather
+        )
+        .environment(\.dynamicTypeSize, .xxxLarge)
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary Hero Cards – AX1 Stacked") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .moderate,
+            severeRisk: .hail(probability: 0.30),
+            weather: SummaryPreviewData.weather
+        )
+        .environment(\.dynamicTypeSize, .accessibility1)
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary Hero Cards – AX3 Stacked") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .enhanced,
+            severeRisk: .wind(probability: 0.45),
+            weather: SummaryPreviewData.weather
+        )
+        .environment(\.dynamicTypeSize, .accessibility3)
         .toolbar(.hidden, for: .navigationBar)
     }
 }
 
 #Preview("Summary – Loading") {
     NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: nil,
+            severeRisk: nil,
+            weather: nil,
+            readinessState: .loadingLocalData,
+            showsOfflineToken: true,
+            outlook: nil
+        )
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+private struct SummaryPreviewContent: View {
+    let stormRisk: StormRiskLevel?
+    let severeRisk: SevereWeatherThreat?
+    let weather: SummaryWeather?
+    let readinessState: SummaryReadinessState
+    let showsOfflineToken: Bool
+    let outlook: ConvectiveOutlookDTO?
+
+    init(
+        stormRisk: StormRiskLevel?,
+        severeRisk: SevereWeatherThreat?,
+        weather: SummaryWeather?,
+        readinessState: SummaryReadinessState = .ready,
+        showsOfflineToken: Bool = false,
+        outlook: ConvectiveOutlookDTO? = ConvectiveOutlook.sampleOutlookDtos.first
+    ) {
+        self.stormRisk = stormRisk
+        self.severeRisk = severeRisk
+        self.weather = weather
+        self.readinessState = readinessState
+        self.showsOfflineToken = showsOfflineToken
+        self.outlook = outlook
+    }
+
+    var body: some View {
         SummaryView(
             snap: .init(
                 coordinates: .init(latitude: 39.75, longitude: -104.44),
@@ -460,22 +512,37 @@ private extension AnyTransition {
                 accuracy: 20,
                 placemarkSummary: "Bennett, CO"
             ),
-            stormRisk: nil,
-            severeRisk: nil,
-            fireRisk: nil,
-            mesos: [],
-            watches: [],
-            outlook: nil,
-            weather: nil,
-            readinessState: .loadingLocalData,
+            stormRisk: stormRisk,
+            severeRisk: severeRisk,
+            fireRisk: .extreme,
+            mesos: MD.sampleDiscussionDTOs,
+            watches: Watch.sampleWatchRows,
+            outlook: outlook,
+            weather: weather,
+            readinessState: readinessState,
             resolutionState: SummaryResolutionState(),
-            showsOfflineToken: true,
+            showsOfflineToken: showsOfflineToken,
             headerCondenseProgress: 0,
-            locationReliabilityRailState: nil,
+            locationReliabilityRailState: .init(onOpen: {}, onDismiss: {}),
             onOpenMapLayer: { _ in },
             onOpenAlerts: {},
             onOpenOutlooks: {}
         )
-        .toolbar(.hidden, for: .navigationBar)
     }
+}
+
+private enum SummaryPreviewData {
+    static let weather = SummaryWeather(
+        temperature: Measurement(value: 82.0, unit: .fahrenheit),
+        symbolName: "sun.max.fill",
+        conditionText: "Warm and humid",
+        asOf: .now,
+        dewPoint: Measurement(value: 68.0, unit: .fahrenheit),
+        humidity: 0.66,
+        windSpeed: Measurement(value: 22.0, unit: .milesPerHour),
+        windGust: Measurement(value: 34.0, unit: .milesPerHour),
+        windDirection: "SSW",
+        pressure: Measurement(value: 29.78, unit: .inchesOfMercury),
+        pressureTrend: "falling"
+    )
 }

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -32,6 +32,7 @@ enum SummaryReadinessState: Equatable {
 
 struct SummaryView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     struct LocationReliabilityRailState {
         let onOpen: () -> Void
@@ -131,6 +132,10 @@ struct SummaryView: View {
         }
     }
 
+    private var adaptiveLayout: SkyAwareAdaptiveLayout {
+        SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize)
+    }
+
     @ViewBuilder
     private var riskSnapshotContent: some View {
         VStack(spacing: 12) {
@@ -164,42 +169,58 @@ struct SummaryView: View {
 
     @ViewBuilder
     private var badgeRow: some View {
-        HStack {
-            Button {
-                onOpenMapLayer(.categorical)
-            } label: {
-                StormRiskBadgeView(level: stormRisk ?? .allClear, isOffline: showsOfflineToken)
-                    .placeholder(stormRisk == nil && showsOfflineToken == false)
-                    .contentShape(RoundedRectangle(cornerRadius: SkyAwareRadius.large, style: .continuous))
+        Group {
+            if adaptiveLayout.usesStackedHeroTiles {
+                VStack(spacing: 10) {
+                    stormRiskButton
+                    severeRiskButton
+                }
+            } else {
+                HStack(spacing: 10) {
+                    stormRiskButton
+                    severeRiskButton
+                }
             }
-            .buttonStyle(
-                SkyAwarePressableButtonStyle(
-                    cornerRadius: SkyAwareRadius.large,
-                    pressedScale: 0.992,
-                    pressedOverlayOpacity: 0.06
-                )
-            )
-            .summaryResolving(resolutionState.isResolving(.stormRisk) && showsOfflineToken == false)
-            .accessibilityHint("Opens the severe risk map.")
-            Spacer()
-            Button {
-                onOpenMapLayer(severeMapLayer)
-            } label: {
-                SevereWeatherBadgeView(threat: severeRisk ?? .allClear, isOffline: showsOfflineToken)
-                    .placeholder(severeRisk == nil && showsOfflineToken == false)
-                    .contentShape(RoundedRectangle(cornerRadius: SkyAwareRadius.large, style: .continuous))
-            }
-            .buttonStyle(
-                SkyAwarePressableButtonStyle(
-                    cornerRadius: SkyAwareRadius.large,
-                    pressedScale: 0.992,
-                    pressedOverlayOpacity: 0.06
-                )
-            )
-            .summaryResolving(resolutionState.isResolving(.severeRisk) && showsOfflineToken == false)
-            .accessibilityHint("Opens the highlighted severe threat map.")
         }
         .padding(.top, 8)
+    }
+
+    private var stormRiskButton: some View {
+        Button {
+            onOpenMapLayer(.categorical)
+        } label: {
+            StormRiskBadgeView(level: stormRisk ?? .allClear, isOffline: showsOfflineToken)
+                .placeholder(stormRisk == nil && showsOfflineToken == false)
+                .contentShape(RoundedRectangle(cornerRadius: SkyAwareRadius.large, style: .continuous))
+        }
+        .buttonStyle(
+            SkyAwarePressableButtonStyle(
+                cornerRadius: SkyAwareRadius.large,
+                pressedScale: 0.992,
+                pressedOverlayOpacity: 0.06
+            )
+        )
+        .summaryResolving(resolutionState.isResolving(.stormRisk) && showsOfflineToken == false)
+        .accessibilityHint("Opens the severe risk map.")
+    }
+
+    private var severeRiskButton: some View {
+        Button {
+            onOpenMapLayer(severeMapLayer)
+        } label: {
+            SevereWeatherBadgeView(threat: severeRisk ?? .allClear, isOffline: showsOfflineToken)
+                .placeholder(severeRisk == nil && showsOfflineToken == false)
+                .contentShape(RoundedRectangle(cornerRadius: SkyAwareRadius.large, style: .continuous))
+        }
+        .buttonStyle(
+            SkyAwarePressableButtonStyle(
+                cornerRadius: SkyAwareRadius.large,
+                pressedScale: 0.992,
+                pressedOverlayOpacity: 0.06
+            )
+        )
+        .summaryResolving(resolutionState.isResolving(.severeRisk) && showsOfflineToken == false)
+        .accessibilityHint("Opens the highlighted severe threat map.")
     }
 
     @ViewBuilder

--- a/Sources/Utilities/Core/SkyAwareAdaptiveLayout.swift
+++ b/Sources/Utilities/Core/SkyAwareAdaptiveLayout.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+enum MapLegendMode {
+    case inline
+    case compactTrigger
+    case sheetOnly
+}
+
+struct SkyAwareAdaptiveLayout {
+    let dynamicTypeSize: DynamicTypeSize
+
+    var usesAccessibilityLayout: Bool {
+        dynamicTypeSize >= .accessibility1
+    }
+
+    var mapLegendMode: MapLegendMode {
+        if dynamicTypeSize >= .accessibility3 {
+            return .sheetOnly
+        }
+        if dynamicTypeSize >= .accessibility1 {
+            return .compactTrigger
+        }
+        return .inline
+    }
+
+    var usesStackedHeroTiles: Bool {
+        usesAccessibilityLayout
+    }
+
+    var usesVerticalMetricRows: Bool {
+        usesAccessibilityLayout
+    }
+}

--- a/Sources/Utilities/Core/SpcProductFooter.swift
+++ b/Sources/Utilities/Core/SpcProductFooter.swift
@@ -8,23 +8,41 @@
 import SwiftUI
 
 struct SpcProductFooter: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     let link: URL
     let validEnd: Date
+
+    private var adaptiveLayout: SkyAwareAdaptiveLayout {
+        SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize)
+    }
     
     var body: some View {
         TimelineView(.periodic(from: .now, by: 60)) { ctx in
             let remaining = max(0, validEnd.timeIntervalSince(ctx.date))
-            HStack {
-                Link(destination: link) {
-                    Label("Open in browser", systemImage: "arrow.up.right.square")
-                        .font(.footnote.weight(.semibold))
+            Group {
+                if adaptiveLayout.usesAccessibilityLayout {
+                    VStack(alignment: .leading, spacing: 8) {
+                        openInBrowserLink
+                        ExpiryLabel(remaining: remaining)
+                    }
+                } else {
+                    HStack {
+                        openInBrowserLink
+                        Spacer()
+                        ExpiryLabel(remaining: remaining)
+                    }
                 }
-                .skyAwareGlassButtonStyle()
-                
-                Spacer()
-                ExpiryLabel(remaining: remaining)
             }
         }
+    }
+
+    private var openInBrowserLink: some View {
+        Link(destination: link) {
+            Label("Open in browser", systemImage: "arrow.up.right.square")
+                .font(.footnote.weight(.semibold))
+        }
+        .skyAwareGlassButtonStyle()
     }
 }
 

--- a/Tests/UnitTests/LayerPickerAdaptiveLayoutTests.swift
+++ b/Tests/UnitTests/LayerPickerAdaptiveLayoutTests.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+#if canImport(Testing)
+import Testing
+@testable import SkyAware
+
+@Suite("Layer Picker Adaptive Layout")
+struct LayerPickerAdaptiveLayoutTests {
+    @Test("Normal and xxxLarge keep grid layout")
+    func normalAndXXXL_useGridLayout() {
+        #expect(LayerPickerSheet.usesAccessibilityListLayoutPolicy(dynamicTypeSize: .large) == false)
+        #expect(LayerPickerSheet.usesAccessibilityListLayoutPolicy(dynamicTypeSize: .xxxLarge) == false)
+    }
+
+    @Test("Accessibility sizes use vertical list layout")
+    func accessibilitySizes_useListLayout() {
+        #expect(LayerPickerSheet.usesAccessibilityListLayoutPolicy(dynamicTypeSize: .accessibility1))
+        #expect(LayerPickerSheet.usesAccessibilityListLayoutPolicy(dynamicTypeSize: .accessibility3))
+    }
+
+    @Test("Warning geometry toggle is hidden in accessibility sizes")
+    func warningToggle_visibilityMatchesPolicy() {
+        #expect(LayerPickerSheet.showsWarningGeometryTogglePolicy(dynamicTypeSize: .large))
+        #expect(LayerPickerSheet.showsWarningGeometryTogglePolicy(dynamicTypeSize: .xxxLarge))
+        #expect(LayerPickerSheet.showsWarningGeometryTogglePolicy(dynamicTypeSize: .accessibility1) == false)
+        #expect(LayerPickerSheet.showsWarningGeometryTogglePolicy(dynamicTypeSize: .accessibility3) == false)
+    }
+}
+#endif

--- a/Tests/UnitTests/SkyAwareAdaptiveLayoutTests.swift
+++ b/Tests/UnitTests/SkyAwareAdaptiveLayoutTests.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+#if canImport(Testing)
+import Testing
+
+@Suite("SkyAware Adaptive Layout")
+struct SkyAwareAdaptiveLayoutTests {
+    @Test("Map legend mode stays inline through xxxLarge")
+    func mapLegendMode_inlineForNormalAndXXXL() {
+        #expect(SkyAwareAdaptiveLayout(dynamicTypeSize: .large).mapLegendMode == .inline)
+        #expect(SkyAwareAdaptiveLayout(dynamicTypeSize: .xxxLarge).mapLegendMode == .inline)
+    }
+
+    @Test("Map legend mode uses compact trigger at accessibility1")
+    func mapLegendMode_compactAtAccessibility1() {
+        #expect(SkyAwareAdaptiveLayout(dynamicTypeSize: .accessibility1).mapLegendMode == .compactTrigger)
+    }
+
+    @Test("Map legend mode uses sheet-only at accessibility3")
+    func mapLegendMode_sheetOnlyAtAccessibility3() {
+        #expect(SkyAwareAdaptiveLayout(dynamicTypeSize: .accessibility3).mapLegendMode == .sheetOnly)
+    }
+
+    @Test("Hero cards stack in accessibility sizes")
+    func heroCards_stackForAccessibilitySizes() {
+        #expect(SkyAwareAdaptiveLayout(dynamicTypeSize: .accessibility1).usesStackedHeroTiles)
+        #expect(SkyAwareAdaptiveLayout(dynamicTypeSize: .accessibility3).usesStackedHeroTiles)
+    }
+
+    @Test("Metric rows become vertical in accessibility sizes")
+    func metricRows_verticalForAccessibilitySizes() {
+        #expect(SkyAwareAdaptiveLayout(dynamicTypeSize: .accessibility1).usesVerticalMetricRows)
+        #expect(SkyAwareAdaptiveLayout(dynamicTypeSize: .accessibility3).usesVerticalMetricRows)
+    }
+}
+#endif

--- a/release/CHANGELOG.md
+++ b/release/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## v0.1.0(56)
+
+### UI / UX
+- Improve Dynamic Type support across Summary, Alerts, Outlooks, and map surfaces so large accessibility text sizes use more readable stacked/vertical layouts.
+<!-- evidence: 66395ee, 599dfba -->
+- Adapt map legend presentation for accessibility text sizes by switching from inline legend rows to a compact legend trigger with sheet presentation.
+<!-- evidence: 66395ee, 599dfba -->
+- Update the map layer picker for large text accessibility with list-style option rows and adjusted control visibility/layout.
+<!-- evidence: f6f91f6, 0d998d1 -->
+
+### Tests / QA
+- Add unit coverage for adaptive layout policy decisions (legend mode and accessibility layout behavior) and layer-picker accessibility layout policy.
+<!-- evidence: 599dfba -->
+
 ## v0.1.0(54)
 
 ### UI / UX

--- a/release/RELEASE_NOTES.md
+++ b/release/RELEASE_NOTES.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## v0.1.0(56)
+
+### Overview
+This update improves large-text accessibility across key SkyAware screens, especially map controls and summary content.
+
+### Highlights
+- Improved Dynamic Type behavior across Summary, Alerts, Outlooks, and map-related surfaces so accessibility text sizes present more readable stacked/vertical layouts.
+- Map legend behavior now adapts for larger accessibility text sizes with a compact trigger and sheet presentation flow.
+- The map layer picker now uses accessibility-friendly list-style layout behavior for large text scenarios.
+- Added unit coverage for adaptive layout policy behavior and layer picker accessibility layout policy decisions.
+
 ## v0.1.0(54)
 
 ### Overview

--- a/release/TESTFLIGHT_NOTES.md
+++ b/release/TESTFLIGHT_NOTES.md
@@ -1,3 +1,11 @@
+SkyAware v0.1.0(56) improves large-text accessibility across core weather surfaces, with better readability in map controls and summary content.
+
+Highlights:
+- Improved Dynamic Type behavior across Summary, Alerts, Outlooks, and map surfaces for accessibility text sizes
+- Map legend presentation now adapts for larger text sizes with a compact trigger and sheet flow
+- Map layer picker layout is now accessibility-friendly for large text scenarios
+- Added unit tests covering adaptive layout policy and layer picker accessibility layout behavior
+
 SkyAware v0.1.0(54) improves denied-permission handling for location and notifications, and includes internal model alignment work.
 
 Highlights:


### PR DESCRIPTION
# Summary
This branch introduces a shared adaptive layout policy for larger Dynamic Type sizes and applies it across key SkyAware screens so critical map, summary, outlook, and alert content remains readable and navigable in accessibility text modes.

# What Changed
- Added `SkyAwareAdaptiveLayout` and `MapLegendMode` as centralized dynamic-type layout policy primitives.
- Updated map legend behavior to switch from inline legend to a compact trigger and sheet presentation for accessibility Dynamic Type sizes.
- Reworked the map layer picker to use an accessibility-friendly vertical list layout, tune labels for very large sizes, and hide the warning-geometry toggle in accessibility layout mode.
- Updated Summary hero cards and atmosphere metrics to stack/flow vertically at accessibility sizes, with supporting preview coverage for normal, XXXL, and accessibility scenarios.
- Applied adaptive-type layout adjustments across additional alert, outlook, and summary components to improve large-text resilience.
- Added unit tests for adaptive layout policy and layer picker accessibility layout policy behavior.

# User Impact
Users who run larger Dynamic Type sizes get a more readable and usable UI across summary, map legend/picker, and related severe weather surfaces, with fewer cramped controls and better accessibility-specific presentation.

# Testing
- Added `SkyAwareAdaptiveLayoutTests` covering map legend mode and accessibility layout policy behavior.
- Added `LayerPickerAdaptiveLayoutTests` covering grid/list switching and warning-toggle visibility policy.
- No local test run evidence was found in this branch history during PR preparation.

# Notes
- Branch scope is committed changes only (`adaptiveText`); the worktree is clean.
- Base branch selected from `refs/remotes/origin/HEAD` (`origin/main`).
