### PR TITLE
Harden diagnostics disclaimer controls and remove fake outlook risk level

### DIFF
--- a/Sources/Features/Settings/SettingsDiagnosticsView.swift
+++ b/Sources/Features/Settings/SettingsDiagnosticsView.swift
@@ -26,6 +26,13 @@ struct SettingsDiagnosticsView: View {
     ) private var apnsDeviceToken: String = ""
 
     @State private var installationId: String = ""
+    private let isDebugBuild: Bool = {
+#if DEBUG
+        true
+#else
+        false
+#endif
+    }()
 
     private var h3CellDisplay: String {
         guard let h3Cell = locationSession.currentSnapshot?.h3Cell else {
@@ -122,7 +129,14 @@ struct SettingsDiagnosticsView: View {
                         UserDefaults.shared?.removeObject(forKey: "disclaimerAcceptedVersion")
                     }
                     .skyAwareGlassButtonStyle()
+
+                    if !isDebugBuild {
+                        Text("Read-only outside Debug builds.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
+                .disabled(!isDebugBuild)
             }
             .padding(.horizontal, 16)
             .padding(.top, 10)

--- a/Sources/Infrastructure/Parsing/Regex/OutlookParser.swift
+++ b/Sources/Infrastructure/Parsing/Regex/OutlookParser.swift
@@ -43,7 +43,7 @@ struct OutlookParser: Sendable {
     
     func extractRiskLevel(_ text: String) -> String? {
         // TODO: Figure out how/if we are going to extract this
-        return "MDT"
+        return nil
     }
     
     func stripHeader(from text: String) -> String {


### PR DESCRIPTION
# Summary
This branch tightens production behavior in diagnostics and removes an inaccurate placeholder from outlook parsing so internal data is more trustworthy.

# What Changed
- Made the Settings diagnostics disclaimer reset action read-only outside `DEBUG` builds.
- Added a visible caption in release builds to indicate the disclaimer control is read-only.
- Disabled the disclaimer reset button in non-debug builds.
- Updated `OutlookParser.extractRiskLevel(_:)` to return `nil` instead of a hardcoded `"MDT"` placeholder.

# User Impact
Production users can no longer trigger the diagnostics disclaimer reset action, and outlook risk level output no longer reports a fabricated value.

# Testing
- Not run in this session.
