### PR TITLE
Enforce geometry-first alert targeting and align APNs payload parsing

### DIFF
--- a/SkyAware.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SkyAware.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/justinrooks/ArcusCore.git",
       "state" : {
-        "revision" : "99d4f0ccc31ad94656232653fc5e9ee6c688abfc",
-        "version" : "0.2.0"
+        "revision" : "618bf3d5a28b1ffd2fbda9fc181d7a431a096105",
+        "version" : "0.3.1"
       }
     },
     {

--- a/Sources/App/RemoteHotAlertHandler.swift
+++ b/Sources/App/RemoteHotAlertHandler.swift
@@ -179,7 +179,7 @@ extension HomeRemoteAlertContext {
     }
 
     private static func identifier(in userInfo: [AnyHashable: Any]) -> String? {
-        for key in ["alertID", "alertId", "seriesID", "seriesId", "eventKey"] {
+        for key in ["arcusAlertId", "alertID", "alertId", "seriesID", "seriesId", "eventKey"] {
             guard let value = userInfo[key] else { continue }
             if let stringValue = normalizedString(from: value) {
                 return stringValue

--- a/Sources/App/RemoteHotAlertHandler.swift
+++ b/Sources/App/RemoteHotAlertHandler.swift
@@ -9,6 +9,7 @@ import Foundation
 import Observation
 import OSLog
 import UIKit
+import ArcusCore
 
 struct RemoteAlertFocusRequest: Identifiable, Equatable, Sendable {
     let id = UUID()
@@ -143,6 +144,15 @@ actor RemoteAlertWidgetSnapshotRefreshDriver: RemoteHotAlertHandler.WidgetSnapsh
 
 extension HomeRemoteAlertContext {
     init?(userInfo: [AnyHashable: Any]) {
+        if let payload = Self.sharedPayload(in: userInfo),
+           let alertID = payload.resolvedAlertID {
+            self.init(
+                alertID: alertID,
+                revisionSent: payload.revisionSent
+            )
+            return
+        }
+
         guard let alertID = Self.identifier(in: userInfo) else {
             return nil
         }
@@ -223,6 +233,23 @@ extension HomeRemoteAlertContext {
     private static func normalizedDate(from epoch: TimeInterval) -> Date {
         let seconds = epoch > 10_000_000_000 ? epoch / 1_000 : epoch
         return Date(timeIntervalSince1970: seconds)
+    }
+
+    private static func sharedPayload(in userInfo: [AnyHashable: Any]) -> HotAlertAPNsPayload? {
+        let dictionary = userInfo.reduce(into: [String: Any]()) { result, entry in
+            guard let key = entry.key as? String else { return }
+            result[key] = entry.value
+        }
+
+        guard JSONSerialization.isValidJSONObject(dictionary),
+              let data = try? JSONSerialization.data(withJSONObject: dictionary)
+        else {
+            return nil
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(HotAlertAPNsPayload.self, from: data)
     }
 }
 

--- a/Sources/Repos/AlertRepo.swift
+++ b/Sources/Repos/AlertRepo.swift
@@ -27,7 +27,14 @@ actor AlertRepo {
             let matchesCell = cell.map { cells.contains($0) } ?? false
             let matchesUGC = ugc.contains(countyCode) || ugc.contains(fireZone) || ugc.contains(forecastZone)
             
-            if (matchesCell || matchesUGC) && isRenderableAlertLifecycle(status: alert.status, messageType: alert.messageType) {
+            let matchesLocation: Bool
+            if alert.geometry != nil {
+                matchesLocation = matchesCell
+            } else {
+                matchesLocation = matchesCell || matchesUGC
+            }
+
+            if matchesLocation && isRenderableAlertLifecycle(status: alert.status, messageType: alert.messageType) {
                 hits.append(alert)
             }
         }

--- a/Tests/UnitTests/AlertRepoActiveTests.swift
+++ b/Tests/UnitTests/AlertRepoActiveTests.swift
@@ -179,6 +179,96 @@ struct AlertRepoActiveTests {
         #expect(hits.map(\.id) == ["active"])
     }
 
+    @Test("Geometry-backed alert excludes UGC-only matches when H3 cell does not match")
+    func geometryBackedAlert_excludesUGCOnlyMatch() async throws {
+        let ctx = ModelContext(container)
+        let now = ISO8601DateFormatter().date(from: "2025-09-20T00:00:00Z")!
+        let tag = "-G1"
+
+        let alert = makeAlert(
+            number: "1\(tag)",
+            issued: now.addingTimeInterval(-3600),
+            effective: now.addingTimeInterval(-300),
+            validEnd: now.addingTimeInterval(600),
+            ugcZones: ["ALC013"],
+            cells: [613725958748241919],
+            geometry: testPolygonGeometry()
+        )
+
+        ctx.insert(alert)
+        try ctx.save()
+
+        let hits = try await repo.active(
+            countyCode: "ALC013",
+            fireZone: "ZZZ000",
+            forecastZone: "ZZZ001",
+            cell: 613725958748241920,
+            on: now
+        )
+
+        #expect(hits.isEmpty)
+    }
+
+    @Test("Geometry-backed alert includes H3 cell matches even when UGC does not match")
+    func geometryBackedAlert_includesCellMatchWithoutUGCMatch() async throws {
+        let ctx = ModelContext(container)
+        let now = ISO8601DateFormatter().date(from: "2025-09-20T00:00:00Z")!
+        let tag = "-G2"
+        let cell: Int64 = 613725958748241919
+
+        let alert = makeAlert(
+            number: "1\(tag)",
+            issued: now.addingTimeInterval(-3600),
+            effective: now.addingTimeInterval(-300),
+            validEnd: now.addingTimeInterval(600),
+            ugcZones: ["ALC013"],
+            cells: [cell],
+            geometry: testPolygonGeometry()
+        )
+
+        ctx.insert(alert)
+        try ctx.save()
+
+        let hits = try await repo.active(
+            countyCode: "ZZZ000",
+            fireZone: "ZZZ001",
+            forecastZone: "ZZZ002",
+            cell: cell,
+            on: now
+        )
+
+        #expect(hits.map(\.id) == ["1\(tag)"])
+    }
+
+    @Test("Geometry-less alert keeps UGC fallback matching")
+    func geometryLessAlert_keepsUGCFallback() async throws {
+        let ctx = ModelContext(container)
+        let now = ISO8601DateFormatter().date(from: "2025-09-20T00:00:00Z")!
+        let tag = "-G3"
+
+        let alert = makeAlert(
+            number: "1\(tag)",
+            issued: now.addingTimeInterval(-3600),
+            effective: now.addingTimeInterval(-300),
+            validEnd: now.addingTimeInterval(600),
+            ugcZones: ["ALC013"],
+            cells: []
+        )
+
+        ctx.insert(alert)
+        try ctx.save()
+
+        let hits = try await repo.active(
+            countyCode: "ALC013",
+            fireZone: "ZZZ000",
+            forecastZone: "ZZZ001",
+            cell: nil,
+            on: now
+        )
+
+        #expect(hits.map(\.id) == ["1\(tag)"])
+    }
+
     @Test("Matches forecast-zone UGCs when county and fire zones do not match")
     func matchesForecastZoneUGC() async throws {
         let ctx = ModelContext(container)

--- a/Tests/UnitTests/RemoteHotAlertHandlerTests.swift
+++ b/Tests/UnitTests/RemoteHotAlertHandlerTests.swift
@@ -1,10 +1,39 @@
 import Foundation
 import Testing
 import UIKit
+import ArcusCore
 @testable import SkyAware
 
 @Suite("Remote hot-alert handler")
 struct RemoteHotAlertHandlerTests {
+    @Test("shared APNs payload canonical key decodes into remote alert context")
+    func sharedPayloadCanonicalKeyDecodeIntoRemoteAlertContext() {
+        let userInfo: [AnyHashable: Any] = [
+            "arcusAlertId": "99999999-8888-7777-6666-555555555555",
+            "revisionSent": "2026-05-20T12:34:56Z"
+        ]
+
+        let context = HomeRemoteAlertContext(userInfo: userInfo)
+
+        #expect(context?.alertID == "99999999-8888-7777-6666-555555555555")
+        #expect(context?.revisionSent == ISO8601DateFormatter().date(from: "2026-05-20T12:34:56Z"))
+    }
+
+    @Test("shared APNs payload keys decode into remote alert context")
+    func sharedPayloadKeysDecodeIntoRemoteAlertContext() {
+        let userInfo: [AnyHashable: Any] = [
+            "arcusAlertId": "99999999-8888-7777-6666-555555555555",
+            "alertID": "11111111-2222-3333-4444-555555555555",
+            "seriesId": "11111111-2222-3333-4444-555555555555",
+            "revisionSent": "2026-05-20T12:34:56Z"
+        ]
+
+        let context = HomeRemoteAlertContext(userInfo: userInfo)
+
+        #expect(context?.alertID == "99999999-8888-7777-6666-555555555555")
+        #expect(context?.revisionSent == ISO8601DateFormatter().date(from: "2026-05-20T12:34:56Z"))
+    }
+
     @Test("background receipt maps to newData when the targeted alert becomes locally available")
     func backgroundReceipt_returnsNewData() async throws {
         let revisionSent = Date(timeIntervalSince1970: 1_776_438_000)

--- a/Tests/UnitTests/RemoteHotAlertHandlerTests.swift
+++ b/Tests/UnitTests/RemoteHotAlertHandlerTests.swift
@@ -34,6 +34,19 @@ struct RemoteHotAlertHandlerTests {
         #expect(context?.revisionSent == ISO8601DateFormatter().date(from: "2026-05-20T12:34:56Z"))
     }
 
+    @Test("canonical alert id falls back when shared payload decode fails")
+    func canonicalAlertIDFallsBackWhenSharedPayloadDecodeFails() {
+        let userInfo: [AnyHashable: Any] = [
+            "arcusAlertId": "99999999-8888-7777-6666-555555555555",
+            "revisionSent": "not-an-iso-date"
+        ]
+
+        let context = HomeRemoteAlertContext(userInfo: userInfo)
+
+        #expect(context?.alertID == "99999999-8888-7777-6666-555555555555")
+        #expect(context?.revisionSent == nil)
+    }
+
     @Test("background receipt maps to newData when the targeted alert becomes locally available")
     func backgroundReceipt_returnsNewData() async throws {
         let revisionSent = Date(timeIntervalSince1970: 1_776_438_000)

--- a/docs/audits/weekly-contract-drift-audit.md
+++ b/docs/audits/weekly-contract-drift-audit.md
@@ -1,0 +1,17 @@
+# Weekly Contract Drift Audit
+
+## 2026-05-20
+- Repos scanned: SkyAware, arcus-signal, ArcusCore
+- Commit window: SkyAware `b5d15fe..HEAD` (recent history reviewed via `git log -n 20`), arcus-signal `ebbfd07..HEAD` (recent history reviewed via `git log -n 20`), ArcusCore `85c3d20..HEAD`
+- Contract surfaces inspected: device registration/location snapshot payloads, alert/device DTOs, APNs payload keys and client handlers, revision/timestamp mapping
+- Top finding: APNs payload contract drift between arcus-signal and SkyAware remote hot-alert ingestion
+- Recommended fix: Add explicit APNs custom payload fields (`alertID` or `seriesId`, plus `revisionSent`) and define/share payload contract in ArcusCore
+- Watchlist items: None
+- Implementation recommended: Yes
+- Status: Resolved on 2026-05-21
+- Resolution notes:
+  - Canonical APNs hot-alert identifier is now `arcusAlertId` (Arcus graph series id).
+  - Compatibility aliases are still emitted/accepted: `alertID` and `seriesId`.
+  - Decode precedence is `arcusAlertId` -> `alertID` -> `seriesId`.
+  - `revisionSent` remains part of the payload contract.
+  - ArcusCore contract tests and app/server focused validations were updated and passed.

--- a/ocs/audits/weekly-bug-scan.md
+++ b/ocs/audits/weekly-bug-scan.md
@@ -1,0 +1,20 @@
+# Weekly Bug Scan
+
+## 2026-05-21T16:07:12Z
+- date: 2026-05-21T16:07:12Z
+- workflow reviewed: Weekly bug scan (audit-only)
+- files inspected:
+  - /Users/justin/Code/project-arcus/Sources/App/RemoteHotAlertHandler.swift
+  - /Users/justin/Code/project-arcus/Sources/Providers/ArcusAlertProvider.swift
+  - /Users/justin/Code/project-arcus/Sources/Repos/AlertRepo.swift
+  - /Users/justin/Code/project-arcus/Sources/App/HomeIngestionSupport.swift
+  - /Users/justin/Code/project-arcus/Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift
+  - /Users/justin/Code/project-arcus/Tests/UnitTests/RemoteHotAlertHandlerTests.swift
+  - /Users/justin/Code/arcus-signal/Sources/App/Jobs/NotificationSendJob.swift
+  - /Users/justin/Code/arcus-signal/Sources/App/Clients/APNsClient.swift
+  - /Users/justin/Code/arcus-signal/Tests/AppTests/NotificationSendJobDeliveryBoundaryTests.swift
+  - /Users/justin/Code/ArcusCore/Sources/ArcusCore/HotAlertAPNsPayload.swift
+- top finding: No high-confidence bug confirmed from commits since 2026-05-14T16:06:33Z.
+- best next fix: No fix recommended; add one APNs end-to-end contract test for payload decode in app delegate path.
+- implementation is recommended: No
+


### PR DESCRIPTION
# Summary
This branch aligns app behavior with updated Arcus alert contracts by adding shared APNs hot-alert payload decoding and enforcing geometry-first targeting for active alerts, while preserving UGC fallback for geometry-less alerts.

# What Changed
- Updated `HomeRemoteAlertContext` parsing to decode shared `HotAlertAPNsPayload` fields first, including `arcusAlertId` and `revisionSent`, before legacy key fallback.
- Added focused unit tests for remote hot-alert payload decoding paths in `RemoteHotAlertHandlerTests`.
- Updated `AlertRepo.active(...)` matching so geometry-backed alerts require H3 cell match and only geometry-less alerts use `matchesCell || matchesUGC` fallback.
- Added focused `AlertRepoActiveTests` coverage for geometry-backed exclusion/inclusion and geometry-less UGC fallback behavior.
- Bumped `ArcusCore` package resolution from `0.2.0` to `0.3.1`.
- Added weekly audit artifacts documenting contract drift review and bug scan outcomes.

# User Impact
Users should no longer see geometry-backed alerts solely due to broad UGC membership when they are outside the alert geometry projection; remote hot-alert deep-link targeting is also more robust against payload key drift.

# Testing
- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:SkyAwareTests/AlertRepoActiveTests test` (passed)

# Notes
- Branch contains two commits: APNs payload contract handling and geometry-first alert targeting.
