### PR TITLE
Harden location and preference upload reliability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@
 - Stub or fake providers and network boundaries.
 - When adding UI, include a smoke UI test for the main navigation or happy path when practical.
 - Keep accessibility identifiers stable when they are used for UI testing.
-- Prefer iPhone 17 or iPhone 17 Pro on iOS 26.4 for local simulator runs when available.
+- Prefer iPhone 17 or iPhone 17 Pro on iOS 26.5 for local simulator runs when available.
 - If test execution produces an `.xcresult`, inspect it and report failures and coverage impact when available.
 - Mirror production namespaces when adding tests.
 

--- a/Shared/WidgetSnapshotStore.swift
+++ b/Shared/WidgetSnapshotStore.swift
@@ -6,10 +6,9 @@ enum WidgetSnapshotStoreLoadResult: Equatable, Sendable {
     case corrupt
 }
 
-struct WidgetSnapshotStore {
+struct WidgetSnapshotStore: Sendable {
     static let defaultAppGroupIdentifier = "group.com.skyaware.app"
 
-    private let fileManager: FileManager
     private let directoryURL: URL
     private let fileName: String
 
@@ -22,7 +21,6 @@ struct WidgetSnapshotStore {
             throw StoreError.containerUnavailable(appGroupIdentifier)
         }
 
-        self.fileManager = fileManager
         self.directoryURL = containerURL
         self.fileName = fileName
     }
@@ -32,19 +30,19 @@ struct WidgetSnapshotStore {
         directoryURL: URL,
         fileName: String = "widget-snapshot.json"
     ) {
-        self.fileManager = fileManager
+        _ = fileManager
         self.directoryURL = directoryURL
         self.fileName = fileName
     }
 
     func write(_ snapshot: WidgetSnapshot) throws {
-        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
         let data = try JSONEncoder().encode(snapshot)
         try data.write(to: snapshotURL, options: [.atomic])
     }
 
     func load() -> WidgetSnapshotStoreLoadResult {
-        guard fileManager.fileExists(atPath: snapshotURL.path) else {
+        guard FileManager.default.fileExists(atPath: snapshotURL.path) else {
             return .missing
         }
 

--- a/SkyAware.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SkyAware.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/justinrooks/ArcusCore.git",
       "state" : {
-        "revision" : "618bf3d5a28b1ffd2fbda9fc181d7a431a096105",
-        "version" : "0.3.1"
+        "revision" : "83b5cecd56387bddf051eeff9b6dafbe4f838fa2",
+        "version" : "0.3.2"
       }
     },
     {

--- a/SkyAware.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SkyAware.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/justinrooks/ArcusCore.git",
       "state" : {
-        "revision" : "4435538441a877b03d6544eefeb7491c745a6a61",
-        "version" : "0.3.4"
+        "revision" : "ebd690e5b6e8b5157f2021befdf9aee9d29598ea",
+        "version" : "0.3.5"
       }
     },
     {

--- a/SkyAware.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SkyAware.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/justinrooks/ArcusCore.git",
       "state" : {
-        "revision" : "83b5cecd56387bddf051eeff9b6dafbe4f838fa2",
-        "version" : "0.3.2"
+        "revision" : "4435538441a877b03d6544eefeb7491c745a6a61",
+        "version" : "0.3.4"
       }
     },
     {

--- a/Sources/App/ArcusSignalConfiguration.swift
+++ b/Sources/App/ArcusSignalConfiguration.swift
@@ -11,6 +11,7 @@ enum ArcusSignalConfiguration {
     static let defaultBaseURL = URL(string: "https://skyaware.bennettbunker.com")!
     static let alertsPath = "/api/v2/alerts"
     static let locationSnapshotsPath = "/api/v1/devices/location-snapshots"
+    static let devicePreferencesPath = "/api/v1/devices/preferences"
 
     private static let infoDictionaryKey = "ArcusSignalURL"
 

--- a/Sources/App/Dependencies.swift
+++ b/Sources/App/Dependencies.swift
@@ -402,6 +402,11 @@ final class Dependencies: Sendable {
             locationUploadCoordinator: locationUploadCoordinator
         )
         logger.info("Location session initialized")
+        Task { @MainActor in
+            RemoteNotificationRegistrar.shared.setTokenStoredObserver { _ in
+                await locationSession.drainPendingLocationUploads()
+            }
+        }
         
         let nws = NwsProvider(
             alertRepo: alertRepo,
@@ -494,7 +499,8 @@ final class Dependencies: Sendable {
             mesoEngine: meso,
             health: healthStore,
             cadence: cadencePolicy,
-            notificationSettingsProvider: notificationSettingsProvider
+            notificationSettingsProvider: notificationSettingsProvider,
+            pendingUploadDrainer: locationUploadCoordinator
         )
         
         let scheduler = BackgroundScheduler(refreshId: appRefreshID)

--- a/Sources/App/Dependencies.swift
+++ b/Sources/App/Dependencies.swift
@@ -335,13 +335,13 @@ final class Dependencies: Sendable {
         )
         let metadataRepo = NwsMetadataRepo()
 
-        let contextPusher: any LocationContextPushing
+        let locationUploadCoordinator: any LocationUploadCoordinating
         if let arcusSignalBaseURL = ArcusSignalConfiguration.configuredBaseURL() {
             let uploader = HTTPLocationSnapshotUploader(baseURL: arcusSignalBaseURL, http: httpClient)
-            contextPusher = LocationSnapshotPusher(uploader: uploader)
+            locationUploadCoordinator = LocationSnapshotPusher(uploader: uploader)
             logger.info("Location snapshot push enabled host=\(arcusSignalBaseURL.host ?? "unknown", privacy: .public)")
         } else {
-            contextPusher = NoOpLocationContextPusher()
+            locationUploadCoordinator = NoOpLocationUploadCoordinator()
             logger.info("Location snapshot push disabled (missing ARCUS_SIGNAL_URL)")
         }
         
@@ -381,7 +381,6 @@ final class Dependencies: Sendable {
             locationClient: makeLocationClient(provider: locationProvider),
             locationProvider: locationProvider,
             gridPointProvider: gridProvider,
-            contextPusher: contextPusher,
             authorizationStatusProvider: {
                 await MainActor.run { locationManager.authStatus }
             },
@@ -399,7 +398,8 @@ final class Dependencies: Sendable {
         let locationSession = LocationSession(
             locationClient: makeLocationClient(provider: locationProvider),
             locationManager: locationManager,
-            locationContextResolver: locationContextResolver
+            locationContextResolver: locationContextResolver,
+            locationUploadCoordinator: locationUploadCoordinator
         )
         logger.info("Location session initialized")
         

--- a/Sources/App/Dependencies.swift
+++ b/Sources/App/Dependencies.swift
@@ -337,8 +337,12 @@ final class Dependencies: Sendable {
 
         let locationUploadCoordinator: any LocationUploadCoordinating
         if let arcusSignalBaseURL = ArcusSignalConfiguration.configuredBaseURL() {
-            let uploader = HTTPLocationSnapshotUploader(baseURL: arcusSignalBaseURL, http: httpClient)
-            locationUploadCoordinator = LocationSnapshotPusher(uploader: uploader)
+            let snapshotUploader = HTTPLocationSnapshotUploader(baseURL: arcusSignalBaseURL, http: httpClient)
+            let preferenceUploader = HTTPDevicePreferenceSyncUploader(baseURL: arcusSignalBaseURL, http: httpClient)
+            locationUploadCoordinator = LocationSnapshotPusher(
+                locationUploader: snapshotUploader,
+                preferenceUploader: preferenceUploader
+            )
             logger.info("Location snapshot push enabled host=\(arcusSignalBaseURL.host ?? "unknown", privacy: .public)")
         } else {
             locationUploadCoordinator = NoOpLocationUploadCoordinator()

--- a/Sources/App/HomeRefreshPipeline.swift
+++ b/Sources/App/HomeRefreshPipeline.swift
@@ -9,6 +9,7 @@ import CoreLocation
 import Observation
 import OSLog
 import SwiftUI
+import ArcusCore
 
 protocol HomeWeatherQuerying: Sendable {
     func currentWeather(for location: CLLocation) async -> SummaryWeather?

--- a/Sources/App/HomeRefreshPipeline.swift
+++ b/Sources/App/HomeRefreshPipeline.swift
@@ -22,6 +22,7 @@ protocol HomeLocationContextPreparing: AnyObject {
         requiresFreshLocation: Bool,
         showsAuthorizationPrompt: Bool,
         uploadSource: LocationUploadSource?,
+        uploadReason: LocationUploadReason?,
         authorizationTimeout: Double,
         locationTimeout: Double,
         maximumAcceptedLocationAge: TimeInterval,

--- a/Sources/App/HomeRefreshPipeline.swift
+++ b/Sources/App/HomeRefreshPipeline.swift
@@ -21,6 +21,7 @@ protocol HomeLocationContextPreparing: AnyObject {
     func prepareCurrentLocationContext(
         requiresFreshLocation: Bool,
         showsAuthorizationPrompt: Bool,
+        uploadSource: LocationUploadSource?,
         authorizationTimeout: Double,
         locationTimeout: Double,
         maximumAcceptedLocationAge: TimeInterval,

--- a/Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift
+++ b/Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift
@@ -37,6 +37,7 @@ protocol HomeContextPreparing: AnyObject, Sendable {
     func prepareCurrentLocationContext(
         requiresFreshLocation: Bool,
         showsAuthorizationPrompt: Bool,
+        uploadSource: LocationUploadSource?,
         authorizationTimeout: Double,
         locationTimeout: Double,
         maximumAcceptedLocationAge: TimeInterval,
@@ -94,7 +95,11 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
         let startedAt = Date()
         environment.logger.info("Executing home ingestion plan={\(plan.logDescription)}")
         await progress.report(.started(.location(plan.lanes)))
-        let context = await resolveContext(for: plan.locationRequest, using: environment.locationSession)
+        let context = await resolveContext(
+            for: plan.locationRequest,
+            uploadSource: uploadSource(for: plan),
+            using: environment.locationSession
+        )
         await progress.report(context == nil ? .skipped(.location(plan.lanes)) : .completed(.location(plan.lanes)))
         let now = Date()
         let executionMode = httpExecutionMode(for: plan)
@@ -165,6 +170,7 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
 
     private func resolveContext(
         for request: HomeIngestionLocationRequest,
+        uploadSource: LocationUploadSource?,
         using locationSession: any HomeContextPreparing
     ) async -> LocationContext? {
         switch request {
@@ -175,6 +181,7 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
             return await locationSession.prepareCurrentLocationContext(
                 requiresFreshLocation: false,
                 showsAuthorizationPrompt: false,
+                uploadSource: uploadSource,
                 authorizationTimeout: 30,
                 locationTimeout: 12,
                 maximumAcceptedLocationAge: 5 * 60,
@@ -184,6 +191,7 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
             return await locationSession.prepareCurrentLocationContext(
                 requiresFreshLocation: false,
                 showsAuthorizationPrompt: false,
+                uploadSource: uploadSource,
                 authorizationTimeout: 30,
                 locationTimeout: 12,
                 maximumAcceptedLocationAge: 5 * 60,
@@ -193,6 +201,7 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
             return await locationSession.prepareCurrentLocationContext(
                 requiresFreshLocation: requiresFreshLocation,
                 showsAuthorizationPrompt: showsAuthorizationPrompt,
+                uploadSource: uploadSource,
                 authorizationTimeout: 30,
                 locationTimeout: 12,
                 maximumAcceptedLocationAge: 5 * 60,
@@ -200,6 +209,42 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
             )
         case .explicit(let context):
             return context
+        }
+    }
+
+    private func uploadSource(for plan: HomeIngestionPlan) -> LocationUploadSource? {
+        if plan.provenance.contains(.background), plan.provenance.contains(.locationChange) {
+            return .backgroundLocationChange
+        }
+        if plan.provenance.contains(.background) {
+            return .backgroundRefresh
+        }
+        if plan.provenance.contains(.manualRefresh) {
+            return .manualRefresh
+        }
+        if plan.provenance.contains(.locationChange) {
+            return .foregroundLocationChange
+        }
+        if plan.provenance.contains(.foregroundActivate), plan.lanes == [.hotAlerts] {
+            return .foregroundPrime
+        }
+        if plan.provenance.contains(.foregroundActivate) {
+            return .foregroundActivate
+        }
+
+        switch plan.locationRequest {
+        case .latestAcceptedSnapshotPrepared:
+            return .backgroundLocationChange
+        case .prepare(let requiresFreshLocation, let showsAuthorizationPrompt):
+            if requiresFreshLocation, showsAuthorizationPrompt {
+                return .foregroundActivate
+            }
+            if requiresFreshLocation {
+                return .manualRefresh
+            }
+            return nil
+        case .currentPrepared, .explicit:
+            return nil
         }
     }
 

--- a/Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift
+++ b/Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift
@@ -38,6 +38,7 @@ protocol HomeContextPreparing: AnyObject, Sendable {
         requiresFreshLocation: Bool,
         showsAuthorizationPrompt: Bool,
         uploadSource: LocationUploadSource?,
+        uploadReason: LocationUploadReason?,
         authorizationTimeout: Double,
         locationTimeout: Double,
         maximumAcceptedLocationAge: TimeInterval,
@@ -98,6 +99,7 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
         let context = await resolveContext(
             for: plan.locationRequest,
             uploadSource: uploadSource(for: plan),
+            uploadReason: uploadReason(for: plan),
             using: environment.locationSession
         )
         await progress.report(context == nil ? .skipped(.location(plan.lanes)) : .completed(.location(plan.lanes)))
@@ -171,6 +173,7 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
     private func resolveContext(
         for request: HomeIngestionLocationRequest,
         uploadSource: LocationUploadSource?,
+        uploadReason: LocationUploadReason?,
         using locationSession: any HomeContextPreparing
     ) async -> LocationContext? {
         switch request {
@@ -182,6 +185,7 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
                 requiresFreshLocation: false,
                 showsAuthorizationPrompt: false,
                 uploadSource: uploadSource,
+                uploadReason: uploadReason,
                 authorizationTimeout: 30,
                 locationTimeout: 12,
                 maximumAcceptedLocationAge: 5 * 60,
@@ -192,6 +196,7 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
                 requiresFreshLocation: false,
                 showsAuthorizationPrompt: false,
                 uploadSource: uploadSource,
+                uploadReason: uploadReason,
                 authorizationTimeout: 30,
                 locationTimeout: 12,
                 maximumAcceptedLocationAge: 5 * 60,
@@ -202,6 +207,7 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
                 requiresFreshLocation: requiresFreshLocation,
                 showsAuthorizationPrompt: showsAuthorizationPrompt,
                 uploadSource: uploadSource,
+                uploadReason: uploadReason,
                 authorizationTimeout: 30,
                 locationTimeout: 12,
                 maximumAcceptedLocationAge: 5 * 60,
@@ -246,6 +252,14 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
         case .currentPrepared, .explicit:
             return nil
         }
+    }
+
+    private func uploadReason(for plan: HomeIngestionPlan) -> LocationUploadReason? {
+        guard uploadSource(for: plan) != nil else { return nil }
+        if plan.provenance.contains(.locationChange) {
+            return .locationChanged
+        }
+        return .locationResolved
     }
 
     private func shouldSyncHotFeeds(plan: HomeIngestionPlan, now: Date) -> Bool {

--- a/Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift
+++ b/Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift
@@ -180,6 +180,15 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
                 maximumAcceptedLocationAge: 5 * 60,
                 placemarkTimeout: 8
             )
+        case .latestAcceptedSnapshotPrepared:
+            return await locationSession.prepareCurrentLocationContext(
+                requiresFreshLocation: false,
+                showsAuthorizationPrompt: false,
+                authorizationTimeout: 30,
+                locationTimeout: 12,
+                maximumAcceptedLocationAge: 5 * 60,
+                placemarkTimeout: 8
+            )
         case .prepare(let requiresFreshLocation, let showsAuthorizationPrompt):
             return await locationSession.prepareCurrentLocationContext(
                 requiresFreshLocation: requiresFreshLocation,

--- a/Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift
+++ b/Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift
@@ -8,6 +8,7 @@
 import CoreLocation
 import Foundation
 import OSLog
+import ArcusCore
 
 enum HomeIngestionProgressScope: Sendable, Equatable {
     case location(HomeIngestionLane)
@@ -59,7 +60,7 @@ protocol HomeIngestionExecuting: Sendable {
 }
 
 actor HomeIngestionExecutor: HomeIngestionExecuting {
-    struct Environment: @unchecked Sendable {
+    struct Environment: Sendable {
         let logger: Logger
         let spcSync: any SpcSyncing
         let arcusAlertSync: any ArcusAlertSyncing

--- a/Sources/App/HomeRefreshV2/HomeRefreshTrigger.swift
+++ b/Sources/App/HomeRefreshV2/HomeRefreshTrigger.swift
@@ -71,6 +71,7 @@ struct HomeIngestionProvenance: OptionSet, Sendable {
 
 enum HomeIngestionLocationRequest: Sendable, Equatable {
     case currentPrepared
+    case latestAcceptedSnapshotPrepared
     case prepare(requiresFreshLocation: Bool, showsAuthorizationPrompt: Bool)
     case explicit(LocationContext)
 
@@ -86,6 +87,14 @@ enum HomeIngestionLocationRequest: Sendable, Equatable {
         case (.explicit(let lhs), .explicit(let rhs)):
             return lhs == rhs
         case (.explicit, .currentPrepared), (.explicit, .prepare):
+            return true
+        case (.explicit, .latestAcceptedSnapshotPrepared):
+            return true
+        case (.prepare, .latestAcceptedSnapshotPrepared):
+            return true
+        case (.latestAcceptedSnapshotPrepared, .latestAcceptedSnapshotPrepared):
+            return true
+        case (.latestAcceptedSnapshotPrepared, .currentPrepared):
             return true
         case (.prepare(let lhsFresh, let lhsPrompt), .prepare(let rhsFresh, let rhsPrompt)):
             let satisfiesFresh = lhsFresh || !rhsFresh
@@ -104,16 +113,18 @@ enum HomeIngestionLocationRequest: Sendable, Equatable {
         switch self {
         case .currentPrepared:
             return 0
-        case .prepare(false, false):
+        case .latestAcceptedSnapshotPrepared:
             return 1
-        case .prepare(true, false):
+        case .prepare(false, false):
             return 2
-        case .prepare(false, true):
+        case .prepare(true, false):
             return 3
-        case .prepare(true, true):
+        case .prepare(false, true):
             return 4
-        case .explicit:
+        case .prepare(true, true):
             return 5
+        case .explicit:
+            return 6
         }
     }
 }
@@ -173,7 +184,7 @@ struct HomeIngestionPlan: Sendable, Equatable {
         case .backgroundLocationChange:
             lanes = .all
             forcedLanes = [.hotAlerts, .weather]
-            locationRequest = .currentPrepared
+            locationRequest = .latestAcceptedSnapshotPrepared
             provenance = [.background, .locationChange]
             isLocationBearing = true
         case .remoteHotAlertReceived:
@@ -300,6 +311,8 @@ extension HomeIngestionLocationRequest {
         switch self {
         case .currentPrepared:
             return "currentPrepared"
+        case .latestAcceptedSnapshotPrepared:
+            return "latestAcceptedSnapshotPrepared"
         case .prepare(let requiresFreshLocation, let showsAuthorizationPrompt):
             return "prepare(fresh=\(requiresFreshLocation),prompt=\(showsAuthorizationPrompt))"
         case .explicit:

--- a/Sources/App/HomeRefreshV2/WidgetSnapshotRefreshCoordinator.swift
+++ b/Sources/App/HomeRefreshV2/WidgetSnapshotRefreshCoordinator.swift
@@ -36,12 +36,12 @@ enum WidgetSnapshotChangeScope: Sendable {
     case activeAlertProjection
 }
 
-protocol WidgetSnapshotRefreshing {
+protocol WidgetSnapshotRefreshing: Sendable {
     func refresh(scope: WidgetSnapshotChangeScope, input: WidgetSnapshotRefreshInput) throws
 }
 
 struct WidgetSnapshotRefreshCoordinator: WidgetSnapshotRefreshing {
-    typealias ReloadTimeline = (String) -> Void
+    typealias ReloadTimeline = @Sendable (String) -> Void
 
     private let builder: WidgetSnapshotBuilder
     private let store: WidgetSnapshotStore

--- a/Sources/App/SkyAwareApp.swift
+++ b/Sources/App/SkyAwareApp.swift
@@ -124,6 +124,7 @@ struct SkyAwareApp: App {
                     let installationId = await InstallationIdentityStore.shared.installationId()
                     logger.debug("Installation ID ready with \(installationId.count, privacy: .public) chars")
                     await RemoteNotificationRegistrar.shared.registerForRemoteNotificationsIfAuthorized(context: "scene-active")
+                    await locationSession.drainPendingLocationUploads()
                 }
                 
                 // If its our first run, spin off a task to set up a background task

--- a/Sources/Features/Background/BackgroundOrchestrator.swift
+++ b/Sources/Features/Background/BackgroundOrchestrator.swift
@@ -37,6 +37,7 @@ actor BackgroundOrchestrator {
     private let healthStore: BgHealthStore
     private let cadence: CadencePolicy
     private let notificationSettingsProvider: NotificationSettingsProviding
+    private let pendingUploadDrainer: any PendingLocationUploadDraining
     
     private let clock = ContinuousClock()
     
@@ -47,7 +48,8 @@ actor BackgroundOrchestrator {
         mesoEngine: MesoEngine,
         health: BgHealthStore,
         cadence: CadencePolicy,
-        notificationSettingsProvider: NotificationSettingsProviding
+        notificationSettingsProvider: NotificationSettingsProviding,
+        pendingUploadDrainer: any PendingLocationUploadDraining = NoOpLocationUploadCoordinator()
     ) {
         self.coordinator = coordinator
         morningEngine = engine
@@ -56,6 +58,7 @@ actor BackgroundOrchestrator {
         self.cadence = cadence
         self.mesoEngine = mesoEngine
         self.notificationSettingsProvider = notificationSettingsProvider
+        self.pendingUploadDrainer = pendingUploadDrainer
         signposter = OSSignposter(logger: logger)
         logger.info("BackgroundOrchestrator initialized")
     }
@@ -77,6 +80,7 @@ actor BackgroundOrchestrator {
             do {
                 try Task.checkCancellation()
                 let settings = await notificationSettingsProvider.current()
+                await pendingUploadDrainer.drainPendingUploads()
                 let ingestionInterval = signposter.beginInterval("Unified Background Ingestion")
                 let snapshot = try await coordinator.enqueueAndWait(
                     .backgroundRefresh,

--- a/Sources/Features/Onboarding/OnboardingView.swift
+++ b/Sources/Features/Onboarding/OnboardingView.swift
@@ -172,12 +172,16 @@ struct OnboardingView: View {
             let context = await locationSession.prepareCurrentLocationContext(
                 requiresFreshLocation: true,
                 showsAuthorizationPrompt: false,
-                uploadSource: nil
+                uploadSource: nil,
+                uploadReason: nil
             )
             if context == nil {
                 logger.notice("Continuing onboarding without an uploaded location context; none became available")
             } else {
-                await locationSession.enqueueCurrentLocationUpload(source: .onboarding)
+                await locationSession.enqueueCurrentLocationUpload(
+                    source: .onboarding,
+                    reason: .locationResolved
+                )
             }
         }
 

--- a/Sources/Features/Onboarding/OnboardingView.swift
+++ b/Sources/Features/Onboarding/OnboardingView.swift
@@ -171,7 +171,8 @@ struct OnboardingView: View {
             notificationStepState = .working("Capturing your first location context...")
             let context = await locationSession.prepareCurrentLocationContext(
                 requiresFreshLocation: true,
-                showsAuthorizationPrompt: false
+                showsAuthorizationPrompt: false,
+                uploadSource: .onboarding
             )
             if context == nil {
                 logger.notice("Continuing onboarding without an uploaded location context; none became available")

--- a/Sources/Features/Onboarding/OnboardingView.swift
+++ b/Sources/Features/Onboarding/OnboardingView.swift
@@ -172,10 +172,12 @@ struct OnboardingView: View {
             let context = await locationSession.prepareCurrentLocationContext(
                 requiresFreshLocation: true,
                 showsAuthorizationPrompt: false,
-                uploadSource: .onboarding
+                uploadSource: nil
             )
             if context == nil {
                 logger.notice("Continuing onboarding without an uploaded location context; none became available")
+            } else {
+                await locationSession.enqueueCurrentLocationUpload(source: .onboarding)
             }
         }
 

--- a/Sources/Features/Settings/SettingsView.swift
+++ b/Sources/Features/Settings/SettingsView.swift
@@ -46,6 +46,7 @@ struct SettingsView: View {
     private let logger = Logger.uiSettings
     private let locationReliabilityLogger = Logger.uiLocationReliability
     @State private var notificationAuthorizationStatus: UNAuthorizationStatus = .notDetermined
+    @State private var suppressNextServerNotificationSync = false
     
     // MARK: Notification Settings
     @AppStorage(
@@ -135,12 +136,16 @@ struct SettingsView: View {
                         Toggle("Subscribe to Server Notifications", isOn: $serverNotificationEnabled)
                             .onChange(of: serverNotificationEnabled) { _, newValue in
                                 handleNotificationToggle(newValue, for: "Server Notifications")
+                                if suppressNextServerNotificationSync {
+                                    suppressNextServerNotificationSync = false
+                                    return
+                                }
                                 if newValue, sendL8nToSignal == false {
                                     sendL8nToSignal = true
                                     return
                                 }
                                 Task {
-                                    await locationSession.pushServerNotificationPreferenceUpdate()
+                                    await locationSession.syncNotificationPreference(enabled: newValue)
                                 }
                             }
                             .disabled(notificationsAreDenied)
@@ -166,12 +171,18 @@ struct SettingsView: View {
                                 if newValue {
                                     _ = locationSession.requestAlwaysAuthorizationUpgradeIfNeeded()
                                     Task {
-                                        await locationSession.pushServerNotificationPreferenceUpdate()
+                                        await locationSession.syncLocationSharingPreference(enabled: true)
+                                        await locationSession.enqueueCurrentLocationUpload(source: .settingsPreference)
                                     }
                                 } else {
+                                    let wasSubscribed = serverNotificationEnabled
+                                    suppressNextServerNotificationSync = wasSubscribed
                                     serverNotificationEnabled = false
                                     Task {
-                                        await locationSession.pushServerNotificationPreferenceUpdate(forceUpload: true)
+                                        await locationSession.syncLocationSharingPreference(enabled: false)
+                                        if wasSubscribed {
+                                            await locationSession.syncNotificationPreference(enabled: false)
+                                        }
                                     }
                                 }
                             }

--- a/Sources/Features/Settings/SettingsView.swift
+++ b/Sources/Features/Settings/SettingsView.swift
@@ -169,17 +169,15 @@ struct SettingsView: View {
                             .onChange(of: sendL8nToSignal) { _, newValue in
                                 handleNotificationToggle(newValue, for: "Send Location to Signal")
                                 if newValue {
-                                    _ = locationSession.requestAlwaysAuthorizationUpgradeIfNeeded()
                                     Task {
-                                        await locationSession.syncLocationSharingPreference(enabled: true)
-                                        await locationSession.enqueueCurrentLocationUpload(source: .settingsPreference)
+                                        await locationSession.updateLocationSharingPreference(enabled: true)
                                     }
                                 } else {
                                     let wasSubscribed = serverNotificationEnabled
                                     suppressNextServerNotificationSync = wasSubscribed
                                     serverNotificationEnabled = false
                                     Task {
-                                        await locationSession.syncLocationSharingPreference(enabled: false)
+                                        await locationSession.updateLocationSharingPreference(enabled: false)
                                         if wasSubscribed {
                                             await locationSession.syncNotificationPreference(enabled: false)
                                         }

--- a/Sources/Infrastructure/Location/HTTPDevicePreferenceSyncUploader.swift
+++ b/Sources/Infrastructure/Location/HTTPDevicePreferenceSyncUploader.swift
@@ -1,0 +1,57 @@
+import Foundation
+import OSLog
+import UIKit
+import ArcusCore
+
+protocol DevicePreferenceSyncUploading: Sendable {
+    func upload(_ payload: DevicePreferenceSyncPayload) async throws
+}
+
+actor HTTPDevicePreferenceSyncUploader: DevicePreferenceSyncUploading {
+    private let endpoint: URL
+    private let http: HTTPClient
+    private let encoder = JSONEncoder()
+    private let decoder: JSONDecoder
+    private let logger = Logger.locationPushUploader
+
+    init(baseURL: URL, http: HTTPClient = URLSessionHTTPClient()) {
+        guard let endpoint = ArcusSignalConfiguration.url(
+            from: baseURL,
+            path: ArcusSignalConfiguration.devicePreferencesPath
+        ) else {
+            preconditionFailure("Invalid Arcus signal base URL")
+        }
+        self.endpoint = endpoint
+        self.http = http
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        self.decoder = decoder
+    }
+
+    func upload(_ payload: DevicePreferenceSyncPayload) async throws {
+        let body = try encoder.encode(payload)
+        let response = try await http.post(endpoint, headers: requestHeaders, body: body)
+        guard (200...299).contains(response.status) else {
+            throw LocationPushError.invalidResponseStatus(response.status)
+        }
+
+        if let data = response.data, data.isEmpty == false {
+            _ = try? decoder.decode(DevicePreferenceSyncAcceptedResponse.self, from: data)
+        }
+
+        logger.info("Device preference sync uploaded")
+    }
+
+    private var requestHeaders: [String: String] {
+        [
+            "User-Agent": HTTPRequestHeaders.userAgent(),
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        ]
+    }
+}
+
+struct NoOpDevicePreferenceSyncUploader: DevicePreferenceSyncUploading {
+    func upload(_ payload: DevicePreferenceSyncPayload) async throws {}
+}

--- a/Sources/Infrastructure/Location/HTTPLocationSnapshotUploader.swift
+++ b/Sources/Infrastructure/Location/HTTPLocationSnapshotUploader.swift
@@ -14,8 +14,18 @@ protocol LocationSnapshotUploading: Sendable {
 }
 
 struct NoOpLocationUploadCoordinator: LocationUploadCoordinating {
-    func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool) async {}
-    func enqueuePreferenceSync(source: LocationUploadSource, forceUpload: Bool, reason: String) async {}
+    func enqueue(
+        _ context: LocationContext,
+        source: LocationUploadSource,
+        reason: LocationUploadReason,
+        forceUpload: Bool
+    ) async {}
+    func enqueuePreferenceSync(
+        source: LocationUploadSource,
+        requestReason: LocationUploadReason,
+        forceUpload: Bool,
+        detail: String
+    ) async {}
     func drainPendingUploads() async {}
 }
 

--- a/Sources/Infrastructure/Location/HTTPLocationSnapshotUploader.swift
+++ b/Sources/Infrastructure/Location/HTTPLocationSnapshotUploader.swift
@@ -41,7 +41,6 @@ actor HTTPLocationSnapshotUploader: LocationSnapshotUploading {
         let body = try encoder.encode(payload)
         let response = try await http.post(endpoint, headers: requestHeaders, body: body)
         guard (200...299).contains(response.status) else {
-            logger.error("Location snapshot upload failed status=\(response.status, privacy: .public)")
             throw LocationPushError.invalidResponseStatus(response.status)
         }
         logger.info("Location snapshot uploaded cell=\(String(payload.h3Cell ?? 0), privacy: .public)")

--- a/Sources/Infrastructure/Location/HTTPLocationSnapshotUploader.swift
+++ b/Sources/Infrastructure/Location/HTTPLocationSnapshotUploader.swift
@@ -55,7 +55,7 @@ actor HTTPLocationSnapshotUploader: LocationSnapshotUploading {
         guard (200...299).contains(response.status) else {
             throw LocationPushError.invalidResponseStatus(response.status)
         }
-        logger.info("Location snapshot uploaded cell=\(String(payload.h3Cell ?? 0), privacy: .public)")
+        logger.info("Location snapshot uploaded")
     }
 
     private var requestHeaders: [String: String] {

--- a/Sources/Infrastructure/Location/HTTPLocationSnapshotUploader.swift
+++ b/Sources/Infrastructure/Location/HTTPLocationSnapshotUploader.swift
@@ -15,6 +15,7 @@ protocol LocationSnapshotUploading: Sendable {
 
 struct NoOpLocationUploadCoordinator: LocationUploadCoordinating {
     func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool) async {}
+    func enqueuePreferenceSync(source: LocationUploadSource, forceUpload: Bool, reason: String) async {}
     func drainPendingUploads() async {}
 }
 

--- a/Sources/Infrastructure/Location/HTTPLocationSnapshotUploader.swift
+++ b/Sources/Infrastructure/Location/HTTPLocationSnapshotUploader.swift
@@ -15,6 +15,7 @@ protocol LocationSnapshotUploading: Sendable {
 
 struct NoOpLocationUploadCoordinator: LocationUploadCoordinating {
     func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool) async {}
+    func drainPendingUploads() async {}
 }
 
 actor HTTPLocationSnapshotUploader: LocationSnapshotUploading {

--- a/Sources/Infrastructure/Location/HTTPLocationSnapshotUploader.swift
+++ b/Sources/Infrastructure/Location/HTTPLocationSnapshotUploader.swift
@@ -13,8 +13,8 @@ protocol LocationSnapshotUploading: Sendable {
     func upload(_ payload: LocationSnapshotPushPayload) async throws
 }
 
-struct NoOpLocationContextPusher: LocationContextPushing {
-    func enqueue(_ context: LocationContext, forceUpload: Bool) async {}
+struct NoOpLocationUploadCoordinator: LocationUploadCoordinating {
+    func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool) async {}
 }
 
 actor HTTPLocationSnapshotUploader: LocationSnapshotUploading {

--- a/Sources/Infrastructure/Location/LocationContextResolver.swift
+++ b/Sources/Infrastructure/Location/LocationContextResolver.swift
@@ -54,8 +54,6 @@ protocol LocationContextResolving: Sendable {
         maximumAcceptedLocationAge: TimeInterval?,
         placemarkTimeout: Double
     ) async throws -> LocationContext
-
-    func enqueueForPush(_ context: LocationContext, forceUpload: Bool) async
 }
 
 actor LocationContextResolver: LocationContextResolving {
@@ -68,7 +66,6 @@ actor LocationContextResolver: LocationContextResolving {
     private let locationClient: LocationClient
     private let locationProvider: LocationProvider
     private let gridPointProvider: GridPointProvider
-    private let contextPusher: any LocationContextPushing
     private let authorizationStatusProvider: AuthorizationStatusProvider
     private let authorizationRequester: AuthorizationRequester
     private let refreshCurrentLocation: CurrentLocationRefresher
@@ -78,7 +75,6 @@ actor LocationContextResolver: LocationContextResolving {
         locationClient: LocationClient,
         locationProvider: LocationProvider,
         gridPointProvider: GridPointProvider,
-        contextPusher: any LocationContextPushing = NoOpLocationContextPusher(),
         authorizationStatusProvider: @escaping AuthorizationStatusProvider,
         authorizationRequester: @escaping AuthorizationRequester,
         refreshCurrentLocation: @escaping CurrentLocationRefresher
@@ -86,7 +82,6 @@ actor LocationContextResolver: LocationContextResolving {
         self.locationClient = locationClient
         self.locationProvider = locationProvider
         self.gridPointProvider = gridPointProvider
-        self.contextPusher = contextPusher
         self.authorizationStatusProvider = authorizationStatusProvider
         self.authorizationRequester = authorizationRequester
         self.refreshCurrentLocation = refreshCurrentLocation
@@ -210,15 +205,10 @@ actor LocationContextResolver: LocationContextResolving {
         }
 
         let context = LocationContext(snapshot: enrichedSnapshot, h3Cell: h3Cell, grid: grid)
-        await contextPusher.enqueue(context)
         logger.info(
             "Location context resolved hasPlacemark=\((enrichedSnapshot.placemarkSummary != nil), privacy: .public) hasCounty=\((grid.countyCode?.isEmpty == false), privacy: .public) hasFireZone=\((grid.fireZone?.isEmpty == false), privacy: .public)"
         )
         return context
-    }
-
-    func enqueueForPush(_ context: LocationContext, forceUpload: Bool = false) async {
-        await contextPusher.enqueue(context, forceUpload: forceUpload)
     }
 
     private func waitForAuthorizationResolution(timeout: Double) async throws -> CLAuthorizationStatus {

--- a/Sources/Infrastructure/Location/LocationSession.swift
+++ b/Sources/Infrastructure/Location/LocationSession.swift
@@ -106,6 +106,7 @@ final class LocationSession {
         requiresFreshLocation: Bool,
         showsAuthorizationPrompt: Bool,
         uploadSource: LocationUploadSource? = nil,
+        uploadReason: LocationUploadReason? = nil,
         authorizationTimeout: Double = 30,
         locationTimeout: Double = 12,
         maximumAcceptedLocationAge: TimeInterval = 5 * 60,
@@ -135,7 +136,12 @@ final class LocationSession {
             currentSnapshot = context.snapshot
             currentContext = context
             if let uploadSource {
-                await locationUploadCoordinator.enqueue(context, source: uploadSource, forceUpload: false)
+                await locationUploadCoordinator.enqueue(
+                    context,
+                    source: uploadSource,
+                    reason: uploadReason ?? .locationResolved,
+                    forceUpload: false
+                )
             }
             startupState = .ready
             return context
@@ -161,11 +167,12 @@ final class LocationSession {
         await syncLocationSharingPreference(enabled: enabled)
     }
 
-    func enqueueCurrentLocationUpload(source: LocationUploadSource) async {
+    func enqueueCurrentLocationUpload(source: LocationUploadSource, reason: LocationUploadReason) async {
         guard let context = await resolveCurrentContextIfNeeded() else { return }
         await locationUploadCoordinator.enqueue(
             context,
             source: source,
+            reason: reason,
             forceUpload: false
         )
     }
@@ -180,14 +187,16 @@ final class LocationSession {
             logger.notice("Queueing preference sync without location context reason=\(reason, privacy: .public)")
             await locationUploadCoordinator.enqueuePreferenceSync(
                 source: .settingsPreference,
+                requestReason: .preferenceChanged,
                 forceUpload: forceUpload,
-                reason: reason
+                detail: reason
             )
             return
         }
         await locationUploadCoordinator.enqueue(
             context,
             source: .settingsPreference,
+            reason: .preferenceChanged,
             forceUpload: forceUpload
         )
     }
@@ -278,6 +287,7 @@ final class LocationSession {
                 await self.locationUploadCoordinator.enqueue(
                     context,
                     source: .foregroundLocationChange,
+                    reason: .locationChanged,
                     forceUpload: false
                 )
             } catch is CancellationError {

--- a/Sources/Infrastructure/Location/LocationSession.swift
+++ b/Sources/Infrastructure/Location/LocationSession.swift
@@ -163,6 +163,10 @@ final class LocationSession {
         )
     }
 
+    func drainPendingLocationUploads() async {
+        await locationUploadCoordinator.drainPendingUploads()
+    }
+
     // TODO(#184): Replace this adapter once Arcus has a dedicated preference sync endpoint.
     private func syncPreferenceViaLegacyLocationPayload(forceUpload: Bool, reason: String) async {
         guard let context = await resolveCurrentContextIfNeeded() else {

--- a/Sources/Infrastructure/Location/LocationSession.swift
+++ b/Sources/Infrastructure/Location/LocationSession.swift
@@ -154,11 +154,11 @@ final class LocationSession {
     }
 
     func syncNotificationPreference(enabled: Bool) async {
-        await syncPreferenceViaLegacyLocationPayload(forceUpload: true, reason: "notification")
+        await syncPreference(forceUpload: true, reason: "notification")
     }
 
     func syncLocationSharingPreference(enabled: Bool) async {
-        await syncPreferenceViaLegacyLocationPayload(forceUpload: true, reason: "location-sharing")
+        await syncPreference(forceUpload: true, reason: "location-sharing")
     }
 
     func updateLocationSharingPreference(enabled: Bool) async {
@@ -182,23 +182,13 @@ final class LocationSession {
         await locationUploadCoordinator.drainPendingUploads()
     }
 
-    // TODO(#184): Replace this adapter once Arcus has a dedicated preference sync endpoint.
-    private func syncPreferenceViaLegacyLocationPayload(forceUpload: Bool, reason: String) async {
-        guard let context = await resolveCurrentContextIfNeeded() else {
-            logger.notice("Queueing preference sync without location context reason=\(reason, privacy: .public)")
-            await locationUploadCoordinator.enqueuePreferenceSync(
-                source: .settingsPreference,
-                requestReason: .preferenceChanged,
-                forceUpload: forceUpload,
-                detail: reason
-            )
-            return
-        }
-        await locationUploadCoordinator.enqueue(
-            context,
+    private func syncPreference(forceUpload: Bool, reason: String) async {
+        logger.notice("Queueing preference sync reason=\(reason, privacy: .public)")
+        await locationUploadCoordinator.enqueuePreferenceSync(
             source: .settingsPreference,
-            reason: .preferenceChanged,
-            forceUpload: forceUpload
+            requestReason: .preferenceChanged,
+            forceUpload: forceUpload,
+            detail: reason
         )
     }
 

--- a/Sources/Infrastructure/Location/LocationSession.swift
+++ b/Sources/Infrastructure/Location/LocationSession.swift
@@ -26,6 +26,7 @@ final class LocationSession {
     private let locationClient: LocationClient
     private let locationManager: LocationManager
     private let locationContextResolver: any LocationContextResolving
+    private let locationUploadCoordinator: any LocationUploadCoordinating
 
     @ObservationIgnored
     private var updatesTask: Task<Void, Never>?
@@ -49,11 +50,13 @@ final class LocationSession {
     init(
         locationClient: LocationClient,
         locationManager: LocationManager,
-        locationContextResolver: any LocationContextResolving
+        locationContextResolver: any LocationContextResolving,
+        locationUploadCoordinator: any LocationUploadCoordinating = NoOpLocationUploadCoordinator()
     ) {
         self.locationClient = locationClient
         self.locationManager = locationManager
         self.locationContextResolver = locationContextResolver
+        self.locationUploadCoordinator = locationUploadCoordinator
         self.authorizationStatus = locationManager.authStatus
         self.accuracyAuthorization = locationManager.accuracyAuthorization
 
@@ -102,6 +105,7 @@ final class LocationSession {
     func prepareCurrentLocationContext(
         requiresFreshLocation: Bool,
         showsAuthorizationPrompt: Bool,
+        uploadSource: LocationUploadSource? = nil,
         authorizationTimeout: Double = 30,
         locationTimeout: Double = 12,
         maximumAcceptedLocationAge: TimeInterval = 5 * 60,
@@ -130,6 +134,9 @@ final class LocationSession {
             )
             currentSnapshot = context.snapshot
             currentContext = context
+            if let uploadSource {
+                await locationUploadCoordinator.enqueue(context, source: uploadSource, forceUpload: false)
+            }
             startupState = .ready
             return context
         } catch {
@@ -141,7 +148,11 @@ final class LocationSession {
 
     func pushServerNotificationPreferenceUpdate(forceUpload: Bool = false) async {
         if let currentContext {
-            await locationContextResolver.enqueueForPush(currentContext, forceUpload: forceUpload)
+            await locationUploadCoordinator.enqueue(
+                currentContext,
+                source: .settingsPreference,
+                forceUpload: forceUpload
+            )
             return
         }
 
@@ -156,7 +167,11 @@ final class LocationSession {
 
         self.currentSnapshot = resolvedContext.snapshot
         applyResolvedContext(resolvedContext)
-        await locationContextResolver.enqueueForPush(resolvedContext, forceUpload: forceUpload)
+        await locationUploadCoordinator.enqueue(
+            resolvedContext,
+            source: .settingsPreference,
+            forceUpload: forceUpload
+        )
     }
 
     private func syncAuthorizationStatus() {
@@ -223,6 +238,11 @@ final class LocationSession {
                     self.applyResolvedContext(context)
                     self.startupState = .ready
                 }
+                await self.locationUploadCoordinator.enqueue(
+                    context,
+                    source: .foregroundLocationChange,
+                    forceUpload: false
+                )
             } catch is CancellationError {
                 return
             } catch {

--- a/Sources/Infrastructure/Location/LocationSession.swift
+++ b/Sources/Infrastructure/Location/LocationSession.swift
@@ -9,6 +9,7 @@ import CoreLocation
 import Observation
 import OSLog
 import SwiftUI
+import ArcusCore
 
 enum LocationStartupState: Equatable {
     case idle

--- a/Sources/Infrastructure/Location/LocationSession.swift
+++ b/Sources/Infrastructure/Location/LocationSession.swift
@@ -154,6 +154,13 @@ final class LocationSession {
         await syncPreferenceViaLegacyLocationPayload(forceUpload: true, reason: "location-sharing")
     }
 
+    func updateLocationSharingPreference(enabled: Bool) async {
+        if enabled {
+            _ = requestAlwaysAuthorizationUpgradeIfNeeded()
+        }
+        await syncLocationSharingPreference(enabled: enabled)
+    }
+
     func enqueueCurrentLocationUpload(source: LocationUploadSource) async {
         guard let context = await resolveCurrentContextIfNeeded() else { return }
         await locationUploadCoordinator.enqueue(

--- a/Sources/Infrastructure/Location/LocationSession.swift
+++ b/Sources/Infrastructure/Location/LocationSession.swift
@@ -146,32 +146,53 @@ final class LocationSession {
         }
     }
 
-    func pushServerNotificationPreferenceUpdate(forceUpload: Bool = false) async {
-        if let currentContext {
-            await locationUploadCoordinator.enqueue(
-                currentContext,
-                source: .settingsPreference,
-                forceUpload: forceUpload
-            )
+    func syncNotificationPreference(enabled: Bool) async {
+        await syncPreferenceViaLegacyLocationPayload(forceUpload: true, reason: "notification")
+    }
+
+    func syncLocationSharingPreference(enabled: Bool) async {
+        await syncPreferenceViaLegacyLocationPayload(forceUpload: true, reason: "location-sharing")
+    }
+
+    func enqueueCurrentLocationUpload(source: LocationUploadSource) async {
+        guard let context = await resolveCurrentContextIfNeeded() else { return }
+        await locationUploadCoordinator.enqueue(
+            context,
+            source: source,
+            forceUpload: false
+        )
+    }
+
+    // TODO(#184): Replace this adapter once Arcus has a dedicated preference sync endpoint.
+    private func syncPreferenceViaLegacyLocationPayload(forceUpload: Bool, reason: String) async {
+        guard let context = await resolveCurrentContextIfNeeded() else {
+            logger.notice("Skipping legacy preference sync; missing location context reason=\(reason, privacy: .public)")
             return
         }
+        await locationUploadCoordinator.enqueue(
+            context,
+            source: .settingsPreference,
+            forceUpload: forceUpload
+        )
+    }
 
-        guard let currentSnapshot else { return }
+    private func resolveCurrentContextIfNeeded() async -> LocationContext? {
+        if let currentContext {
+            return currentContext
+        }
+
+        guard let currentSnapshot else { return nil }
         guard let resolvedContext = try? await locationContextResolver.resolveContext(
             from: currentSnapshot,
             maximumAcceptedLocationAge: nil,
             placemarkTimeout: 8
         ) else {
-            return
+            return nil
         }
 
         self.currentSnapshot = resolvedContext.snapshot
         applyResolvedContext(resolvedContext)
-        await locationUploadCoordinator.enqueue(
-            resolvedContext,
-            source: .settingsPreference,
-            forceUpload: forceUpload
-        )
+        return resolvedContext
     }
 
     private func syncAuthorizationStatus() {

--- a/Sources/Infrastructure/Location/LocationSession.swift
+++ b/Sources/Infrastructure/Location/LocationSession.swift
@@ -170,7 +170,12 @@ final class LocationSession {
     // TODO(#184): Replace this adapter once Arcus has a dedicated preference sync endpoint.
     private func syncPreferenceViaLegacyLocationPayload(forceUpload: Bool, reason: String) async {
         guard let context = await resolveCurrentContextIfNeeded() else {
-            logger.notice("Skipping legacy preference sync; missing location context reason=\(reason, privacy: .public)")
+            logger.notice("Queueing preference sync without location context reason=\(reason, privacy: .public)")
+            await locationUploadCoordinator.enqueuePreferenceSync(
+                source: .settingsPreference,
+                forceUpload: forceUpload,
+                reason: reason
+            )
             return
         }
         await locationUploadCoordinator.enqueue(

--- a/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
+++ b/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
@@ -11,13 +11,24 @@ import OSLog
 import UIKit
 import ArcusCore
 
-protocol LocationContextPushing: Sendable {
-    func enqueue(_ context: LocationContext, forceUpload: Bool) async
+enum LocationUploadSource: String, Sendable {
+    case foregroundPrime
+    case foregroundActivate
+    case foregroundLocationChange
+    case manualRefresh
+    case backgroundRefresh
+    case backgroundLocationChange
+    case onboarding
+    case settingsPreference
 }
 
-extension LocationContextPushing {
-    func enqueue(_ context: LocationContext) async {
-        await enqueue(context, forceUpload: false)
+protocol LocationUploadCoordinating: Sendable {
+    func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool) async
+}
+
+extension LocationUploadCoordinating {
+    func enqueue(_ context: LocationContext, source: LocationUploadSource) async {
+        await enqueue(context, source: source, forceUpload: false)
     }
 }
 
@@ -25,7 +36,7 @@ enum LocationPushError: Error {
     case invalidResponseStatus(Int)
 }
 
-actor LocationSnapshotPusher: LocationContextPushing {
+actor LocationSnapshotPusher: LocationUploadCoordinating {
     typealias APNsTokenProvider = @Sendable () -> String
     typealias InstallationIDProvider = @Sendable () async -> String
     typealias SubscriptionStatusProvider = @Sendable () -> Bool
@@ -70,7 +81,7 @@ actor LocationSnapshotPusher: LocationContextPushing {
         self.retryDelaysSeconds = retryDelaysSeconds
     }
 
-    func enqueue(_ context: LocationContext, forceUpload: Bool = false) async {
+    func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool = false) async {
         guard forceUpload || locationUploadEnabledProvider() else {
             logger.debug("Skipping location snapshot upload; disabled in settings")
             return
@@ -96,7 +107,7 @@ actor LocationSnapshotPusher: LocationContextPushing {
             fireZone: context.grid.fireZone,
             apnsDeviceToken: apnsToken,
             installationId: installationId,
-            source: "unknown",
+            source: source.rawValue,
             auth: {
                 switch CLLocationManager().authorizationStatus {
                 case .authorizedAlways: return "always"

--- a/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
+++ b/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
@@ -11,7 +11,7 @@ import OSLog
 import UIKit
 import ArcusCore
 
-enum LocationUploadSource: String, Sendable {
+enum LocationUploadSource: String, Sendable, Codable {
     case foregroundPrime
     case foregroundActivate
     case foregroundLocationChange
@@ -24,12 +24,15 @@ enum LocationUploadSource: String, Sendable {
 
 protocol LocationUploadCoordinating: Sendable {
     func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool) async
+    func drainPendingUploads() async
 }
 
 extension LocationUploadCoordinating {
     func enqueue(_ context: LocationContext, source: LocationUploadSource) async {
         await enqueue(context, source: source, forceUpload: false)
     }
+
+    func drainPendingUploads() async {}
 }
 
 enum LocationPushError: Error {
@@ -47,6 +50,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
     nonisolated private static let userDefaultsSuiteName = "com.justinrooks.skyaware"
     nonisolated private static let serverNotificationEnabledKey = "serverNotificationEnabled"
     nonisolated private static let locationUploadEnabledKey = "sendL8ntoSignal"
+    nonisolated private static let pendingRequestsKey = "pendingLocationUploadRequests"
 
     private let uploader: any LocationSnapshotUploading
     private let apnsTokenProvider: APNsTokenProvider
@@ -57,11 +61,14 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
     private let nowProvider: NowProvider
     private let retryDelaysSeconds: [UInt64]
     private let dedupeWindowSeconds: TimeInterval
+    private let queueStore: any LocationUploadQueueStoring
     private let logger = Logger.locationPushPusher
 
-    private var queue: [LocationSnapshotPushPayload] = []
+    private var queue: [QueuedUpload] = []
     private var isProcessing = false
     private var lastUploadBySemanticKey: [DeduplicationKey: Date] = [:]
+    private var pendingByCoalescingKey: [PendingCoalescingKey: PersistedLocationUploadRequest] = [:]
+    private var hasLoadedPersistedPending = false
 
     init(
         uploader: any LocationSnapshotUploading,
@@ -82,7 +89,8 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         },
         nowProvider: @escaping NowProvider = { Date() },
         retryDelaysSeconds: [UInt64] = [0, 5, 15],
-        dedupeWindowSeconds: TimeInterval = 15
+        dedupeWindowSeconds: TimeInterval = 15,
+        queueStore: (any LocationUploadQueueStoring)? = nil
     ) {
         self.uploader = uploader
         self.apnsTokenProvider = apnsTokenProvider
@@ -93,6 +101,10 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         self.nowProvider = nowProvider
         self.retryDelaysSeconds = retryDelaysSeconds
         self.dedupeWindowSeconds = dedupeWindowSeconds
+        self.queueStore = queueStore ?? UserDefaultsLocationUploadQueueStore(
+            suiteName: Self.userDefaultsSuiteName,
+            key: Self.pendingRequestsKey
+        )
     }
 
     func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool = false) async {
@@ -101,14 +113,26 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
             return
         }
 
-        let snapshot = context.snapshot
+        await ensurePersistedPendingLoaded()
         let installationId = await installationIdProvider()
         let apnsToken = apnsTokenProvider().trimmingCharacters(in: .whitespacesAndNewlines)
         let isSubscribed = subscriptionStatusProvider()
         let authorizationStatus = authorizationStatusProvider()
         let now = nowProvider()
+        let persisted = PersistedLocationUploadRequest(
+            context: PersistedLocationContext(context),
+            source: source,
+            forceUpload: forceUpload,
+            installationId: installationId,
+            requestedAt: now,
+            isSubscribed: isSubscribed,
+            authorizationState: Self.authorizationName(for: authorizationStatus),
+            apnsToken: apnsToken
+        )
+
         guard !apnsToken.isEmpty else {
             logger.debug("Skipping location snapshot upload; APNs token unavailable")
+            await upsertPending(persisted)
             return
         }
         let dedupeKey = DeduplicationKey(
@@ -126,43 +150,67 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
             logger.debug("Deduplicating location snapshot upload request")
             return
         }
-        let payload = LocationSnapshotPushPayload(
-            capturedAt: snapshot.timestamp,
-            locationAgeSeconds: now.timeIntervalSince(snapshot.timestamp),
-            horizontalAccuracyMeters: snapshot.accuracy,
-            cellScheme: "h3",
-            h3Cell: context.h3Cell,
-            h3Resolution: 8, // TODO: Make this global someday
-            county: context.grid.countyCode,
-            zone: context.grid.forecastZone,
-            fireZone: context.grid.fireZone,
-            apnsDeviceToken: apnsToken,
-            installationId: installationId,
-            source: source.rawValue,
-            auth: Self.authorizationName(for: authorizationStatus),
-            appVersion: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "",
-            buildNumber: Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "",
-            platform: "iOS",
-            osVersion: await UIDevice.current.systemVersion,
-            apnsEnvironment: {
-                #if DEBUG
-                return "sandbox"
-                #else
-                return "prod"
-                #endif
-            }(),
-            countyLabel: context.grid.countyLabel,
-            fireZoneLabel: context.grid.fireZoneLabel,
-            isSubscribed: isSubscribed
+        let payload = await makePayload(
+            from: persisted,
+            apnsToken: apnsToken,
+            isSubscribed: isSubscribed,
+            authorizationState: Self.authorizationName(for: authorizationStatus),
+            now: now
         )
+        let coalescingKey = coalescingKey(for: persisted)
+        if pendingByCoalescingKey[coalescingKey] == nil {
+            await upsertPending(persisted)
+        }
 
-        queue.append(payload)
+        queue.append(QueuedUpload(payload: payload, coalescingKey: coalescingKey))
         lastUploadBySemanticKey[dedupeKey] = now
 
         guard !isProcessing else { return }
-        isProcessing = true
-        await drainQueue()
-        isProcessing = false
+        await processQueue()
+    }
+
+    func drainPendingUploads() async {
+        await ensurePersistedPendingLoaded()
+
+        guard !pendingByCoalescingKey.isEmpty else { return }
+
+        let apnsToken = apnsTokenProvider().trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !apnsToken.isEmpty else {
+            logger.debug("Skipping pending location upload drain; APNs token unavailable")
+            return
+        }
+
+        for pending in pendingByCoalescingKey.values.sorted(by: { $0.requestedAt < $1.requestedAt }) {
+            let now = nowProvider()
+            let dedupeKey = DeduplicationKey(
+                installationId: pending.installationId,
+                apnsToken: apnsToken,
+                h3Cell: pending.context.h3Cell,
+                county: pending.context.county,
+                fireZone: pending.context.fireZone,
+                forecastZone: pending.context.forecastZone,
+                isSubscribed: pending.isSubscribed,
+                authorizationState: pending.authorizationState,
+                forceUpload: pending.forceUpload
+            )
+            if shouldDedupeRequest(for: dedupeKey, now: now) {
+                pendingByCoalescingKey.removeValue(forKey: coalescingKey(for: pending))
+                await persistPendingState()
+                continue
+            }
+            let payload = await makePayload(
+                from: pending,
+                apnsToken: apnsToken,
+                isSubscribed: pending.isSubscribed,
+                authorizationState: pending.authorizationState,
+                now: now
+            )
+            queue.append(QueuedUpload(payload: payload, coalescingKey: coalescingKey(for: pending)))
+            lastUploadBySemanticKey[dedupeKey] = now
+        }
+
+        guard !isProcessing else { return }
+        await processQueue()
     }
 
     private func shouldDedupeRequest(for key: DeduplicationKey, now: Date) -> Bool {
@@ -182,10 +230,20 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         }
     }
 
+    private func processQueue() async {
+        isProcessing = true
+        defer { isProcessing = false }
+        await drainQueue()
+    }
+
     private func drainQueue() async {
         while !queue.isEmpty {
-            let payload = queue.removeFirst()
-            _ = await uploadWithRetry(payload)
+            let workItem = queue.removeFirst()
+            let didUpload = await uploadWithRetry(workItem.payload)
+            if didUpload {
+                pendingByCoalescingKey.removeValue(forKey: workItem.coalescingKey)
+                await persistPendingState()
+            }
         }
     }
 
@@ -264,6 +322,77 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         }
     }
 
+    private func makePayload(
+        from request: PersistedLocationUploadRequest,
+        apnsToken: String,
+        isSubscribed: Bool,
+        authorizationState: String,
+        now: Date
+    ) async -> LocationSnapshotPushPayload {
+        LocationSnapshotPushPayload(
+            capturedAt: request.context.capturedAt,
+            locationAgeSeconds: now.timeIntervalSince(request.context.capturedAt),
+            horizontalAccuracyMeters: request.context.horizontalAccuracyMeters,
+            cellScheme: "h3",
+            h3Cell: request.context.h3Cell,
+            h3Resolution: 8,
+            county: request.context.county,
+            zone: request.context.forecastZone,
+            fireZone: request.context.fireZone,
+            apnsDeviceToken: apnsToken,
+            installationId: request.installationId,
+            source: request.source.rawValue,
+            auth: authorizationState,
+            appVersion: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "",
+            buildNumber: Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "",
+            platform: "iOS",
+            osVersion: await UIDevice.current.systemVersion,
+            apnsEnvironment: {
+                #if DEBUG
+                return "sandbox"
+                #else
+                return "prod"
+                #endif
+            }(),
+            countyLabel: request.context.countyLabel,
+            fireZoneLabel: request.context.fireZoneLabel,
+            isSubscribed: isSubscribed
+        )
+    }
+
+    private func ensurePersistedPendingLoaded() async {
+        guard hasLoadedPersistedPending == false else { return }
+        hasLoadedPersistedPending = true
+        let loaded = await queueStore.loadPendingRequests()
+        pendingByCoalescingKey = Dictionary(
+            uniqueKeysWithValues: loaded.map { (coalescingKey(for: $0), $0) }
+        )
+    }
+
+    private func upsertPending(_ request: PersistedLocationUploadRequest) async {
+        pendingByCoalescingKey[coalescingKey(for: request)] = request
+        await persistPendingState()
+    }
+
+    private func persistPendingState() async {
+        let requests = pendingByCoalescingKey.values.sorted(by: { $0.requestedAt < $1.requestedAt })
+        await queueStore.savePendingRequests(requests)
+    }
+
+    private func coalescingKey(for request: PersistedLocationUploadRequest) -> PendingCoalescingKey {
+        PendingCoalescingKey(
+            installationId: request.installationId,
+            apnsToken: request.apnsToken,
+            h3Cell: request.context.h3Cell,
+            county: request.context.county,
+            fireZone: request.context.fireZone,
+            forecastZone: request.context.forecastZone,
+            isSubscribed: request.isSubscribed,
+            authorizationState: request.authorizationState,
+            forceUpload: request.forceUpload
+        )
+    }
+
     nonisolated private static func readApnsTokenFromDefaults() -> String {
         UserDefaults(suiteName: userDefaultsSuiteName)?
             .string(forKey: RemoteNotificationRegistrar.apnsDeviceTokenKey) ?? ""
@@ -295,5 +424,100 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         let isSubscribed: Bool
         let authorizationState: String
         let forceUpload: Bool
+    }
+
+    private struct PendingCoalescingKey: Hashable, Codable {
+        let installationId: String
+        let apnsToken: String
+        let h3Cell: Int64
+        let county: String?
+        let fireZone: String?
+        let forecastZone: String?
+        let isSubscribed: Bool
+        let authorizationState: String
+        let forceUpload: Bool
+    }
+
+    private struct QueuedUpload {
+        let payload: LocationSnapshotPushPayload
+        let coalescingKey: PendingCoalescingKey
+    }
+}
+
+protocol LocationUploadQueueStoring: Sendable {
+    func loadPendingRequests() async -> [PersistedLocationUploadRequest]
+    func savePendingRequests(_ requests: [PersistedLocationUploadRequest]) async
+}
+
+struct PersistedLocationUploadRequest: Sendable, Codable, Equatable {
+    let context: PersistedLocationContext
+    let source: LocationUploadSource
+    let forceUpload: Bool
+    let installationId: String
+    let requestedAt: Date
+    let isSubscribed: Bool
+    let authorizationState: String
+    let apnsToken: String
+}
+
+struct PersistedLocationContext: Sendable, Codable, Equatable {
+    let capturedAt: Date
+    let horizontalAccuracyMeters: Double
+    let h3Cell: Int64
+    let county: String?
+    let fireZone: String?
+    let forecastZone: String?
+    let countyLabel: String?
+    let fireZoneLabel: String?
+
+    init(_ context: LocationContext) {
+        self.capturedAt = context.snapshot.timestamp
+        self.horizontalAccuracyMeters = context.snapshot.accuracy
+        self.h3Cell = context.h3Cell
+        self.county = context.grid.countyCode
+        self.fireZone = context.grid.fireZone
+        self.forecastZone = context.grid.forecastZone
+        self.countyLabel = context.grid.countyLabel
+        self.fireZoneLabel = context.grid.fireZoneLabel
+    }
+
+    init(payload: LocationSnapshotPushPayload) {
+        self.capturedAt = payload.capturedAt ?? .now
+        self.horizontalAccuracyMeters = payload.horizontalAccuracyMeters ?? 0
+        self.h3Cell = payload.h3Cell ?? 0
+        self.county = payload.county
+        self.fireZone = payload.fireZone
+        self.forecastZone = payload.zone
+        self.countyLabel = payload.countyLabel
+        self.fireZoneLabel = payload.fireZoneLabel
+    }
+}
+
+actor UserDefaultsLocationUploadQueueStore: LocationUploadQueueStoring {
+    private let defaults: UserDefaults
+    private let key: String
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(suiteName: String, key: String) {
+        self.defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        self.key = key
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+    }
+
+    func loadPendingRequests() async -> [PersistedLocationUploadRequest] {
+        guard let data = defaults.data(forKey: key) else { return [] }
+        return (try? decoder.decode([PersistedLocationUploadRequest].self, from: data)) ?? []
+    }
+
+    func savePendingRequests(_ requests: [PersistedLocationUploadRequest]) async {
+        if requests.isEmpty {
+            defaults.removeObject(forKey: key)
+            return
+        }
+        if let data = try? encoder.encode(requests) {
+            defaults.set(data, forKey: key)
+        }
     }
 }

--- a/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
+++ b/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
@@ -22,9 +22,12 @@ enum LocationUploadSource: String, Sendable, Codable {
     case settingsPreference
 }
 
-protocol LocationUploadCoordinating: Sendable {
-    func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool) async
+protocol PendingLocationUploadDraining: Sendable {
     func drainPendingUploads() async
+}
+
+protocol LocationUploadCoordinating: PendingLocationUploadDraining, Sendable {
+    func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool) async
 }
 
 extension LocationUploadCoordinating {

--- a/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
+++ b/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
@@ -111,8 +111,13 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
     }
 
     func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool = false) async {
+        logger.info(
+            "Location upload request accepted source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public)"
+        )
         guard forceUpload || locationUploadEnabledProvider() else {
-            logger.debug("Skipping location snapshot upload; disabled in settings")
+            logger.notice(
+                "Location upload request skipped reason=disabled source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public)"
+            )
             return
         }
 
@@ -134,7 +139,9 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         )
 
         guard !apnsToken.isEmpty else {
-            logger.debug("Skipping location snapshot upload; APNs token unavailable")
+            logger.notice(
+                "Location upload request persisted reason=missingToken source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public)"
+            )
             await upsertPending(persisted)
             return
         }
@@ -150,7 +157,9 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
             forceUpload: forceUpload
         )
         if shouldDedupeRequest(for: dedupeKey, now: now) {
-            logger.debug("Deduplicating location snapshot upload request")
+            logger.notice(
+                "Location upload request deduped source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public)"
+            )
             return
         }
         let payload = await makePayload(
@@ -162,6 +171,9 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         )
         let coalescingKey = coalescingKey(for: persisted)
         if pendingByCoalescingKey[coalescingKey] == nil {
+            logger.debug(
+                "Location upload request persisted reason=queued source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public)"
+            )
             await upsertPending(persisted)
         }
 
@@ -176,13 +188,16 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         await ensurePersistedPendingLoaded()
 
         guard !pendingByCoalescingKey.isEmpty else { return }
+        logger.info("Location upload drain started pendingCount=\(self.pendingByCoalescingKey.count, privacy: .public)")
 
         let apnsToken = apnsTokenProvider().trimmingCharacters(in: .whitespacesAndNewlines)
         guard !apnsToken.isEmpty else {
-            logger.debug("Skipping pending location upload drain; APNs token unavailable")
+            logger.notice("Location upload drain skipped reason=missingToken")
             return
         }
 
+        var enqueuedCount = 0
+        var dedupedCount = 0
         for pending in pendingByCoalescingKey.values.sorted(by: { $0.requestedAt < $1.requestedAt }) {
             let now = nowProvider()
             let dedupeKey = DeduplicationKey(
@@ -197,6 +212,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
                 forceUpload: pending.forceUpload
             )
             if shouldDedupeRequest(for: dedupeKey, now: now) {
+                dedupedCount += 1
                 pendingByCoalescingKey.removeValue(forKey: coalescingKey(for: pending))
                 await persistPendingState()
                 continue
@@ -209,8 +225,12 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
                 now: now
             )
             queue.append(QueuedUpload(payload: payload, coalescingKey: coalescingKey(for: pending)))
+            enqueuedCount += 1
             lastUploadBySemanticKey[dedupeKey] = now
         }
+        logger.info(
+            "Location upload drain completed enqueued=\(enqueuedCount, privacy: .public) deduped=\(dedupedCount, privacy: .public) remainingPending=\(self.pendingByCoalescingKey.count, privacy: .public)"
+        )
 
         guard !isProcessing else { return }
         await processQueue()
@@ -244,8 +264,15 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
             let workItem = queue.removeFirst()
             let didUpload = await uploadWithRetry(workItem.payload)
             if didUpload {
+                logger.notice(
+                    "Location upload succeeded source=\(workItem.payload.source, privacy: .public)"
+                )
                 pendingByCoalescingKey.removeValue(forKey: workItem.coalescingKey)
                 await persistPendingState()
+            } else {
+                logger.error(
+                    "Location upload failed source=\(workItem.payload.source, privacy: .public)"
+                )
             }
         }
     }
@@ -269,7 +296,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
                     logger.warning("Location snapshot upload attempt failed; retrying")
                 }
             } catch is CancellationError {
-                logger.debug("Location snapshot upload cancelled")
+                logger.notice("Location upload cancelled source=\(payload.source, privacy: .public)")
                 return false
             } catch {
                 let isFinalAttempt = index == retryDelaysSeconds.count - 1

--- a/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
+++ b/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
@@ -11,17 +11,6 @@ import OSLog
 import UIKit
 import ArcusCore
 
-enum LocationUploadSource: String, Sendable, Codable {
-    case foregroundPrime
-    case foregroundActivate
-    case foregroundLocationChange
-    case manualRefresh
-    case backgroundRefresh
-    case backgroundLocationChange
-    case onboarding
-    case settingsPreference
-}
-
 enum LocationUploadReason: String, Sendable, Codable, Equatable {
     case locationResolved
     case locationChanged

--- a/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
+++ b/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
@@ -66,7 +66,8 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
     nonisolated private static let locationUploadEnabledKey = "sendL8ntoSignal"
     nonisolated private static let pendingRequestsKey = "pendingLocationUploadRequests"
 
-    private let uploader: any LocationSnapshotUploading
+    private let locationUploader: any LocationSnapshotUploading
+    private let preferenceUploader: any DevicePreferenceSyncUploading
     private let apnsTokenProvider: APNsTokenProvider
     private let installationIdProvider: InstallationIDProvider
     private let subscriptionStatusProvider: SubscriptionStatusProvider
@@ -83,6 +84,45 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
     private var lastUploadBySemanticKey: [DeduplicationKey: Date] = [:]
     private var pendingByCoalescingKey: [PendingCoalescingKey: PersistedLocationUploadRequest] = [:]
     private var hasLoadedPersistedPending = false
+
+    init(
+        locationUploader: any LocationSnapshotUploading,
+        preferenceUploader: any DevicePreferenceSyncUploading = NoOpDevicePreferenceSyncUploader(),
+        apnsTokenProvider: @escaping APNsTokenProvider = {
+            LocationSnapshotPusher.readApnsTokenFromDefaults()
+        },
+        installationIdProvider: @escaping InstallationIDProvider = {
+            InstallationIdentityStore.shared.installationId()
+        },
+        subscriptionStatusProvider: @escaping SubscriptionStatusProvider = {
+            LocationSnapshotPusher.readSubscriptionStatusFromDefaults()
+        },
+        locationUploadEnabledProvider: @escaping LocationUploadEnabledProvider = {
+            LocationSnapshotPusher.readLocationUploadEnabledFromDefaults()
+        },
+        authorizationStatusProvider: @escaping AuthorizationStatusProvider = {
+            CLLocationManager().authorizationStatus
+        },
+        nowProvider: @escaping NowProvider = { Date() },
+        retryDelaysSeconds: [UInt64] = [0, 5, 15],
+        dedupeWindowSeconds: TimeInterval = 15,
+        queueStore: (any LocationUploadQueueStoring)? = nil
+    ) {
+        self.locationUploader = locationUploader
+        self.preferenceUploader = preferenceUploader
+        self.apnsTokenProvider = apnsTokenProvider
+        self.installationIdProvider = installationIdProvider
+        self.subscriptionStatusProvider = subscriptionStatusProvider
+        self.locationUploadEnabledProvider = locationUploadEnabledProvider
+        self.authorizationStatusProvider = authorizationStatusProvider
+        self.nowProvider = nowProvider
+        self.retryDelaysSeconds = retryDelaysSeconds
+        self.dedupeWindowSeconds = dedupeWindowSeconds
+        self.queueStore = queueStore ?? UserDefaultsLocationUploadQueueStore(
+            suiteName: Self.userDefaultsSuiteName,
+            key: Self.pendingRequestsKey
+        )
+    }
 
     init(
         uploader: any LocationSnapshotUploading,
@@ -106,18 +146,18 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         dedupeWindowSeconds: TimeInterval = 15,
         queueStore: (any LocationUploadQueueStoring)? = nil
     ) {
-        self.uploader = uploader
-        self.apnsTokenProvider = apnsTokenProvider
-        self.installationIdProvider = installationIdProvider
-        self.subscriptionStatusProvider = subscriptionStatusProvider
-        self.locationUploadEnabledProvider = locationUploadEnabledProvider
-        self.authorizationStatusProvider = authorizationStatusProvider
-        self.nowProvider = nowProvider
-        self.retryDelaysSeconds = retryDelaysSeconds
-        self.dedupeWindowSeconds = dedupeWindowSeconds
-        self.queueStore = queueStore ?? UserDefaultsLocationUploadQueueStore(
-            suiteName: Self.userDefaultsSuiteName,
-            key: Self.pendingRequestsKey
+        self.init(
+            locationUploader: uploader,
+            preferenceUploader: NoOpDevicePreferenceSyncUploader(),
+            apnsTokenProvider: apnsTokenProvider,
+            installationIdProvider: installationIdProvider,
+            subscriptionStatusProvider: subscriptionStatusProvider,
+            locationUploadEnabledProvider: locationUploadEnabledProvider,
+            authorizationStatusProvider: authorizationStatusProvider,
+            nowProvider: nowProvider,
+            retryDelaysSeconds: retryDelaysSeconds,
+            dedupeWindowSeconds: dedupeWindowSeconds,
+            queueStore: queueStore
         )
     }
 
@@ -144,7 +184,6 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         let authorizationStatus = authorizationStatusProvider()
         let now = nowProvider()
         let persisted = PersistedLocationUploadRequest(
-            context: PersistedLocationContext(context),
             source: source,
             reason: reason,
             forceUpload: forceUpload,
@@ -152,7 +191,8 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
             requestedAt: now,
             isSubscribed: isSubscribed,
             authorizationState: Self.authorizationName(for: authorizationStatus),
-            apnsToken: apnsToken
+            apnsToken: apnsToken,
+            operation: .locationSnapshot(context: PersistedLocationContext(context))
         )
 
         guard !apnsToken.isEmpty else {
@@ -165,10 +205,12 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         let dedupeKey = DeduplicationKey(
             installationId: installationId,
             apnsToken: apnsToken,
-            h3Cell: context.h3Cell,
-            county: context.grid.countyCode,
-            fireZone: context.grid.fireZone,
-            forecastZone: context.grid.forecastZone,
+            operation: .locationSnapshot(
+                h3Cell: context.h3Cell,
+                county: context.grid.countyCode,
+                fireZone: context.grid.fireZone,
+                forecastZone: context.grid.forecastZone
+            ),
             isSubscribed: isSubscribed,
             authorizationState: Self.authorizationName(for: authorizationStatus),
             forceUpload: forceUpload
@@ -179,7 +221,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
             )
             return
         }
-        let payload = await makePayload(
+        let payload = await makeLocationPayload(
             from: persisted,
             apnsToken: apnsToken,
             isSubscribed: isSubscribed,
@@ -194,7 +236,14 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
             await upsertPending(persisted)
         }
 
-        queue.append(QueuedUpload(payload: payload, coalescingKey: coalescingKey, reason: reason))
+        queue.append(
+            QueuedUpload(
+                operation: .locationSnapshot(payload),
+                coalescingKey: coalescingKey,
+                reason: reason,
+                source: source.rawValue
+            )
+        )
         lastUploadBySemanticKey[dedupeKey] = now
 
         guard !isProcessing else { return }
@@ -224,7 +273,6 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         let authorizationStatus = authorizationStatusProvider()
         let now = nowProvider()
         let persisted = PersistedLocationUploadRequest(
-            context: nil,
             source: source,
             reason: requestReason,
             forceUpload: forceUpload,
@@ -232,7 +280,8 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
             requestedAt: now,
             isSubscribed: isSubscribed,
             authorizationState: Self.authorizationName(for: authorizationStatus),
-            apnsToken: apnsToken
+            apnsToken: apnsToken,
+            operation: .preferenceSync
         )
 
         guard !apnsToken.isEmpty else {
@@ -246,10 +295,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         let dedupeKey = DeduplicationKey(
             installationId: installationId,
             apnsToken: apnsToken,
-            h3Cell: nil,
-            county: nil,
-            fireZone: nil,
-            forecastZone: nil,
+            operation: .preferenceSync,
             isSubscribed: isSubscribed,
             authorizationState: Self.authorizationName(for: authorizationStatus),
             forceUpload: forceUpload
@@ -261,12 +307,11 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
             return
         }
 
-        let payload = await makePayload(
+        let payload = await makePreferencePayload(
             from: persisted,
             apnsToken: apnsToken,
             isSubscribed: isSubscribed,
-            authorizationState: Self.authorizationName(for: authorizationStatus),
-            now: now
+            authorizationState: Self.authorizationName(for: authorizationStatus)
         )
         let coalescingKey = coalescingKey(for: persisted)
         if pendingByCoalescingKey[coalescingKey] == nil {
@@ -276,7 +321,14 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
             await upsertPending(persisted)
         }
 
-        queue.append(QueuedUpload(payload: payload, coalescingKey: coalescingKey, reason: requestReason))
+        queue.append(
+            QueuedUpload(
+                operation: .preferenceSync(payload),
+                coalescingKey: coalescingKey,
+                reason: requestReason,
+                source: source.rawValue
+            )
+        )
         lastUploadBySemanticKey[dedupeKey] = now
 
         guard !isProcessing else { return }
@@ -302,10 +354,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
             let dedupeKey = DeduplicationKey(
                 installationId: pending.installationId,
                 apnsToken: apnsToken,
-                h3Cell: pending.context?.h3Cell,
-                county: pending.context?.county,
-                fireZone: pending.context?.fireZone,
-                forecastZone: pending.context?.forecastZone,
+                operation: pending.operation.deduplicationOperation,
                 isSubscribed: pending.isSubscribed,
                 authorizationState: pending.authorizationState,
                 forceUpload: pending.forceUpload
@@ -316,20 +365,39 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
                 await persistPendingState()
                 continue
             }
-            let payload = await makePayload(
-                from: pending,
-                apnsToken: apnsToken,
-                isSubscribed: pending.isSubscribed,
-                authorizationState: pending.authorizationState,
-                now: now
-            )
-            queue.append(
-                QueuedUpload(
-                    payload: payload,
-                    coalescingKey: coalescingKey(for: pending),
-                    reason: pending.reason
+            switch pending.operation {
+            case .locationSnapshot:
+                let payload = await makeLocationPayload(
+                    from: pending,
+                    apnsToken: apnsToken,
+                    isSubscribed: pending.isSubscribed,
+                    authorizationState: pending.authorizationState,
+                    now: now
                 )
-            )
+                queue.append(
+                    QueuedUpload(
+                        operation: .locationSnapshot(payload),
+                        coalescingKey: coalescingKey(for: pending),
+                        reason: pending.reason,
+                        source: pending.source.rawValue
+                    )
+                )
+            case .preferenceSync:
+                let payload = await makePreferencePayload(
+                    from: pending,
+                    apnsToken: apnsToken,
+                    isSubscribed: pending.isSubscribed,
+                    authorizationState: pending.authorizationState
+                )
+                queue.append(
+                    QueuedUpload(
+                        operation: .preferenceSync(payload),
+                        coalescingKey: coalescingKey(for: pending),
+                        reason: pending.reason,
+                        source: pending.source.rawValue
+                    )
+                )
+            }
             enqueuedCount += 1
             lastUploadBySemanticKey[dedupeKey] = now
         }
@@ -371,16 +439,16 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
                 return
             }
             let workItem = queue.removeFirst()
-            let didUpload = await uploadWithRetry(workItem.payload, reason: workItem.reason)
+            let didUpload = await uploadWithRetry(workItem)
             if didUpload {
                 logger.notice(
-                    "Location upload succeeded source=\(workItem.payload.source, privacy: .public) reason=\(workItem.reason.rawValue, privacy: .public)"
+                    "Location upload succeeded source=\(workItem.source, privacy: .public) reason=\(workItem.reason.rawValue, privacy: .public)"
                 )
                 pendingByCoalescingKey.removeValue(forKey: workItem.coalescingKey)
                 await persistPendingState()
             } else {
                 logger.error(
-                    "Location upload failed source=\(workItem.payload.source, privacy: .public) reason=\(workItem.reason.rawValue, privacy: .public)"
+                    "Location upload failed source=\(workItem.source, privacy: .public) reason=\(workItem.reason.rawValue, privacy: .public)"
                 )
                 if Task.isCancelled {
                     logger.notice("Location upload queue drain stopped after cancellation")
@@ -390,12 +458,12 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         }
     }
 
-    private func uploadWithRetry(_ payload: LocationSnapshotPushPayload, reason: LocationUploadReason) async -> Bool {
+    private func uploadWithRetry(_ workItem: QueuedUpload) async -> Bool {
         for (index, delay) in retryDelaysSeconds.enumerated() {
             do {
                 try Task.checkCancellation()
             } catch is CancellationError {
-                logger.notice("Location upload cancelled before attempt source=\(payload.source, privacy: .public) reason=\(reason.rawValue, privacy: .public)")
+                logger.notice("Location upload cancelled before attempt source=\(workItem.source, privacy: .public) reason=\(workItem.reason.rawValue, privacy: .public)")
                 return false
             } catch {
                 return false
@@ -406,34 +474,41 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
                     try await Task.sleep(for: .seconds(Int(delay)))
                     try Task.checkCancellation()
                 } catch is CancellationError {
-                    logger.notice("Location upload cancelled during retry backoff source=\(payload.source, privacy: .public) reason=\(reason.rawValue, privacy: .public)")
+                    logger.notice("Location upload cancelled during retry backoff source=\(workItem.source, privacy: .public) reason=\(workItem.reason.rawValue, privacy: .public)")
                     return false
                 } catch {
                     return false
                 }
             }
             do {
-                try await uploader.upload(payload)
+                switch workItem.operation {
+                case .locationSnapshot(let payload):
+                    try await locationUploader.upload(payload)
+                case .preferenceSync(let payload):
+                    try await preferenceUploader.upload(payload)
+                }
                 return true
             } catch let error as LocationPushError {
-                if await uploadWithLegacySourceFallbackIfNeeded(for: payload, error: error) {
-                    return true
+                if case .locationSnapshot(let payload) = workItem.operation {
+                    if await uploadWithLegacySourceFallbackIfNeeded(for: payload, error: error) {
+                        return true
+                    }
                 }
                 let isFinalAttempt = index == retryDelaysSeconds.count - 1
                 if isFinalAttempt {
-                    logger.error("Location snapshot upload failed after retries: \(error.localizedDescription, privacy: .public)")
+                    logger.error("Upload failed after retries: \(error.localizedDescription, privacy: .public)")
                 } else {
-                    logger.warning("Location snapshot upload attempt failed; retrying")
+                    logger.warning("Upload attempt failed; retrying")
                 }
             } catch is CancellationError {
-                logger.notice("Location upload cancelled source=\(payload.source, privacy: .public) reason=\(reason.rawValue, privacy: .public)")
+                logger.notice("Location upload cancelled source=\(workItem.source, privacy: .public) reason=\(workItem.reason.rawValue, privacy: .public)")
                 return false
             } catch {
                 let isFinalAttempt = index == retryDelaysSeconds.count - 1
                 if isFinalAttempt {
-                    logger.error("Location snapshot upload failed after retries: \(error.localizedDescription, privacy: .public)")
+                    logger.error("Upload failed after retries: \(error.localizedDescription, privacy: .public)")
                 } else {
-                    logger.warning("Location snapshot upload attempt failed; retrying")
+                    logger.warning("Upload attempt failed; retrying")
                 }
             }
         }
@@ -474,7 +549,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         )
 
         do {
-            try await uploader.upload(fallbackPayload)
+            try await locationUploader.upload(fallbackPayload)
             logger.notice("Location snapshot upload succeeded with legacy source fallback")
             return true
         } catch {
@@ -482,27 +557,30 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         }
     }
 
-    private func makePayload(
+    private func makeLocationPayload(
         from request: PersistedLocationUploadRequest,
         apnsToken: String,
         isSubscribed: Bool,
         authorizationState: String,
         now: Date
     ) async -> LocationSnapshotPushPayload {
-        let capturedAt = request.context?.capturedAt ?? request.requestedAt
-        let locationAgeSeconds = request.context.map { now.timeIntervalSince($0.capturedAt) } ?? 0
-        let horizontalAccuracyMeters = request.context?.horizontalAccuracyMeters ?? 0
+        guard case .locationSnapshot(let context) = request.operation else {
+            preconditionFailure("Location payload requested for non-location operation")
+        }
+        let capturedAt = context.capturedAt
+        let locationAgeSeconds = now.timeIntervalSince(context.capturedAt)
+        let horizontalAccuracyMeters = context.horizontalAccuracyMeters
 
         return LocationSnapshotPushPayload(
             capturedAt: capturedAt,
             locationAgeSeconds: locationAgeSeconds,
             horizontalAccuracyMeters: horizontalAccuracyMeters,
             cellScheme: "h3",
-            h3Cell: request.context?.h3Cell,
-            h3Resolution: request.context == nil ? nil : 8,
-            county: request.context?.county,
-            zone: request.context?.forecastZone,
-            fireZone: request.context?.fireZone,
+            h3Cell: context.h3Cell,
+            h3Resolution: 8,
+            county: context.county,
+            zone: context.forecastZone,
+            fireZone: context.fireZone,
             apnsDeviceToken: apnsToken,
             installationId: request.installationId,
             source: request.source.rawValue,
@@ -518,9 +596,36 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
                 return "prod"
                 #endif
             }(),
-            countyLabel: request.context?.countyLabel,
-            fireZoneLabel: request.context?.fireZoneLabel,
+            countyLabel: context.countyLabel,
+            fireZoneLabel: context.fireZoneLabel,
             isSubscribed: isSubscribed
+        )
+    }
+
+    private func makePreferencePayload(
+        from request: PersistedLocationUploadRequest,
+        apnsToken: String,
+        isSubscribed: Bool,
+        authorizationState: String
+    ) async -> DevicePreferenceSyncPayload {
+        DevicePreferenceSyncPayload(
+            installationId: request.installationId,
+            apnsDeviceToken: apnsToken,
+            apnsEnvironment: {
+                #if DEBUG
+                return "sandbox"
+                #else
+                return "prod"
+                #endif
+            }(),
+            platform: "iOS",
+            osVersion: await UIDevice.current.systemVersion,
+            appVersion: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "",
+            buildNumber: Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "",
+            auth: authorizationState,
+            isSubscribed: isSubscribed,
+            source: request.source.rawValue,
+            reason: request.reason.rawValue
         )
     }
 
@@ -547,10 +652,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         PendingCoalescingKey(
             installationId: request.installationId,
             apnsToken: request.apnsToken,
-            h3Cell: request.context?.h3Cell,
-            county: request.context?.county,
-            fireZone: request.context?.fireZone,
-            forecastZone: request.context?.forecastZone,
+            operation: request.operation.deduplicationOperation,
             isSubscribed: request.isSubscribed,
             authorizationState: request.authorizationState,
             forceUpload: request.forceUpload
@@ -581,10 +683,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
     private struct DeduplicationKey: Hashable {
         let installationId: String
         let apnsToken: String
-        let h3Cell: Int64?
-        let county: String?
-        let fireZone: String?
-        let forecastZone: String?
+        let operation: PendingDeduplicationOperation
         let isSubscribed: Bool
         let authorizationState: String
         let forceUpload: Bool
@@ -593,19 +692,17 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
     private struct PendingCoalescingKey: Hashable, Codable {
         let installationId: String
         let apnsToken: String
-        let h3Cell: Int64?
-        let county: String?
-        let fireZone: String?
-        let forecastZone: String?
+        let operation: PendingDeduplicationOperation
         let isSubscribed: Bool
         let authorizationState: String
         let forceUpload: Bool
     }
 
     private struct QueuedUpload {
-        let payload: LocationSnapshotPushPayload
+        let operation: QueuedOperation
         let coalescingKey: PendingCoalescingKey
         let reason: LocationUploadReason
+        let source: String
     }
 }
 
@@ -615,7 +712,6 @@ protocol LocationUploadQueueStoring: Sendable {
 }
 
 struct PersistedLocationUploadRequest: Sendable, Codable, Equatable {
-    let context: PersistedLocationContext?
     let source: LocationUploadSource
     let reason: LocationUploadReason
     let forceUpload: Bool
@@ -624,6 +720,137 @@ struct PersistedLocationUploadRequest: Sendable, Codable, Equatable {
     let isSubscribed: Bool
     let authorizationState: String
     let apnsToken: String
+    let operation: PersistedUploadOperation
+
+    enum CodingKeys: String, CodingKey {
+        case source
+        case reason
+        case forceUpload
+        case installationId
+        case requestedAt
+        case isSubscribed
+        case authorizationState
+        case apnsToken
+        case operation
+        case context
+    }
+
+    init(
+        source: LocationUploadSource,
+        reason: LocationUploadReason,
+        forceUpload: Bool,
+        installationId: String,
+        requestedAt: Date,
+        isSubscribed: Bool,
+        authorizationState: String,
+        apnsToken: String,
+        operation: PersistedUploadOperation
+    ) {
+        self.source = source
+        self.reason = reason
+        self.forceUpload = forceUpload
+        self.installationId = installationId
+        self.requestedAt = requestedAt
+        self.isSubscribed = isSubscribed
+        self.authorizationState = authorizationState
+        self.apnsToken = apnsToken
+        self.operation = operation
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        source = try container.decode(LocationUploadSource.self, forKey: .source)
+        reason = try container.decode(LocationUploadReason.self, forKey: .reason)
+        forceUpload = try container.decode(Bool.self, forKey: .forceUpload)
+        installationId = try container.decode(String.self, forKey: .installationId)
+        requestedAt = try container.decode(Date.self, forKey: .requestedAt)
+        isSubscribed = try container.decode(Bool.self, forKey: .isSubscribed)
+        authorizationState = try container.decode(String.self, forKey: .authorizationState)
+        apnsToken = try container.decode(String.self, forKey: .apnsToken)
+
+        if let operation = try container.decodeIfPresent(PersistedUploadOperation.self, forKey: .operation) {
+            self.operation = operation
+        } else if let context = try container.decodeIfPresent(PersistedLocationContext.self, forKey: .context) {
+            self.operation = .locationSnapshot(context: context)
+        } else {
+            self.operation = .preferenceSync
+        }
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(source, forKey: .source)
+        try container.encode(reason, forKey: .reason)
+        try container.encode(forceUpload, forKey: .forceUpload)
+        try container.encode(installationId, forKey: .installationId)
+        try container.encode(requestedAt, forKey: .requestedAt)
+        try container.encode(isSubscribed, forKey: .isSubscribed)
+        try container.encode(authorizationState, forKey: .authorizationState)
+        try container.encode(apnsToken, forKey: .apnsToken)
+        try container.encode(operation, forKey: .operation)
+    }
+}
+
+enum PersistedUploadOperation: Sendable, Codable, Equatable {
+    case locationSnapshot(context: PersistedLocationContext)
+    case preferenceSync
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case context
+    }
+
+    enum Kind: String, Codable {
+        case locationSnapshot
+        case preferenceSync
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .locationSnapshot:
+            let context = try container.decode(PersistedLocationContext.self, forKey: .context)
+            self = .locationSnapshot(context: context)
+        case .preferenceSync:
+            self = .preferenceSync
+        }
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .locationSnapshot(let context):
+            try container.encode(Kind.locationSnapshot, forKey: .kind)
+            try container.encode(context, forKey: .context)
+        case .preferenceSync:
+            try container.encode(Kind.preferenceSync, forKey: .kind)
+        }
+    }
+
+    var deduplicationOperation: PendingDeduplicationOperation {
+        switch self {
+        case .locationSnapshot(let context):
+            return .locationSnapshot(
+                h3Cell: context.h3Cell,
+                county: context.county,
+                fireZone: context.fireZone,
+                forecastZone: context.forecastZone
+            )
+        case .preferenceSync:
+            return .preferenceSync
+        }
+    }
+}
+
+enum PendingDeduplicationOperation: Sendable, Codable, Hashable {
+    case locationSnapshot(h3Cell: Int64, county: String?, fireZone: String?, forecastZone: String?)
+    case preferenceSync
+}
+
+enum QueuedOperation: Sendable {
+    case locationSnapshot(LocationSnapshotPushPayload)
+    case preferenceSync(DevicePreferenceSyncPayload)
 }
 
 struct PersistedLocationContext: Sendable, Codable, Equatable {

--- a/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
+++ b/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
@@ -83,6 +83,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
     private var isProcessing = false
     private var lastUploadBySemanticKey: [DeduplicationKey: Date] = [:]
     private var pendingByCoalescingKey: [PendingCoalescingKey: PersistedLocationUploadRequest] = [:]
+    private var queuedOrActiveCoalescingKeys: Set<PendingCoalescingKey> = []
     private var hasLoadedPersistedPending = false
 
     init(
@@ -235,16 +236,15 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
             )
             await upsertPending(persisted)
         }
-
-        queue.append(
+        guard enqueueIfNotQueuedOrActive(
             QueuedUpload(
                 operation: .locationSnapshot(payload),
                 coalescingKey: coalescingKey,
+                semanticDedupeKey: dedupeKey,
                 reason: reason,
                 source: source.rawValue
             )
-        )
-        lastUploadBySemanticKey[dedupeKey] = now
+        ) else { return }
 
         guard !isProcessing else { return }
         await processQueue()
@@ -320,16 +320,15 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
             )
             await upsertPending(persisted)
         }
-
-        queue.append(
+        guard enqueueIfNotQueuedOrActive(
             QueuedUpload(
                 operation: .preferenceSync(payload),
                 coalescingKey: coalescingKey,
+                semanticDedupeKey: dedupeKey,
                 reason: requestReason,
                 source: source.rawValue
             )
-        )
-        lastUploadBySemanticKey[dedupeKey] = now
+        ) else { return }
 
         guard !isProcessing else { return }
         await processQueue()
@@ -374,14 +373,17 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
                     authorizationState: pending.authorizationState,
                     now: now
                 )
-                queue.append(
+                if enqueueIfNotQueuedOrActive(
                     QueuedUpload(
                         operation: .locationSnapshot(payload),
                         coalescingKey: coalescingKey(for: pending),
+                        semanticDedupeKey: dedupeKey,
                         reason: pending.reason,
                         source: pending.source.rawValue
                     )
-                )
+                ) == false {
+                    continue
+                }
             case .preferenceSync:
                 let payload = await makePreferencePayload(
                     from: pending,
@@ -389,17 +391,19 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
                     isSubscribed: pending.isSubscribed,
                     authorizationState: pending.authorizationState
                 )
-                queue.append(
+                if enqueueIfNotQueuedOrActive(
                     QueuedUpload(
                         operation: .preferenceSync(payload),
                         coalescingKey: coalescingKey(for: pending),
+                        semanticDedupeKey: dedupeKey,
                         reason: pending.reason,
                         source: pending.source.rawValue
                     )
-                )
+                ) == false {
+                    continue
+                }
             }
             enqueuedCount += 1
-            lastUploadBySemanticKey[dedupeKey] = now
         }
         logger.info(
             "Location upload drain completed enqueued=\(enqueuedCount, privacy: .public) deduped=\(dedupedCount, privacy: .public) remainingPending=\(self.pendingByCoalescingKey.count, privacy: .public)"
@@ -439,11 +443,15 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
                 return
             }
             let workItem = queue.removeFirst()
+            defer { queuedOrActiveCoalescingKeys.remove(workItem.coalescingKey) }
             let didUpload = await uploadWithRetry(workItem)
             if didUpload {
                 logger.notice(
                     "Location upload succeeded source=\(workItem.source, privacy: .public) reason=\(workItem.reason.rawValue, privacy: .public)"
                 )
+                if let semanticDedupeKey = workItem.semanticDedupeKey {
+                    lastUploadBySemanticKey[semanticDedupeKey] = nowProvider()
+                }
                 pendingByCoalescingKey.removeValue(forKey: workItem.coalescingKey)
                 await persistPendingState()
             } else {
@@ -456,6 +464,13 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
                 }
             }
         }
+    }
+
+    private func enqueueIfNotQueuedOrActive(_ workItem: QueuedUpload) -> Bool {
+        let inserted = queuedOrActiveCoalescingKeys.insert(workItem.coalescingKey).inserted
+        guard inserted else { return false }
+        queue.append(workItem)
+        return true
     }
 
     private func uploadWithRetry(_ workItem: QueuedUpload) async -> Bool {
@@ -701,6 +716,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
     private struct QueuedUpload {
         let operation: QueuedOperation
         let coalescingKey: PendingCoalescingKey
+        let semanticDedupeKey: DeduplicationKey?
         let reason: LocationUploadReason
         let source: String
     }

--- a/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
+++ b/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
@@ -22,23 +22,42 @@ enum LocationUploadSource: String, Sendable, Codable {
     case settingsPreference
 }
 
+enum LocationUploadReason: String, Sendable, Codable, Equatable {
+    case locationResolved
+    case locationChanged
+    case preferenceChanged
+    case tokenBecameAvailable
+    case retry
+}
+
 protocol PendingLocationUploadDraining: Sendable {
     func drainPendingUploads() async
 }
 
 protocol LocationUploadCoordinating: PendingLocationUploadDraining, Sendable {
-    func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool) async
-    func enqueuePreferenceSync(source: LocationUploadSource, forceUpload: Bool, reason: String) async
+    func enqueue(
+        _ context: LocationContext,
+        source: LocationUploadSource,
+        reason: LocationUploadReason,
+        forceUpload: Bool
+    ) async
+    func enqueuePreferenceSync(
+        source: LocationUploadSource,
+        requestReason: LocationUploadReason,
+        forceUpload: Bool,
+        detail: String
+    ) async
 }
 
 extension LocationUploadCoordinating {
-    func enqueue(_ context: LocationContext, source: LocationUploadSource) async {
-        await enqueue(context, source: source, forceUpload: false)
-    }
-
     func drainPendingUploads() async {}
 
-    func enqueuePreferenceSync(source: LocationUploadSource, forceUpload: Bool, reason: String) async {}
+    func enqueuePreferenceSync(
+        source: LocationUploadSource,
+        requestReason: LocationUploadReason,
+        forceUpload: Bool,
+        detail: String
+    ) async {}
 }
 
 enum LocationPushError: Error {
@@ -113,13 +132,18 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         )
     }
 
-    func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool = false) async {
+    func enqueue(
+        _ context: LocationContext,
+        source: LocationUploadSource,
+        reason: LocationUploadReason,
+        forceUpload: Bool = false
+    ) async {
         logger.info(
-            "Location upload request accepted source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public)"
+            "Location upload request accepted source=\(source.rawValue, privacy: .public) reason=\(reason.rawValue, privacy: .public) force=\(forceUpload, privacy: .public)"
         )
         guard forceUpload || locationUploadEnabledProvider() else {
             logger.notice(
-                "Location upload request skipped reason=disabled source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public)"
+                "Location upload request skipped skipReason=disabled source=\(source.rawValue, privacy: .public) reason=\(reason.rawValue, privacy: .public) force=\(forceUpload, privacy: .public)"
             )
             return
         }
@@ -133,6 +157,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         let persisted = PersistedLocationUploadRequest(
             context: PersistedLocationContext(context),
             source: source,
+            reason: reason,
             forceUpload: forceUpload,
             installationId: installationId,
             requestedAt: now,
@@ -143,7 +168,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
 
         guard !apnsToken.isEmpty else {
             logger.notice(
-                "Location upload request persisted reason=missingToken source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public)"
+                "Location upload request persisted persistReason=missingToken source=\(source.rawValue, privacy: .public) reason=\(reason.rawValue, privacy: .public) force=\(forceUpload, privacy: .public)"
             )
             await upsertPending(persisted)
             return
@@ -161,7 +186,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         )
         if shouldDedupeRequest(for: dedupeKey, now: now) {
             logger.notice(
-                "Location upload request deduped source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public)"
+                "Location upload request deduped source=\(source.rawValue, privacy: .public) reason=\(reason.rawValue, privacy: .public) force=\(forceUpload, privacy: .public)"
             )
             return
         }
@@ -175,25 +200,30 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         let coalescingKey = coalescingKey(for: persisted)
         if pendingByCoalescingKey[coalescingKey] == nil {
             logger.debug(
-                "Location upload request persisted reason=queued source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public)"
+                "Location upload request persisted persistReason=queued source=\(source.rawValue, privacy: .public) reason=\(reason.rawValue, privacy: .public) force=\(forceUpload, privacy: .public)"
             )
             await upsertPending(persisted)
         }
 
-        queue.append(QueuedUpload(payload: payload, coalescingKey: coalescingKey))
+        queue.append(QueuedUpload(payload: payload, coalescingKey: coalescingKey, reason: reason))
         lastUploadBySemanticKey[dedupeKey] = now
 
         guard !isProcessing else { return }
         await processQueue()
     }
 
-    func enqueuePreferenceSync(source: LocationUploadSource, forceUpload: Bool, reason: String) async {
+    func enqueuePreferenceSync(
+        source: LocationUploadSource,
+        requestReason: LocationUploadReason,
+        forceUpload: Bool,
+        detail: String
+    ) async {
         logger.info(
-            "Preference sync request accepted source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public) reason=\(reason, privacy: .public)"
+            "Preference sync request accepted source=\(source.rawValue, privacy: .public) reason=\(requestReason.rawValue, privacy: .public) force=\(forceUpload, privacy: .public) detail=\(detail, privacy: .public)"
         )
         guard forceUpload || locationUploadEnabledProvider() else {
             logger.notice(
-                "Preference sync request skipped reason=disabled source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public)"
+                "Preference sync request skipped skipReason=disabled source=\(source.rawValue, privacy: .public) reason=\(requestReason.rawValue, privacy: .public) force=\(forceUpload, privacy: .public) detail=\(detail, privacy: .public)"
             )
             return
         }
@@ -207,6 +237,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         let persisted = PersistedLocationUploadRequest(
             context: nil,
             source: source,
+            reason: requestReason,
             forceUpload: forceUpload,
             installationId: installationId,
             requestedAt: now,
@@ -217,7 +248,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
 
         guard !apnsToken.isEmpty else {
             logger.notice(
-                "Preference sync request persisted reason=missingToken source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public) reason=\(reason, privacy: .public)"
+                "Preference sync request persisted persistReason=missingToken source=\(source.rawValue, privacy: .public) reason=\(requestReason.rawValue, privacy: .public) force=\(forceUpload, privacy: .public) detail=\(detail, privacy: .public)"
             )
             await upsertPending(persisted)
             return
@@ -236,7 +267,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         )
         if shouldDedupeRequest(for: dedupeKey, now: now) {
             logger.notice(
-                "Preference sync request deduped source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public) reason=\(reason, privacy: .public)"
+                "Preference sync request deduped source=\(source.rawValue, privacy: .public) reason=\(requestReason.rawValue, privacy: .public) force=\(forceUpload, privacy: .public) detail=\(detail, privacy: .public)"
             )
             return
         }
@@ -251,12 +282,12 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         let coalescingKey = coalescingKey(for: persisted)
         if pendingByCoalescingKey[coalescingKey] == nil {
             logger.debug(
-                "Preference sync request persisted reason=queued source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public) reason=\(reason, privacy: .public)"
+                "Preference sync request persisted persistReason=queued source=\(source.rawValue, privacy: .public) reason=\(requestReason.rawValue, privacy: .public) force=\(forceUpload, privacy: .public) detail=\(detail, privacy: .public)"
             )
             await upsertPending(persisted)
         }
 
-        queue.append(QueuedUpload(payload: payload, coalescingKey: coalescingKey))
+        queue.append(QueuedUpload(payload: payload, coalescingKey: coalescingKey, reason: requestReason))
         lastUploadBySemanticKey[dedupeKey] = now
 
         guard !isProcessing else { return }
@@ -303,7 +334,13 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
                 authorizationState: pending.authorizationState,
                 now: now
             )
-            queue.append(QueuedUpload(payload: payload, coalescingKey: coalescingKey(for: pending)))
+            queue.append(
+                QueuedUpload(
+                    payload: payload,
+                    coalescingKey: coalescingKey(for: pending),
+                    reason: pending.reason
+                )
+            )
             enqueuedCount += 1
             lastUploadBySemanticKey[dedupeKey] = now
         }
@@ -345,16 +382,16 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
                 return
             }
             let workItem = queue.removeFirst()
-            let didUpload = await uploadWithRetry(workItem.payload)
+            let didUpload = await uploadWithRetry(workItem.payload, reason: workItem.reason)
             if didUpload {
                 logger.notice(
-                    "Location upload succeeded source=\(workItem.payload.source, privacy: .public)"
+                    "Location upload succeeded source=\(workItem.payload.source, privacy: .public) reason=\(workItem.reason.rawValue, privacy: .public)"
                 )
                 pendingByCoalescingKey.removeValue(forKey: workItem.coalescingKey)
                 await persistPendingState()
             } else {
                 logger.error(
-                    "Location upload failed source=\(workItem.payload.source, privacy: .public)"
+                    "Location upload failed source=\(workItem.payload.source, privacy: .public) reason=\(workItem.reason.rawValue, privacy: .public)"
                 )
                 if Task.isCancelled {
                     logger.notice("Location upload queue drain stopped after cancellation")
@@ -364,12 +401,12 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         }
     }
 
-    private func uploadWithRetry(_ payload: LocationSnapshotPushPayload) async -> Bool {
+    private func uploadWithRetry(_ payload: LocationSnapshotPushPayload, reason: LocationUploadReason) async -> Bool {
         for (index, delay) in retryDelaysSeconds.enumerated() {
             do {
                 try Task.checkCancellation()
             } catch is CancellationError {
-                logger.notice("Location upload cancelled before attempt source=\(payload.source, privacy: .public)")
+                logger.notice("Location upload cancelled before attempt source=\(payload.source, privacy: .public) reason=\(reason.rawValue, privacy: .public)")
                 return false
             } catch {
                 return false
@@ -380,7 +417,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
                     try await Task.sleep(for: .seconds(Int(delay)))
                     try Task.checkCancellation()
                 } catch is CancellationError {
-                    logger.notice("Location upload cancelled during retry backoff source=\(payload.source, privacy: .public)")
+                    logger.notice("Location upload cancelled during retry backoff source=\(payload.source, privacy: .public) reason=\(reason.rawValue, privacy: .public)")
                     return false
                 } catch {
                     return false
@@ -400,7 +437,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
                     logger.warning("Location snapshot upload attempt failed; retrying")
                 }
             } catch is CancellationError {
-                logger.notice("Location upload cancelled source=\(payload.source, privacy: .public)")
+                logger.notice("Location upload cancelled source=\(payload.source, privacy: .public) reason=\(reason.rawValue, privacy: .public)")
                 return false
             } catch {
                 let isFinalAttempt = index == retryDelaysSeconds.count - 1
@@ -579,6 +616,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
     private struct QueuedUpload {
         let payload: LocationSnapshotPushPayload
         let coalescingKey: PendingCoalescingKey
+        let reason: LocationUploadReason
     }
 }
 
@@ -590,6 +628,7 @@ protocol LocationUploadQueueStoring: Sendable {
 struct PersistedLocationUploadRequest: Sendable, Codable, Equatable {
     let context: PersistedLocationContext?
     let source: LocationUploadSource
+    let reason: LocationUploadReason
     let forceUpload: Bool
     let installationId: String
     let requestedAt: Date

--- a/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
+++ b/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
@@ -666,7 +666,6 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
     private func coalescingKey(for request: PersistedLocationUploadRequest) -> PendingCoalescingKey {
         PendingCoalescingKey(
             installationId: request.installationId,
-            apnsToken: request.apnsToken,
             operation: request.operation.deduplicationOperation,
             isSubscribed: request.isSubscribed,
             authorizationState: request.authorizationState,
@@ -706,7 +705,6 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
 
     private struct PendingCoalescingKey: Hashable, Codable {
         let installationId: String
-        let apnsToken: String
         let operation: PendingDeduplicationOperation
         let isSubscribed: Bool
         let authorizationState: String

--- a/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
+++ b/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
@@ -28,6 +28,7 @@ protocol PendingLocationUploadDraining: Sendable {
 
 protocol LocationUploadCoordinating: PendingLocationUploadDraining, Sendable {
     func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool) async
+    func enqueuePreferenceSync(source: LocationUploadSource, forceUpload: Bool, reason: String) async
 }
 
 extension LocationUploadCoordinating {
@@ -36,6 +37,8 @@ extension LocationUploadCoordinating {
     }
 
     func drainPendingUploads() async {}
+
+    func enqueuePreferenceSync(source: LocationUploadSource, forceUpload: Bool, reason: String) async {}
 }
 
 enum LocationPushError: Error {
@@ -184,6 +187,82 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         await processQueue()
     }
 
+    func enqueuePreferenceSync(source: LocationUploadSource, forceUpload: Bool, reason: String) async {
+        logger.info(
+            "Preference sync request accepted source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public) reason=\(reason, privacy: .public)"
+        )
+        guard forceUpload || locationUploadEnabledProvider() else {
+            logger.notice(
+                "Preference sync request skipped reason=disabled source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public)"
+            )
+            return
+        }
+
+        await ensurePersistedPendingLoaded()
+        let installationId = await installationIdProvider()
+        let apnsToken = apnsTokenProvider().trimmingCharacters(in: .whitespacesAndNewlines)
+        let isSubscribed = subscriptionStatusProvider()
+        let authorizationStatus = authorizationStatusProvider()
+        let now = nowProvider()
+        let persisted = PersistedLocationUploadRequest(
+            context: nil,
+            source: source,
+            forceUpload: forceUpload,
+            installationId: installationId,
+            requestedAt: now,
+            isSubscribed: isSubscribed,
+            authorizationState: Self.authorizationName(for: authorizationStatus),
+            apnsToken: apnsToken
+        )
+
+        guard !apnsToken.isEmpty else {
+            logger.notice(
+                "Preference sync request persisted reason=missingToken source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public) reason=\(reason, privacy: .public)"
+            )
+            await upsertPending(persisted)
+            return
+        }
+
+        let dedupeKey = DeduplicationKey(
+            installationId: installationId,
+            apnsToken: apnsToken,
+            h3Cell: nil,
+            county: nil,
+            fireZone: nil,
+            forecastZone: nil,
+            isSubscribed: isSubscribed,
+            authorizationState: Self.authorizationName(for: authorizationStatus),
+            forceUpload: forceUpload
+        )
+        if shouldDedupeRequest(for: dedupeKey, now: now) {
+            logger.notice(
+                "Preference sync request deduped source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public) reason=\(reason, privacy: .public)"
+            )
+            return
+        }
+
+        let payload = await makePayload(
+            from: persisted,
+            apnsToken: apnsToken,
+            isSubscribed: isSubscribed,
+            authorizationState: Self.authorizationName(for: authorizationStatus),
+            now: now
+        )
+        let coalescingKey = coalescingKey(for: persisted)
+        if pendingByCoalescingKey[coalescingKey] == nil {
+            logger.debug(
+                "Preference sync request persisted reason=queued source=\(source.rawValue, privacy: .public) force=\(forceUpload, privacy: .public) reason=\(reason, privacy: .public)"
+            )
+            await upsertPending(persisted)
+        }
+
+        queue.append(QueuedUpload(payload: payload, coalescingKey: coalescingKey))
+        lastUploadBySemanticKey[dedupeKey] = now
+
+        guard !isProcessing else { return }
+        await processQueue()
+    }
+
     func drainPendingUploads() async {
         await ensurePersistedPendingLoaded()
 
@@ -203,10 +282,10 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
             let dedupeKey = DeduplicationKey(
                 installationId: pending.installationId,
                 apnsToken: apnsToken,
-                h3Cell: pending.context.h3Cell,
-                county: pending.context.county,
-                fireZone: pending.context.fireZone,
-                forecastZone: pending.context.forecastZone,
+                h3Cell: pending.context?.h3Cell,
+                county: pending.context?.county,
+                fireZone: pending.context?.fireZone,
+                forecastZone: pending.context?.forecastZone,
                 isSubscribed: pending.isSubscribed,
                 authorizationState: pending.authorizationState,
                 forceUpload: pending.forceUpload
@@ -359,16 +438,20 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         authorizationState: String,
         now: Date
     ) async -> LocationSnapshotPushPayload {
-        LocationSnapshotPushPayload(
-            capturedAt: request.context.capturedAt,
-            locationAgeSeconds: now.timeIntervalSince(request.context.capturedAt),
-            horizontalAccuracyMeters: request.context.horizontalAccuracyMeters,
+        let capturedAt = request.context?.capturedAt ?? request.requestedAt
+        let locationAgeSeconds = request.context.map { now.timeIntervalSince($0.capturedAt) } ?? 0
+        let horizontalAccuracyMeters = request.context?.horizontalAccuracyMeters ?? 0
+
+        return LocationSnapshotPushPayload(
+            capturedAt: capturedAt,
+            locationAgeSeconds: locationAgeSeconds,
+            horizontalAccuracyMeters: horizontalAccuracyMeters,
             cellScheme: "h3",
-            h3Cell: request.context.h3Cell,
-            h3Resolution: 8,
-            county: request.context.county,
-            zone: request.context.forecastZone,
-            fireZone: request.context.fireZone,
+            h3Cell: request.context?.h3Cell,
+            h3Resolution: request.context == nil ? nil : 8,
+            county: request.context?.county,
+            zone: request.context?.forecastZone,
+            fireZone: request.context?.fireZone,
             apnsDeviceToken: apnsToken,
             installationId: request.installationId,
             source: request.source.rawValue,
@@ -384,8 +467,8 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
                 return "prod"
                 #endif
             }(),
-            countyLabel: request.context.countyLabel,
-            fireZoneLabel: request.context.fireZoneLabel,
+            countyLabel: request.context?.countyLabel,
+            fireZoneLabel: request.context?.fireZoneLabel,
             isSubscribed: isSubscribed
         )
     }
@@ -413,10 +496,10 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         PendingCoalescingKey(
             installationId: request.installationId,
             apnsToken: request.apnsToken,
-            h3Cell: request.context.h3Cell,
-            county: request.context.county,
-            fireZone: request.context.fireZone,
-            forecastZone: request.context.forecastZone,
+            h3Cell: request.context?.h3Cell,
+            county: request.context?.county,
+            fireZone: request.context?.fireZone,
+            forecastZone: request.context?.forecastZone,
             isSubscribed: request.isSubscribed,
             authorizationState: request.authorizationState,
             forceUpload: request.forceUpload
@@ -447,7 +530,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
     private struct DeduplicationKey: Hashable {
         let installationId: String
         let apnsToken: String
-        let h3Cell: Int64
+        let h3Cell: Int64?
         let county: String?
         let fireZone: String?
         let forecastZone: String?
@@ -459,7 +542,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
     private struct PendingCoalescingKey: Hashable, Codable {
         let installationId: String
         let apnsToken: String
-        let h3Cell: Int64
+        let h3Cell: Int64?
         let county: String?
         let fireZone: String?
         let forecastZone: String?
@@ -480,7 +563,7 @@ protocol LocationUploadQueueStoring: Sendable {
 }
 
 struct PersistedLocationUploadRequest: Sendable, Codable, Equatable {
-    let context: PersistedLocationContext
+    let context: PersistedLocationContext?
     let source: LocationUploadSource
     let forceUpload: Bool
     let installationId: String
@@ -512,8 +595,8 @@ struct PersistedLocationContext: Sendable, Codable, Equatable {
     }
 
     init(payload: LocationSnapshotPushPayload) {
-        self.capturedAt = payload.capturedAt ?? .now
-        self.horizontalAccuracyMeters = payload.horizontalAccuracyMeters ?? 0
+        self.capturedAt = payload.capturedAt
+        self.horizontalAccuracyMeters = payload.horizontalAccuracyMeters
         self.h3Cell = payload.h3Cell ?? 0
         self.county = payload.county
         self.fireZone = payload.fireZone

--- a/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
+++ b/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
@@ -41,6 +41,8 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
     typealias InstallationIDProvider = @Sendable () async -> String
     typealias SubscriptionStatusProvider = @Sendable () -> Bool
     typealias LocationUploadEnabledProvider = @Sendable () -> Bool
+    typealias AuthorizationStatusProvider = @Sendable () -> CLAuthorizationStatus
+    typealias NowProvider = @Sendable () -> Date
 
     nonisolated private static let userDefaultsSuiteName = "com.justinrooks.skyaware"
     nonisolated private static let serverNotificationEnabledKey = "serverNotificationEnabled"
@@ -51,11 +53,15 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
     private let installationIdProvider: InstallationIDProvider
     private let subscriptionStatusProvider: SubscriptionStatusProvider
     private let locationUploadEnabledProvider: LocationUploadEnabledProvider
+    private let authorizationStatusProvider: AuthorizationStatusProvider
+    private let nowProvider: NowProvider
     private let retryDelaysSeconds: [UInt64]
+    private let dedupeWindowSeconds: TimeInterval
     private let logger = Logger.locationPushPusher
 
     private var queue: [LocationSnapshotPushPayload] = []
     private var isProcessing = false
+    private var lastUploadBySemanticKey: [DeduplicationKey: Date] = [:]
 
     init(
         uploader: any LocationSnapshotUploading,
@@ -71,14 +77,22 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         locationUploadEnabledProvider: @escaping LocationUploadEnabledProvider = {
             LocationSnapshotPusher.readLocationUploadEnabledFromDefaults()
         },
-        retryDelaysSeconds: [UInt64] = [0, 5, 15]
+        authorizationStatusProvider: @escaping AuthorizationStatusProvider = {
+            CLLocationManager().authorizationStatus
+        },
+        nowProvider: @escaping NowProvider = { Date() },
+        retryDelaysSeconds: [UInt64] = [0, 5, 15],
+        dedupeWindowSeconds: TimeInterval = 15
     ) {
         self.uploader = uploader
         self.apnsTokenProvider = apnsTokenProvider
         self.installationIdProvider = installationIdProvider
         self.subscriptionStatusProvider = subscriptionStatusProvider
         self.locationUploadEnabledProvider = locationUploadEnabledProvider
+        self.authorizationStatusProvider = authorizationStatusProvider
+        self.nowProvider = nowProvider
         self.retryDelaysSeconds = retryDelaysSeconds
+        self.dedupeWindowSeconds = dedupeWindowSeconds
     }
 
     func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool = false) async {
@@ -91,13 +105,30 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         let installationId = await installationIdProvider()
         let apnsToken = apnsTokenProvider().trimmingCharacters(in: .whitespacesAndNewlines)
         let isSubscribed = subscriptionStatusProvider()
+        let authorizationStatus = authorizationStatusProvider()
+        let now = nowProvider()
         guard !apnsToken.isEmpty else {
             logger.debug("Skipping location snapshot upload; APNs token unavailable")
             return
         }
+        let dedupeKey = DeduplicationKey(
+            installationId: installationId,
+            apnsToken: apnsToken,
+            h3Cell: context.h3Cell,
+            county: context.grid.countyCode,
+            fireZone: context.grid.fireZone,
+            forecastZone: context.grid.forecastZone,
+            isSubscribed: isSubscribed,
+            authorizationState: Self.authorizationName(for: authorizationStatus),
+            forceUpload: forceUpload
+        )
+        if shouldDedupeRequest(for: dedupeKey, now: now) {
+            logger.debug("Deduplicating location snapshot upload request")
+            return
+        }
         let payload = LocationSnapshotPushPayload(
             capturedAt: snapshot.timestamp,
-            locationAgeSeconds: Date().timeIntervalSince(snapshot.timestamp),
+            locationAgeSeconds: now.timeIntervalSince(snapshot.timestamp),
             horizontalAccuracyMeters: snapshot.accuracy,
             cellScheme: "h3",
             h3Cell: context.h3Cell,
@@ -108,16 +139,7 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
             apnsDeviceToken: apnsToken,
             installationId: installationId,
             source: source.rawValue,
-            auth: {
-                switch CLLocationManager().authorizationStatus {
-                case .authorizedAlways: return "always"
-                case .authorizedWhenInUse: return "whenInUse"
-                case .denied: return "denied"
-                case .restricted: return "restricted"
-                case .notDetermined: return "notDetermined"
-                @unknown default: return "unknown"
-                }
-            }(),
+            auth: Self.authorizationName(for: authorizationStatus),
             appVersion: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "",
             buildNumber: Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "",
             platform: "iOS",
@@ -135,11 +157,29 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         )
 
         queue.append(payload)
+        lastUploadBySemanticKey[dedupeKey] = now
 
         guard !isProcessing else { return }
         isProcessing = true
         await drainQueue()
         isProcessing = false
+    }
+
+    private func shouldDedupeRequest(for key: DeduplicationKey, now: Date) -> Bool {
+        guard dedupeWindowSeconds > 0 else { return false }
+        guard let lastUploadAt = lastUploadBySemanticKey[key] else { return false }
+        return now.timeIntervalSince(lastUploadAt) <= dedupeWindowSeconds
+    }
+
+    private nonisolated static func authorizationName(for status: CLAuthorizationStatus) -> String {
+        switch status {
+        case .authorizedAlways: return "always"
+        case .authorizedWhenInUse: return "whenInUse"
+        case .denied: return "denied"
+        case .restricted: return "restricted"
+        case .notDetermined: return "notDetermined"
+        @unknown default: return "unknown"
+        }
     }
 
     private func drainQueue() async {
@@ -157,6 +197,16 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
             do {
                 try await uploader.upload(payload)
                 return true
+            } catch let error as LocationPushError {
+                if await uploadWithLegacySourceFallbackIfNeeded(for: payload, error: error) {
+                    return true
+                }
+                let isFinalAttempt = index == retryDelaysSeconds.count - 1
+                if isFinalAttempt {
+                    logger.error("Location snapshot upload failed after retries: \(error.localizedDescription, privacy: .public)")
+                } else {
+                    logger.warning("Location snapshot upload attempt failed; retrying")
+                }
             } catch is CancellationError {
                 logger.debug("Location snapshot upload cancelled")
                 return false
@@ -171,6 +221,47 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
         }
 
         return false
+    }
+
+    private func uploadWithLegacySourceFallbackIfNeeded(
+        for payload: LocationSnapshotPushPayload,
+        error: LocationPushError
+    ) async -> Bool {
+        guard case .invalidResponseStatus(let status) = error else { return false }
+        guard status == 400 || status == 422 else { return false }
+        guard payload.source != "unknown" else { return false }
+
+        let fallbackPayload = LocationSnapshotPushPayload(
+            capturedAt: payload.capturedAt,
+            locationAgeSeconds: payload.locationAgeSeconds,
+            horizontalAccuracyMeters: payload.horizontalAccuracyMeters,
+            cellScheme: payload.cellScheme,
+            h3Cell: payload.h3Cell,
+            h3Resolution: payload.h3Resolution,
+            county: payload.county,
+            zone: payload.zone,
+            fireZone: payload.fireZone,
+            apnsDeviceToken: payload.apnsDeviceToken,
+            installationId: payload.installationId,
+            source: "unknown",
+            auth: payload.auth,
+            appVersion: payload.appVersion,
+            buildNumber: payload.buildNumber,
+            platform: payload.platform,
+            osVersion: payload.osVersion,
+            apnsEnvironment: payload.apnsEnvironment,
+            countyLabel: payload.countyLabel,
+            fireZoneLabel: payload.fireZoneLabel,
+            isSubscribed: payload.isSubscribed
+        )
+
+        do {
+            try await uploader.upload(fallbackPayload)
+            logger.notice("Location snapshot upload succeeded with legacy source fallback")
+            return true
+        } catch {
+            return false
+        }
     }
 
     nonisolated private static func readApnsTokenFromDefaults() -> String {
@@ -192,5 +283,17 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
             return value
         }
         return true
+    }
+
+    private struct DeduplicationKey: Hashable {
+        let installationId: String
+        let apnsToken: String
+        let h3Cell: Int64
+        let county: String?
+        let fireZone: String?
+        let forecastZone: String?
+        let isSubscribed: Bool
+        let authorizationState: String
+        let forceUpload: Bool
     }
 }

--- a/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
+++ b/Sources/Infrastructure/Location/LocationSnapshotPusher.swift
@@ -340,6 +340,10 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
 
     private func drainQueue() async {
         while !queue.isEmpty {
+            if Task.isCancelled {
+                logger.notice("Location upload queue drain cancelled")
+                return
+            }
             let workItem = queue.removeFirst()
             let didUpload = await uploadWithRetry(workItem.payload)
             if didUpload {
@@ -352,14 +356,35 @@ actor LocationSnapshotPusher: LocationUploadCoordinating {
                 logger.error(
                     "Location upload failed source=\(workItem.payload.source, privacy: .public)"
                 )
+                if Task.isCancelled {
+                    logger.notice("Location upload queue drain stopped after cancellation")
+                    return
+                }
             }
         }
     }
 
     private func uploadWithRetry(_ payload: LocationSnapshotPushPayload) async -> Bool {
         for (index, delay) in retryDelaysSeconds.enumerated() {
+            do {
+                try Task.checkCancellation()
+            } catch is CancellationError {
+                logger.notice("Location upload cancelled before attempt source=\(payload.source, privacy: .public)")
+                return false
+            } catch {
+                return false
+            }
+
             if delay > 0 {
-                try? await Task.sleep(for: .seconds(Int(delay)))
+                do {
+                    try await Task.sleep(for: .seconds(Int(delay)))
+                    try Task.checkCancellation()
+                } catch is CancellationError {
+                    logger.notice("Location upload cancelled during retry backoff source=\(payload.source, privacy: .public)")
+                    return false
+                } catch {
+                    return false
+                }
             }
             do {
                 try await uploader.upload(payload)

--- a/Sources/Notifications/RemoteNotificationRegistrar.swift
+++ b/Sources/Notifications/RemoteNotificationRegistrar.swift
@@ -21,6 +21,7 @@ final class RemoteNotificationRegistrar {
     private let logger: Logger
     private let registerRemoteNotifications: @MainActor () -> Void
     private var tokenWaiters: [UUID: CheckedContinuation<String?, Never>] = [:]
+    private var tokenStoredObserver: (@MainActor @Sendable (String) async -> Void)?
 
     init(
         center: UNUserNotificationCenter = .current(),
@@ -54,9 +55,18 @@ final class RemoteNotificationRegistrar {
         let waiters = Array(tokenWaiters.values)
         tokenWaiters.removeAll()
         waiters.forEach { $0.resume(returning: token) }
+        if let tokenStoredObserver {
+            Task { @MainActor in
+                await tokenStoredObserver(token)
+            }
+        }
 #if DEBUG
         logger.debug("APNs device token stored for debug run")
 #endif
+    }
+
+    func setTokenStoredObserver(_ observer: (@MainActor @Sendable (String) async -> Void)?) {
+        tokenStoredObserver = observer
     }
 
     func waitForDeviceToken(timeout: Duration = .seconds(10)) async -> String? {

--- a/Tests/UnitTests/BackgroundOrchestratorCadenceTests.swift
+++ b/Tests/UnitTests/BackgroundOrchestratorCadenceTests.swift
@@ -3,6 +3,7 @@ import Testing
 import SwiftData
 import CoreLocation
 import OSLog
+import ArcusCore
 @testable import SkyAware
 
 @Suite("BackgroundScheduler replacement policy", .serialized)

--- a/Tests/UnitTests/BackgroundOrchestratorCadenceTests.swift
+++ b/Tests/UnitTests/BackgroundOrchestratorCadenceTests.swift
@@ -538,6 +538,7 @@ private final class FakeLocationSession: HomeContextPreparing {
     func prepareCurrentLocationContext(
         requiresFreshLocation: Bool,
         showsAuthorizationPrompt: Bool,
+        uploadSource: LocationUploadSource?,
         authorizationTimeout: Double,
         locationTimeout: Double,
         maximumAcceptedLocationAge: TimeInterval,

--- a/Tests/UnitTests/BackgroundOrchestratorCadenceTests.swift
+++ b/Tests/UnitTests/BackgroundOrchestratorCadenceTests.swift
@@ -544,6 +544,7 @@ private final class FakeLocationSession: HomeContextPreparing {
         requiresFreshLocation: Bool,
         showsAuthorizationPrompt: Bool,
         uploadSource: LocationUploadSource?,
+        uploadReason: LocationUploadReason?,
         authorizationTimeout: Double,
         locationTimeout: Double,
         maximumAcceptedLocationAge: TimeInterval,

--- a/Tests/UnitTests/BackgroundOrchestratorCadenceTests.swift
+++ b/Tests/UnitTests/BackgroundOrchestratorCadenceTests.swift
@@ -149,6 +149,7 @@ struct BackgroundOrchestratorCadenceTests {
             ),
             runGate: gate
         )
+        let uploadDrainer = RecordingPendingUploadDrainer()
         let orchestrator = BackgroundOrchestrator(
             coordinator: coordinator,
             policy: RefreshPolicy(),
@@ -169,7 +170,8 @@ struct BackgroundOrchestratorCadenceTests {
             cadence: CadencePolicy(),
             notificationSettingsProvider: StaticSettingsProvider(
                 settings: .init(morningSummariesEnabled: false, mesoNotificationsEnabled: false)
-            )
+            ),
+            pendingUploadDrainer: uploadDrainer
         )
         let completion = CompletionFlag()
 
@@ -186,6 +188,7 @@ struct BackgroundOrchestratorCadenceTests {
 
         let request = try #require(await coordinator.requests().first)
         #expect(request.trigger == .backgroundRefresh)
+        #expect(await uploadDrainer.drainCount() == 1)
 
         await gate.open()
         await runTask.value
@@ -257,7 +260,8 @@ private extension BackgroundOrchestratorCadenceTests {
         refreshedLocation: CLLocationCoordinate2D? = nil,
         refreshSucceeds: Bool = false,
         cachedSnapshotTimestamp: Date = Date(),
-        settings: NotificationSettings
+        settings: NotificationSettings,
+        pendingUploadDrainer: any PendingLocationUploadDraining = NoOpLocationUploadCoordinator()
     ) async throws -> SystemUnderTest {
         let container = try await MainActor.run { try TestStore.container(for: [BgRunSnapshot.self]) }
         try await MainActor.run { try TestStore.reset(BgRunSnapshot.self, in: container) }
@@ -328,7 +332,8 @@ private extension BackgroundOrchestratorCadenceTests {
             mesoEngine: mesoEngine,
             health: healthStore,
             cadence: CadencePolicy(),
-            notificationSettingsProvider: StaticSettingsProvider(settings: settings)
+            notificationSettingsProvider: StaticSettingsProvider(settings: settings),
+            pendingUploadDrainer: pendingUploadDrainer
         )
 
         return .init(orchestrator: orchestrator, modelContainer: container, spc: spc)
@@ -649,6 +654,18 @@ private actor CompletionFlag {
 
     func isFinished() -> Bool {
         finished
+    }
+}
+
+private actor RecordingPendingUploadDrainer: PendingLocationUploadDraining {
+    private var count = 0
+
+    func drainPendingUploads() async {
+        count += 1
+    }
+
+    func drainCount() -> Int {
+        count
     }
 }
 

--- a/Tests/UnitTests/HomeIngestionCoordinatorTests.swift
+++ b/Tests/UnitTests/HomeIngestionCoordinatorTests.swift
@@ -46,7 +46,7 @@ struct HomeIngestionCoordinatorTests {
         )
         #expect(backgroundLocationPlan.lanes == .all)
         #expect(backgroundLocationPlan.forcedLanes == [.hotAlerts, .weather])
-        #expect(backgroundLocationPlan.locationRequest == .currentPrepared)
+        #expect(backgroundLocationPlan.locationRequest == .latestAcceptedSnapshotPrepared)
     }
 
     @Test("runs one ingestion plan at a time")

--- a/Tests/UnitTests/HomeIngestionCoordinatorTests.swift
+++ b/Tests/UnitTests/HomeIngestionCoordinatorTests.swift
@@ -11,36 +11,42 @@ struct HomeIngestionCoordinatorTests {
         )
         #expect(activatePlan.lanes == .all)
         #expect(activatePlan.forcedLanes.isEmpty)
+        #expect(activatePlan.locationRequest == .prepare(requiresFreshLocation: true, showsAuthorizationPrompt: true))
 
         let manualPlan = HomeIngestionPlan(
             request: .init(trigger: .manualRefresh)
         )
         #expect(manualPlan.lanes == .all)
         #expect(manualPlan.forcedLanes == .all)
+        #expect(manualPlan.locationRequest == .prepare(requiresFreshLocation: true, showsAuthorizationPrompt: false))
 
         let tickPlan = HomeIngestionPlan(
             request: .init(trigger: .sessionTick)
         )
         #expect(tickPlan.lanes == [.hotAlerts])
         #expect(tickPlan.forcedLanes.isEmpty)
+        #expect(tickPlan.locationRequest == .currentPrepared)
 
         let locationPlan = HomeIngestionPlan(
             request: .init(trigger: .foregroundLocationChange)
         )
         #expect(locationPlan.lanes == .all)
         #expect(locationPlan.forcedLanes == [.hotAlerts, .weather])
+        #expect(locationPlan.locationRequest == .currentPrepared)
 
         let backgroundRefreshPlan = HomeIngestionPlan(
             request: .init(trigger: .backgroundRefresh)
         )
         #expect(backgroundRefreshPlan.lanes == .all)
         #expect(backgroundRefreshPlan.forcedLanes == [.hotAlerts])
+        #expect(backgroundRefreshPlan.locationRequest == .prepare(requiresFreshLocation: true, showsAuthorizationPrompt: false))
 
         let backgroundLocationPlan = HomeIngestionPlan(
             request: .init(trigger: .backgroundLocationChange)
         )
         #expect(backgroundLocationPlan.lanes == .all)
         #expect(backgroundLocationPlan.forcedLanes == [.hotAlerts, .weather])
+        #expect(backgroundLocationPlan.locationRequest == .currentPrepared)
     }
 
     @Test("runs one ingestion plan at a time")

--- a/Tests/UnitTests/HomeRefreshPipelineTests.swift
+++ b/Tests/UnitTests/HomeRefreshPipelineTests.swift
@@ -581,8 +581,8 @@ struct HomeRefreshPipelineTests {
         #expect(pipeline.outlook?.title == "Day 2 Convective Outlook")
     }
 
-    @Test("background location change plan reuses currentPrepared context and skips fresh prepare")
-    func backgroundLocationChange_reusesCurrentPreparedContext() async throws {
+    @Test("background location change resolves from latest accepted snapshot instead of stale current context")
+    func backgroundLocationChange_resolvesLatestAcceptedSnapshot() async throws {
         let oldSnapshot = LocationSnapshot(
             coordinates: .init(latitude: 39.75, longitude: -104.44),
             timestamp: Date(timeIntervalSince1970: 100),
@@ -665,9 +665,41 @@ struct HomeRefreshPipelineTests {
             plan: HomeIngestionPlan(request: .init(trigger: .backgroundLocationChange))
         )
 
+        #expect(locationSession.prepareCalls.count == 1)
+        #expect(locationSession.prepareCalls[0] == .init(requiresFreshLocation: false, showsAuthorizationPrompt: false))
+        #expect(snapshot.locationSnapshot == freshContext.snapshot)
+        #expect(snapshot.refreshKey == freshContext.refreshKey)
+    }
+
+    @Test("session tick continues reusing current prepared context")
+    func sessionTick_reusesCurrentPreparedContext() async throws {
+        let currentContext = makeContext(timestamp: 100)
+        let newerPreparedContext = makeContext(timestamp: 200)
+        let locationSession = FakeLocationSession(currentContext: currentContext, preparedContext: newerPreparedContext)
+        let spc = FakeSpcProvider()
+        let alerts = FakeAlertProvider()
+        let weather = FakeWeatherClient()
+        let snapshotStore = HomeSnapshotStore(spcRisk: spc, spcOutlook: spc, arcusAlerts: alerts)
+        let executor = HomeIngestionExecutor(
+            environment: .init(
+                logger: Logger(subsystem: "SkyAwareTests", category: "HomeRefreshPipelineTests"),
+                spcSync: spc,
+                arcusAlertSync: alerts,
+                weatherClient: weather,
+                locationSession: locationSession,
+                snapshotStore: snapshotStore,
+                projectionStore: nil,
+                widgetSnapshotRefresher: nil
+            )
+        )
+
+        let snapshot = try await executor.run(
+            plan: HomeIngestionPlan(request: .init(trigger: .sessionTick))
+        )
+
         #expect(locationSession.prepareCalls.isEmpty)
-        #expect(snapshot.locationSnapshot == oldContext.snapshot)
-        #expect(snapshot.refreshKey == oldContext.refreshKey)
+        #expect(snapshot.locationSnapshot == currentContext.snapshot)
+        #expect(snapshot.refreshKey == currentContext.refreshKey)
     }
 
     private func makeEnvironment(

--- a/Tests/UnitTests/HomeRefreshPipelineTests.swift
+++ b/Tests/UnitTests/HomeRefreshPipelineTests.swift
@@ -670,21 +670,22 @@ struct HomeRefreshPipelineTests {
             locationSession.prepareCalls[0] == .init(
                 requiresFreshLocation: false,
                 showsAuthorizationPrompt: false,
-                uploadSource: .backgroundLocationChange
+                uploadSource: .backgroundLocationChange,
+                uploadReason: .locationChanged
             )
         )
         #expect(snapshot.locationSnapshot == freshContext.snapshot)
         #expect(snapshot.refreshKey == freshContext.refreshKey)
     }
 
-    @Test("ingestion trigger location preparation carries deterministic upload sources")
-    func ingestionTrigger_locationPreparationCarriesExpectedUploadSource() async throws {
-        let cases: [(HomeRefreshTrigger, LocationUploadSource)] = [
-            (.foregroundActivate, .foregroundActivate),
-            (.manualRefresh, .manualRefresh),
-            (.foregroundLocationChange, .foregroundLocationChange),
-            (.backgroundRefresh, .backgroundRefresh),
-            (.backgroundLocationChange, .backgroundLocationChange)
+    @Test("ingestion trigger location preparation carries deterministic upload source and reason")
+    func ingestionTrigger_locationPreparationCarriesExpectedUploadSourceAndReason() async throws {
+        let cases: [(HomeRefreshTrigger, LocationUploadSource, LocationUploadReason)] = [
+            (.foregroundActivate, .foregroundActivate, .locationResolved),
+            (.manualRefresh, .manualRefresh, .locationResolved),
+            (.foregroundLocationChange, .foregroundLocationChange, .locationChanged),
+            (.backgroundRefresh, .backgroundRefresh, .locationResolved),
+            (.backgroundLocationChange, .backgroundLocationChange, .locationChanged)
         ]
 
         for testCase in cases {
@@ -712,6 +713,7 @@ struct HomeRefreshPipelineTests {
 
             let prepareCall = try #require(locationSession.prepareCalls.first)
             #expect(prepareCall.uploadSource == testCase.1)
+            #expect(prepareCall.uploadReason == testCase.2)
         }
     }
 
@@ -996,6 +998,7 @@ private final class FakeLocationSession: HomeLocationContextPreparing, HomeConte
         let requiresFreshLocation: Bool
         let showsAuthorizationPrompt: Bool
         let uploadSource: LocationUploadSource?
+        let uploadReason: LocationUploadReason?
     }
 
     var currentContext: LocationContext?
@@ -1018,6 +1021,7 @@ private final class FakeLocationSession: HomeLocationContextPreparing, HomeConte
         requiresFreshLocation: Bool,
         showsAuthorizationPrompt: Bool,
         uploadSource: LocationUploadSource?,
+        uploadReason: LocationUploadReason?,
         authorizationTimeout: Double,
         locationTimeout: Double,
         maximumAcceptedLocationAge: TimeInterval,
@@ -1027,7 +1031,8 @@ private final class FakeLocationSession: HomeLocationContextPreparing, HomeConte
             .init(
                 requiresFreshLocation: requiresFreshLocation,
                 showsAuthorizationPrompt: showsAuthorizationPrompt,
-                uploadSource: uploadSource
+                uploadSource: uploadSource,
+                uploadReason: uploadReason
             )
         )
         if let prepareGate {

--- a/Tests/UnitTests/HomeRefreshPipelineTests.swift
+++ b/Tests/UnitTests/HomeRefreshPipelineTests.swift
@@ -666,9 +666,53 @@ struct HomeRefreshPipelineTests {
         )
 
         #expect(locationSession.prepareCalls.count == 1)
-        #expect(locationSession.prepareCalls[0] == .init(requiresFreshLocation: false, showsAuthorizationPrompt: false))
+        #expect(
+            locationSession.prepareCalls[0] == .init(
+                requiresFreshLocation: false,
+                showsAuthorizationPrompt: false,
+                uploadSource: .backgroundLocationChange
+            )
+        )
         #expect(snapshot.locationSnapshot == freshContext.snapshot)
         #expect(snapshot.refreshKey == freshContext.refreshKey)
+    }
+
+    @Test("ingestion trigger location preparation carries deterministic upload sources")
+    func ingestionTrigger_locationPreparationCarriesExpectedUploadSource() async throws {
+        let cases: [(HomeRefreshTrigger, LocationUploadSource)] = [
+            (.foregroundActivate, .foregroundActivate),
+            (.manualRefresh, .manualRefresh),
+            (.foregroundLocationChange, .foregroundLocationChange),
+            (.backgroundRefresh, .backgroundRefresh),
+            (.backgroundLocationChange, .backgroundLocationChange)
+        ]
+
+        for testCase in cases {
+            let locationSession = FakeLocationSession(currentContext: nil, preparedContext: makeContext())
+            let spc = FakeSpcProvider()
+            let alerts = FakeAlertProvider()
+            let weather = FakeWeatherClient()
+            let snapshotStore = HomeSnapshotStore(spcRisk: spc, spcOutlook: spc, arcusAlerts: alerts)
+            let executor = HomeIngestionExecutor(
+                environment: .init(
+                    logger: Logger(subsystem: "SkyAwareTests", category: "HomeRefreshPipelineTests"),
+                    spcSync: spc,
+                    arcusAlertSync: alerts,
+                    weatherClient: weather,
+                    locationSession: locationSession,
+                    snapshotStore: snapshotStore,
+                    projectionStore: nil,
+                    widgetSnapshotRefresher: nil
+                )
+            )
+
+            _ = try await executor.run(
+                plan: HomeIngestionPlan(request: .init(trigger: testCase.0))
+            )
+
+            let prepareCall = try #require(locationSession.prepareCalls.first)
+            #expect(prepareCall.uploadSource == testCase.1)
+        }
     }
 
     @Test("session tick continues reusing current prepared context")
@@ -951,6 +995,7 @@ private final class FakeLocationSession: HomeLocationContextPreparing, HomeConte
     struct PrepareCall: Equatable {
         let requiresFreshLocation: Bool
         let showsAuthorizationPrompt: Bool
+        let uploadSource: LocationUploadSource?
     }
 
     var currentContext: LocationContext?
@@ -981,7 +1026,8 @@ private final class FakeLocationSession: HomeLocationContextPreparing, HomeConte
         prepareCalls.append(
             .init(
                 requiresFreshLocation: requiresFreshLocation,
-                showsAuthorizationPrompt: showsAuthorizationPrompt
+                showsAuthorizationPrompt: showsAuthorizationPrompt,
+                uploadSource: uploadSource
             )
         )
         if let prepareGate {

--- a/Tests/UnitTests/HomeRefreshPipelineTests.swift
+++ b/Tests/UnitTests/HomeRefreshPipelineTests.swift
@@ -972,6 +972,7 @@ private final class FakeLocationSession: HomeLocationContextPreparing, HomeConte
     func prepareCurrentLocationContext(
         requiresFreshLocation: Bool,
         showsAuthorizationPrompt: Bool,
+        uploadSource: LocationUploadSource?,
         authorizationTimeout: Double,
         locationTimeout: Double,
         maximumAcceptedLocationAge: TimeInterval,

--- a/Tests/UnitTests/HomeRefreshPipelineTests.swift
+++ b/Tests/UnitTests/HomeRefreshPipelineTests.swift
@@ -2,6 +2,7 @@ import CoreLocation
 import Foundation
 import OSLog
 import Testing
+import ArcusCore
 @testable import SkyAware
 
 @Suite("Home Refresh Pipeline", .serialized)

--- a/Tests/UnitTests/HomeRefreshPipelineTests.swift
+++ b/Tests/UnitTests/HomeRefreshPipelineTests.swift
@@ -581,6 +581,95 @@ struct HomeRefreshPipelineTests {
         #expect(pipeline.outlook?.title == "Day 2 Convective Outlook")
     }
 
+    @Test("background location change plan reuses currentPrepared context and skips fresh prepare")
+    func backgroundLocationChange_reusesCurrentPreparedContext() async throws {
+        let oldSnapshot = LocationSnapshot(
+            coordinates: .init(latitude: 39.75, longitude: -104.44),
+            timestamp: Date(timeIntervalSince1970: 100),
+            accuracy: 25,
+            placemarkSummary: "Bennett, CO",
+            h3Cell: 111_111
+        )
+        let oldGrid = GridPointSnapshot(
+            nwsId: "BOU/10,20",
+            latitude: oldSnapshot.coordinates.latitude,
+            longitude: oldSnapshot.coordinates.longitude,
+            gridId: "BOU",
+            gridX: 10,
+            gridY: 20,
+            forecastURL: nil,
+            forecastHourlyURL: nil,
+            forecastGridDataURL: nil,
+            observationStationsURL: nil,
+            city: "Bennett",
+            state: "CO",
+            timeZoneId: "America/Denver",
+            radarStationId: nil,
+            forecastZone: "COZ038",
+            countyCode: "COC005",
+            fireZone: "COZ214",
+            countyLabel: "Arapahoe",
+            fireZoneLabel: "Front Range"
+        )
+        let oldContext = LocationContext(snapshot: oldSnapshot, h3Cell: 111_111, grid: oldGrid)
+
+        let freshSnapshot = LocationSnapshot(
+            coordinates: .init(latitude: 40.01, longitude: -104.10),
+            timestamp: Date(timeIntervalSince1970: 200),
+            accuracy: 20,
+            placemarkSummary: "Weld County, CO",
+            h3Cell: 222_222
+        )
+        let freshGrid = GridPointSnapshot(
+            nwsId: "BOU/22,30",
+            latitude: freshSnapshot.coordinates.latitude,
+            longitude: freshSnapshot.coordinates.longitude,
+            gridId: "BOU",
+            gridX: 22,
+            gridY: 30,
+            forecastURL: nil,
+            forecastHourlyURL: nil,
+            forecastGridDataURL: nil,
+            observationStationsURL: nil,
+            city: "Brighton",
+            state: "CO",
+            timeZoneId: "America/Denver",
+            radarStationId: nil,
+            forecastZone: "COZ040",
+            countyCode: "COC123",
+            fireZone: "COZ250",
+            countyLabel: "Weld",
+            fireZoneLabel: "Northeast Plains"
+        )
+        let freshContext = LocationContext(snapshot: freshSnapshot, h3Cell: 222_222, grid: freshGrid)
+
+        let locationSession = FakeLocationSession(currentContext: oldContext, preparedContext: freshContext)
+        let spc = FakeSpcProvider()
+        let alerts = FakeAlertProvider()
+        let weather = FakeWeatherClient()
+        let snapshotStore = HomeSnapshotStore(spcRisk: spc, spcOutlook: spc, arcusAlerts: alerts)
+        let executor = HomeIngestionExecutor(
+            environment: .init(
+                logger: Logger(subsystem: "SkyAwareTests", category: "HomeRefreshPipelineTests"),
+                spcSync: spc,
+                arcusAlertSync: alerts,
+                weatherClient: weather,
+                locationSession: locationSession,
+                snapshotStore: snapshotStore,
+                projectionStore: nil,
+                widgetSnapshotRefresher: nil
+            )
+        )
+
+        let snapshot = try await executor.run(
+            plan: HomeIngestionPlan(request: .init(trigger: .backgroundLocationChange))
+        )
+
+        #expect(locationSession.prepareCalls.isEmpty)
+        #expect(snapshot.locationSnapshot == oldContext.snapshot)
+        #expect(snapshot.refreshKey == oldContext.refreshKey)
+    }
+
     private func makeEnvironment(
         spc: FakeSpcProvider = FakeSpcProvider(),
         alerts: FakeAlertProvider = FakeAlertProvider(),

--- a/Tests/UnitTests/LocationManagerTests.swift
+++ b/Tests/UnitTests/LocationManagerTests.swift
@@ -135,21 +135,34 @@ struct LocationSessionTests {
         private var enqueueCount = 0
         private var lastForceUpload: Bool?
         private var lastSource: LocationUploadSource?
+        private var lastReason: LocationUploadReason?
         private var preferenceSyncCount = 0
         private var lastPreferenceReason: String?
         private var drainCount = 0
 
-        func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool) async {
+        func enqueue(
+            _ context: LocationContext,
+            source: LocationUploadSource,
+            reason: LocationUploadReason,
+            forceUpload: Bool
+        ) async {
             enqueueCount += 1
             lastForceUpload = forceUpload
             lastSource = source
+            lastReason = reason
         }
 
-        func enqueuePreferenceSync(source: LocationUploadSource, forceUpload: Bool, reason: String) async {
+        func enqueuePreferenceSync(
+            source: LocationUploadSource,
+            requestReason: LocationUploadReason,
+            forceUpload: Bool,
+            detail: String
+        ) async {
             preferenceSyncCount += 1
             lastForceUpload = forceUpload
             lastSource = source
-            lastPreferenceReason = reason
+            lastReason = requestReason
+            lastPreferenceReason = detail
         }
 
         func drainPendingUploads() async {
@@ -159,6 +172,7 @@ struct LocationSessionTests {
         func recordedEnqueueCount() -> Int { enqueueCount }
         func recordedLastForceUpload() -> Bool? { lastForceUpload }
         func recordedLastSource() -> LocationUploadSource? { lastSource }
+        func recordedLastReason() -> LocationUploadReason? { lastReason }
         func recordedPreferenceSyncCount() -> Int { preferenceSyncCount }
         func recordedLastPreferenceReason() -> String? { lastPreferenceReason }
         func recordedDrainCount() -> Int { drainCount }
@@ -304,6 +318,7 @@ struct LocationSessionTests {
         #expect(await uploader.recordedEnqueueCount() == 1)
         #expect(await uploader.recordedLastForceUpload() == true)
         #expect(await uploader.recordedLastSource() == .settingsPreference)
+        #expect(await uploader.recordedLastReason() == .preferenceChanged)
         #expect(session.currentContext == context)
     }
 
@@ -366,6 +381,7 @@ struct LocationSessionTests {
         #expect(await uploader.recordedEnqueueCount() == 1)
         #expect(await uploader.recordedLastForceUpload() == true)
         #expect(await uploader.recordedLastSource() == .settingsPreference)
+        #expect(await uploader.recordedLastReason() == .preferenceChanged)
         #expect(session.currentContext == context)
         #expect(session.currentSnapshot == context.snapshot)
     }
@@ -426,6 +442,7 @@ struct LocationSessionTests {
         #expect(await uploader.recordedPreferenceSyncCount() == 0)
         #expect(await uploader.recordedLastForceUpload() == true)
         #expect(await uploader.recordedLastSource() == .settingsPreference)
+        #expect(await uploader.recordedLastReason() == .preferenceChanged)
     }
 
     @MainActor
@@ -454,6 +471,7 @@ struct LocationSessionTests {
         #expect(await uploader.recordedPreferenceSyncCount() == 1)
         #expect(await uploader.recordedLastForceUpload() == true)
         #expect(await uploader.recordedLastSource() == .settingsPreference)
+        #expect(await uploader.recordedLastReason() == .preferenceChanged)
         #expect(await uploader.recordedLastPreferenceReason() == "location-sharing")
     }
 
@@ -484,6 +502,7 @@ struct LocationSessionTests {
         #expect(await uploader.recordedPreferenceSyncCount() == 1)
         #expect(await uploader.recordedLastForceUpload() == true)
         #expect(await uploader.recordedLastSource() == .settingsPreference)
+        #expect(await uploader.recordedLastReason() == .preferenceChanged)
         #expect(await uploader.recordedLastPreferenceReason() == "location-sharing")
     }
 
@@ -514,6 +533,7 @@ struct LocationSessionTests {
         #expect(await uploader.recordedPreferenceSyncCount() == 1)
         #expect(await uploader.recordedLastForceUpload() == true)
         #expect(await uploader.recordedLastSource() == .settingsPreference)
+        #expect(await uploader.recordedLastReason() == .preferenceChanged)
         #expect(await uploader.recordedLastPreferenceReason() == "notification")
     }
 
@@ -570,11 +590,12 @@ struct LocationSessionTests {
         session.currentSnapshot = context.snapshot
         session.currentContext = nil
 
-        await session.enqueueCurrentLocationUpload(source: .settingsPreference)
+        await session.enqueueCurrentLocationUpload(source: .settingsPreference, reason: .preferenceChanged)
 
         #expect(await uploader.recordedEnqueueCount() == 1)
         #expect(await uploader.recordedLastForceUpload() == false)
         #expect(await uploader.recordedLastSource() == .settingsPreference)
+        #expect(await uploader.recordedLastReason() == .preferenceChanged)
         #expect(session.currentContext == context)
     }
 

--- a/Tests/UnitTests/LocationManagerTests.swift
+++ b/Tests/UnitTests/LocationManagerTests.swift
@@ -135,6 +135,7 @@ struct LocationSessionTests {
         private var enqueueCount = 0
         private var lastForceUpload: Bool?
         private var lastSource: LocationUploadSource?
+        private var drainCount = 0
 
         func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool) async {
             enqueueCount += 1
@@ -142,9 +143,14 @@ struct LocationSessionTests {
             lastSource = source
         }
 
+        func drainPendingUploads() async {
+            drainCount += 1
+        }
+
         func recordedEnqueueCount() -> Int { enqueueCount }
         func recordedLastForceUpload() -> Bool? { lastForceUpload }
         func recordedLastSource() -> LocationUploadSource? { lastSource }
+        func recordedDrainCount() -> Int { drainCount }
     }
 
     @MainActor
@@ -412,6 +418,28 @@ struct LocationSessionTests {
         #expect(await uploader.recordedLastForceUpload() == false)
         #expect(await uploader.recordedLastSource() == .settingsPreference)
         #expect(session.currentContext == context)
+    }
+
+    @MainActor
+    @Test("drainPendingLocationUploads forwards to upload coordinator")
+    func drainPendingLocationUploads_forwardsToCoordinator() async throws {
+        let provider = LocationProvider()
+        let manager = LocationManager(
+            manager: LocationManagerTests.StubAuthorizationManager(status: .authorizedWhenInUse),
+            onUpdate: { _ in }
+        )
+        let resolver = StubResolver(context: nil, error: .locationTimeout)
+        let uploader = StubUploadCoordinator()
+        let session = LocationSession(
+            locationClient: makeLocationClient(provider: provider),
+            locationManager: manager,
+            locationContextResolver: resolver,
+            locationUploadCoordinator: uploader
+        )
+
+        await session.drainPendingLocationUploads()
+
+        #expect(await uploader.recordedDrainCount() == 1)
     }
 
     @MainActor

--- a/Tests/UnitTests/LocationManagerTests.swift
+++ b/Tests/UnitTests/LocationManagerTests.swift
@@ -230,8 +230,8 @@ struct LocationSessionTests {
     }
 
     @MainActor
-    @Test("pushServerNotificationPreferenceUpdate forwards current context for upload")
-    func pushServerNotificationPreferenceUpdate_forwardsCurrentContext() async throws {
+    @Test("syncNotificationPreference forwards current context as forced preference sync")
+    func syncNotificationPreference_forwardsCurrentContextAsForcedSync() async throws {
         let provider = LocationProvider()
         let manager = LocationManager(
             manager: LocationManagerTests.StubAuthorizationManager(status: .authorizedWhenInUse),
@@ -282,17 +282,17 @@ struct LocationSessionTests {
             showsAuthorizationPrompt: false
         )
 
-        await session.pushServerNotificationPreferenceUpdate()
+        await session.syncNotificationPreference(enabled: true)
 
         #expect(await uploader.recordedEnqueueCount() == 1)
-        #expect(await uploader.recordedLastForceUpload() == false)
+        #expect(await uploader.recordedLastForceUpload() == true)
         #expect(await uploader.recordedLastSource() == .settingsPreference)
         #expect(session.currentContext == context)
     }
 
     @MainActor
-    @Test("pushServerNotificationPreferenceUpdate resolves missing context and enqueues with force flag")
-    func pushServerNotificationPreferenceUpdate_resolvesMissingContext_andEnqueuesWithForceFlag() async throws {
+    @Test("syncLocationSharingPreference resolves missing context and enqueues forced sync")
+    func syncLocationSharingPreference_resolvesMissingContext_andEnqueuesForcedSync() async throws {
         let provider = LocationProvider()
         let manager = LocationManager(
             manager: LocationManagerTests.StubAuthorizationManager(status: .authorizedWhenInUse),
@@ -344,7 +344,7 @@ struct LocationSessionTests {
         session.currentSnapshot = context.snapshot
         session.currentContext = nil
 
-        await session.pushServerNotificationPreferenceUpdate(forceUpload: true)
+        await session.syncLocationSharingPreference(enabled: false)
 
         #expect(await uploader.recordedEnqueueCount() == 1)
         #expect(await uploader.recordedLastForceUpload() == true)
@@ -354,8 +354,8 @@ struct LocationSessionTests {
     }
 
     @MainActor
-    @Test("pushServerNotificationPreferenceUpdate resolves from snapshot and enqueues once")
-    func pushServerNotificationPreferenceUpdate_resolvesFromSnapshotAndEnqueuesOnce() async throws {
+    @Test("enqueueCurrentLocationUpload resolves from snapshot and enqueues non-forced upload once")
+    func enqueueCurrentLocationUpload_resolvesFromSnapshotAndEnqueuesOnce() async throws {
         let provider = LocationProvider()
         let manager = LocationManager(
             manager: LocationManagerTests.StubAuthorizationManager(status: .authorizedWhenInUse),
@@ -406,10 +406,10 @@ struct LocationSessionTests {
         session.currentSnapshot = context.snapshot
         session.currentContext = nil
 
-        await session.pushServerNotificationPreferenceUpdate(forceUpload: true)
+        await session.enqueueCurrentLocationUpload(source: .settingsPreference)
 
         #expect(await uploader.recordedEnqueueCount() == 1)
-        #expect(await uploader.recordedLastForceUpload() == true)
+        #expect(await uploader.recordedLastForceUpload() == false)
         #expect(await uploader.recordedLastSource() == .settingsPreference)
         #expect(session.currentContext == context)
     }

--- a/Tests/UnitTests/LocationManagerTests.swift
+++ b/Tests/UnitTests/LocationManagerTests.swift
@@ -99,12 +99,14 @@ struct LocationSessionTests {
     private actor StubResolver: LocationContextResolving {
         let context: LocationContext?
         let error: LocationContextError?
+        let enqueueOnResolve: Bool
         private var enqueueCount = 0
         private var lastForceUpload: Bool?
 
-        init(context: LocationContext?, error: LocationContextError?) {
+        init(context: LocationContext?, error: LocationContextError?, enqueueOnResolve: Bool = false) {
             self.context = context
             self.error = error
+            self.enqueueOnResolve = enqueueOnResolve
         }
 
         func prepareCurrentContext(
@@ -126,6 +128,10 @@ struct LocationSessionTests {
             maximumAcceptedLocationAge: TimeInterval?,
             placemarkTimeout: Double
         ) async throws -> LocationContext {
+            if enqueueOnResolve {
+                enqueueCount += 1
+                lastForceUpload = false
+            }
             if let context {
                 return context
             }
@@ -344,6 +350,64 @@ struct LocationSessionTests {
         #expect(await resolver.recordedLastForceUpload() == true)
         #expect(session.currentContext == context)
         #expect(session.currentSnapshot == context.snapshot)
+    }
+
+    @MainActor
+    @Test("pushServerNotificationPreferenceUpdate can double enqueue when resolveContext also enqueues")
+    func pushServerNotificationPreferenceUpdate_resolvesFromSnapshotAndDoubleEnqueues() async throws {
+        let provider = LocationProvider()
+        let manager = LocationManager(
+            manager: LocationManagerTests.StubAuthorizationManager(status: .authorizedWhenInUse),
+            onUpdate: { _ in }
+        )
+
+        let context = LocationContext(
+            snapshot: LocationSnapshot(
+                coordinates: CLLocationCoordinate2D(latitude: 39.7392, longitude: -104.9903),
+                timestamp: Date(timeIntervalSince1970: 1_234_567),
+                accuracy: 20,
+                placemarkSummary: "Denver, CO",
+                h3Cell: 0x882681b485fffff
+            ),
+            h3Cell: 0x882681b485fffff,
+            grid: GridPointSnapshot(
+                nwsId: "https://api.weather.gov/points/39.7392,-104.9903",
+                latitude: 39.7392,
+                longitude: -104.9903,
+                gridId: "BOU",
+                gridX: 56,
+                gridY: 66,
+                forecastURL: nil,
+                forecastHourlyURL: nil,
+                forecastGridDataURL: nil,
+                observationStationsURL: nil,
+                city: "Denver",
+                state: "CO",
+                timeZoneId: "America/Denver",
+                radarStationId: "KFTG",
+                forecastZone: "COZ039",
+                countyCode: "COC031",
+                fireZone: "COZ246",
+                countyLabel: "Denver County",
+                fireZoneLabel: "East Central Colorado"
+            )
+        )
+        let resolver = StubResolver(context: context, error: nil, enqueueOnResolve: true)
+        let session = LocationSession(
+            locationClient: makeLocationClient(provider: provider),
+            locationManager: manager,
+            locationContextResolver: resolver
+        )
+
+        try await Task.sleep(for: .milliseconds(20))
+        session.currentSnapshot = context.snapshot
+        session.currentContext = nil
+
+        await session.pushServerNotificationPreferenceUpdate(forceUpload: true)
+
+        #expect(await resolver.recordedEnqueueCount() == 2)
+        #expect(await resolver.recordedLastForceUpload() == true)
+        #expect(session.currentContext == context)
     }
 
     @MainActor

--- a/Tests/UnitTests/LocationManagerTests.swift
+++ b/Tests/UnitTests/LocationManagerTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreLocation
 import Testing
+import ArcusCore
 @testable import SkyAware
 
 @Suite("LocationManager")
@@ -261,8 +262,8 @@ struct LocationSessionTests {
     }
 
     @MainActor
-    @Test("syncNotificationPreference forwards current context as forced preference sync")
-    func syncNotificationPreference_forwardsCurrentContextAsForcedSync() async throws {
+    @Test("syncNotificationPreference enqueues forced preference sync")
+    func syncNotificationPreference_enqueuesForcedPreferenceSync() async throws {
         let provider = LocationProvider()
         let manager = LocationManager(
             manager: LocationManagerTests.StubAuthorizationManager(status: .authorizedWhenInUse),
@@ -315,7 +316,8 @@ struct LocationSessionTests {
 
         await session.syncNotificationPreference(enabled: true)
 
-        #expect(await uploader.recordedEnqueueCount() == 1)
+        #expect(await uploader.recordedEnqueueCount() == 0)
+        #expect(await uploader.recordedPreferenceSyncCount() == 1)
         #expect(await uploader.recordedLastForceUpload() == true)
         #expect(await uploader.recordedLastSource() == .settingsPreference)
         #expect(await uploader.recordedLastReason() == .preferenceChanged)
@@ -323,8 +325,8 @@ struct LocationSessionTests {
     }
 
     @MainActor
-    @Test("syncLocationSharingPreference resolves missing context and enqueues forced sync")
-    func syncLocationSharingPreference_resolvesMissingContext_andEnqueuesForcedSync() async throws {
+    @Test("syncLocationSharingPreference enqueues forced preference sync without resolving context")
+    func syncLocationSharingPreference_enqueuesForcedPreferenceSyncWithoutResolvingContext() async throws {
         let provider = LocationProvider()
         let manager = LocationManager(
             manager: LocationManagerTests.StubAuthorizationManager(status: .authorizedWhenInUse),
@@ -378,11 +380,13 @@ struct LocationSessionTests {
 
         await session.syncLocationSharingPreference(enabled: false)
 
-        #expect(await uploader.recordedEnqueueCount() == 1)
+        #expect(await uploader.recordedEnqueueCount() == 0)
+        #expect(await uploader.recordedPreferenceSyncCount() == 1)
         #expect(await uploader.recordedLastForceUpload() == true)
         #expect(await uploader.recordedLastSource() == .settingsPreference)
         #expect(await uploader.recordedLastReason() == .preferenceChanged)
-        #expect(session.currentContext == context)
+        #expect(await uploader.recordedLastPreferenceReason() == "location-sharing")
+        #expect(session.currentContext == nil)
         #expect(session.currentSnapshot == context.snapshot)
     }
 
@@ -438,11 +442,12 @@ struct LocationSessionTests {
         await session.updateLocationSharingPreference(enabled: true)
 
         #expect(authManager.requestAlwaysCount == 1)
-        #expect(await uploader.recordedEnqueueCount() == 1)
-        #expect(await uploader.recordedPreferenceSyncCount() == 0)
+        #expect(await uploader.recordedEnqueueCount() == 0)
+        #expect(await uploader.recordedPreferenceSyncCount() == 1)
         #expect(await uploader.recordedLastForceUpload() == true)
         #expect(await uploader.recordedLastSource() == .settingsPreference)
         #expect(await uploader.recordedLastReason() == .preferenceChanged)
+        #expect(await uploader.recordedLastPreferenceReason() == "location-sharing")
     }
 
     @MainActor

--- a/Tests/UnitTests/LocationManagerTests.swift
+++ b/Tests/UnitTests/LocationManagerTests.swift
@@ -99,14 +99,10 @@ struct LocationSessionTests {
     private actor StubResolver: LocationContextResolving {
         let context: LocationContext?
         let error: LocationContextError?
-        let enqueueOnResolve: Bool
-        private var enqueueCount = 0
-        private var lastForceUpload: Bool?
 
-        init(context: LocationContext?, error: LocationContextError?, enqueueOnResolve: Bool = false) {
+        init(context: LocationContext?, error: LocationContextError?) {
             self.context = context
             self.error = error
-            self.enqueueOnResolve = enqueueOnResolve
         }
 
         func prepareCurrentContext(
@@ -128,28 +124,27 @@ struct LocationSessionTests {
             maximumAcceptedLocationAge: TimeInterval?,
             placemarkTimeout: Double
         ) async throws -> LocationContext {
-            if enqueueOnResolve {
-                enqueueCount += 1
-                lastForceUpload = false
-            }
             if let context {
                 return context
             }
             throw error ?? LocationContextError.locationTimeout
         }
+    }
 
-        func enqueueForPush(_ context: LocationContext, forceUpload: Bool) async {
+    private actor StubUploadCoordinator: LocationUploadCoordinating {
+        private var enqueueCount = 0
+        private var lastForceUpload: Bool?
+        private var lastSource: LocationUploadSource?
+
+        func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool) async {
             enqueueCount += 1
             lastForceUpload = forceUpload
+            lastSource = source
         }
 
-        func recordedEnqueueCount() -> Int {
-            enqueueCount
-        }
-
-        func recordedLastForceUpload() -> Bool? {
-            lastForceUpload
-        }
+        func recordedEnqueueCount() -> Int { enqueueCount }
+        func recordedLastForceUpload() -> Bool? { lastForceUpload }
+        func recordedLastSource() -> LocationUploadSource? { lastSource }
     }
 
     @MainActor
@@ -275,10 +270,12 @@ struct LocationSessionTests {
             )
         )
         let resolver = StubResolver(context: context, error: nil)
+        let uploader = StubUploadCoordinator()
         let session = LocationSession(
             locationClient: makeLocationClient(provider: provider),
             locationManager: manager,
-            locationContextResolver: resolver
+            locationContextResolver: resolver,
+            locationUploadCoordinator: uploader
         )
         _ = await session.prepareCurrentLocationContext(
             requiresFreshLocation: false,
@@ -287,8 +284,9 @@ struct LocationSessionTests {
 
         await session.pushServerNotificationPreferenceUpdate()
 
-        #expect(await resolver.recordedEnqueueCount() == 1)
-        #expect(await resolver.recordedLastForceUpload() == false)
+        #expect(await uploader.recordedEnqueueCount() == 1)
+        #expect(await uploader.recordedLastForceUpload() == false)
+        #expect(await uploader.recordedLastSource() == .settingsPreference)
         #expect(session.currentContext == context)
     }
 
@@ -333,10 +331,12 @@ struct LocationSessionTests {
             )
         )
         let resolver = StubResolver(context: context, error: nil)
+        let uploader = StubUploadCoordinator()
         let session = LocationSession(
             locationClient: makeLocationClient(provider: provider),
             locationManager: manager,
-            locationContextResolver: resolver
+            locationContextResolver: resolver,
+            locationUploadCoordinator: uploader
         )
 
         // Let initialization tasks settle, then set deterministic test state.
@@ -346,15 +346,16 @@ struct LocationSessionTests {
 
         await session.pushServerNotificationPreferenceUpdate(forceUpload: true)
 
-        #expect(await resolver.recordedEnqueueCount() == 1)
-        #expect(await resolver.recordedLastForceUpload() == true)
+        #expect(await uploader.recordedEnqueueCount() == 1)
+        #expect(await uploader.recordedLastForceUpload() == true)
+        #expect(await uploader.recordedLastSource() == .settingsPreference)
         #expect(session.currentContext == context)
         #expect(session.currentSnapshot == context.snapshot)
     }
 
     @MainActor
-    @Test("pushServerNotificationPreferenceUpdate can double enqueue when resolveContext also enqueues")
-    func pushServerNotificationPreferenceUpdate_resolvesFromSnapshotAndDoubleEnqueues() async throws {
+    @Test("pushServerNotificationPreferenceUpdate resolves from snapshot and enqueues once")
+    func pushServerNotificationPreferenceUpdate_resolvesFromSnapshotAndEnqueuesOnce() async throws {
         let provider = LocationProvider()
         let manager = LocationManager(
             manager: LocationManagerTests.StubAuthorizationManager(status: .authorizedWhenInUse),
@@ -392,11 +393,13 @@ struct LocationSessionTests {
                 fireZoneLabel: "East Central Colorado"
             )
         )
-        let resolver = StubResolver(context: context, error: nil, enqueueOnResolve: true)
+        let resolver = StubResolver(context: context, error: nil)
+        let uploader = StubUploadCoordinator()
         let session = LocationSession(
             locationClient: makeLocationClient(provider: provider),
             locationManager: manager,
-            locationContextResolver: resolver
+            locationContextResolver: resolver,
+            locationUploadCoordinator: uploader
         )
 
         try await Task.sleep(for: .milliseconds(20))
@@ -405,8 +408,9 @@ struct LocationSessionTests {
 
         await session.pushServerNotificationPreferenceUpdate(forceUpload: true)
 
-        #expect(await resolver.recordedEnqueueCount() == 2)
-        #expect(await resolver.recordedLastForceUpload() == true)
+        #expect(await uploader.recordedEnqueueCount() == 1)
+        #expect(await uploader.recordedLastForceUpload() == true)
+        #expect(await uploader.recordedLastSource() == .settingsPreference)
         #expect(session.currentContext == context)
     }
 

--- a/Tests/UnitTests/LocationManagerTests.swift
+++ b/Tests/UnitTests/LocationManagerTests.swift
@@ -135,12 +135,21 @@ struct LocationSessionTests {
         private var enqueueCount = 0
         private var lastForceUpload: Bool?
         private var lastSource: LocationUploadSource?
+        private var preferenceSyncCount = 0
+        private var lastPreferenceReason: String?
         private var drainCount = 0
 
         func enqueue(_ context: LocationContext, source: LocationUploadSource, forceUpload: Bool) async {
             enqueueCount += 1
             lastForceUpload = forceUpload
             lastSource = source
+        }
+
+        func enqueuePreferenceSync(source: LocationUploadSource, forceUpload: Bool, reason: String) async {
+            preferenceSyncCount += 1
+            lastForceUpload = forceUpload
+            lastSource = source
+            lastPreferenceReason = reason
         }
 
         func drainPendingUploads() async {
@@ -150,6 +159,8 @@ struct LocationSessionTests {
         func recordedEnqueueCount() -> Int { enqueueCount }
         func recordedLastForceUpload() -> Bool? { lastForceUpload }
         func recordedLastSource() -> LocationUploadSource? { lastSource }
+        func recordedPreferenceSyncCount() -> Int { preferenceSyncCount }
+        func recordedLastPreferenceReason() -> String? { lastPreferenceReason }
         func recordedDrainCount() -> Int { drainCount }
     }
 
@@ -357,6 +368,66 @@ struct LocationSessionTests {
         #expect(await uploader.recordedLastSource() == .settingsPreference)
         #expect(session.currentContext == context)
         #expect(session.currentSnapshot == context.snapshot)
+    }
+
+    @MainActor
+    @Test("syncLocationSharingPreference with no context or snapshot queues durable preference sync")
+    func syncLocationSharingPreference_withoutContextOrSnapshot_queuesPreferenceSync() async throws {
+        let provider = LocationProvider()
+        let manager = LocationManager(
+            manager: LocationManagerTests.StubAuthorizationManager(status: .authorizedWhenInUse),
+            onUpdate: { _ in }
+        )
+        let resolver = StubResolver(context: nil, error: .locationTimeout)
+        let uploader = StubUploadCoordinator()
+        let session = LocationSession(
+            locationClient: makeLocationClient(provider: provider),
+            locationManager: manager,
+            locationContextResolver: resolver,
+            locationUploadCoordinator: uploader
+        )
+
+        try await Task.sleep(for: .milliseconds(20))
+        session.currentContext = nil
+        session.currentSnapshot = nil
+
+        await session.syncLocationSharingPreference(enabled: false)
+
+        #expect(await uploader.recordedEnqueueCount() == 0)
+        #expect(await uploader.recordedPreferenceSyncCount() == 1)
+        #expect(await uploader.recordedLastForceUpload() == true)
+        #expect(await uploader.recordedLastSource() == .settingsPreference)
+        #expect(await uploader.recordedLastPreferenceReason() == "location-sharing")
+    }
+
+    @MainActor
+    @Test("syncNotificationPreference with no context or snapshot queues durable preference sync")
+    func syncNotificationPreference_withoutContextOrSnapshot_queuesPreferenceSync() async throws {
+        let provider = LocationProvider()
+        let manager = LocationManager(
+            manager: LocationManagerTests.StubAuthorizationManager(status: .authorizedWhenInUse),
+            onUpdate: { _ in }
+        )
+        let resolver = StubResolver(context: nil, error: .locationTimeout)
+        let uploader = StubUploadCoordinator()
+        let session = LocationSession(
+            locationClient: makeLocationClient(provider: provider),
+            locationManager: manager,
+            locationContextResolver: resolver,
+            locationUploadCoordinator: uploader
+        )
+
+        try await Task.sleep(for: .milliseconds(20))
+        session.currentContext = nil
+        session.currentSnapshot = nil
+
+        await session.syncNotificationPreference(enabled: false)
+
+        #expect(await uploader.recordedEnqueueCount() == 0)
+        #expect(await uploader.recordedPreferenceSyncCount() == 1)
+        #expect(await uploader.recordedLastForceUpload() == true)
+        #expect(await uploader.recordedLastSource() == .settingsPreference)
+        #expect(await uploader.recordedLastPreferenceReason() == "notification")
     }
 
     @MainActor

--- a/Tests/UnitTests/LocationManagerTests.swift
+++ b/Tests/UnitTests/LocationManagerTests.swift
@@ -371,6 +371,93 @@ struct LocationSessionTests {
     }
 
     @MainActor
+    @Test("updateLocationSharingPreference when enabling requests always upgrade and emits one forced settings sync")
+    func updateLocationSharingPreference_whenEnabling_requestsAlwaysUpgradeAndEmitsSingleForcedSettingsSync() async throws {
+        let provider = LocationProvider()
+        let authManager = LocationManagerTests.StubAuthorizationManager(status: .authorizedWhenInUse)
+        let manager = LocationManager(manager: authManager, onUpdate: { _ in })
+        let context = LocationContext(
+            snapshot: LocationSnapshot(
+                coordinates: CLLocationCoordinate2D(latitude: 39.7392, longitude: -104.9903),
+                timestamp: Date(timeIntervalSince1970: 1_234_567),
+                accuracy: 20,
+                placemarkSummary: "Denver, CO",
+                h3Cell: 0x882681b485fffff
+            ),
+            h3Cell: 0x882681b485fffff,
+            grid: GridPointSnapshot(
+                nwsId: "https://api.weather.gov/points/39.7392,-104.9903",
+                latitude: 39.7392,
+                longitude: -104.9903,
+                gridId: "BOU",
+                gridX: 56,
+                gridY: 66,
+                forecastURL: nil,
+                forecastHourlyURL: nil,
+                forecastGridDataURL: nil,
+                observationStationsURL: nil,
+                city: "Denver",
+                state: "CO",
+                timeZoneId: "America/Denver",
+                radarStationId: "KFTG",
+                forecastZone: "COZ039",
+                countyCode: "COC031",
+                fireZone: "COZ246",
+                countyLabel: "Denver County",
+                fireZoneLabel: "East Central Colorado"
+            )
+        )
+        let uploader = StubUploadCoordinator()
+        let session = LocationSession(
+            locationClient: makeLocationClient(provider: provider),
+            locationManager: manager,
+            locationContextResolver: StubResolver(context: context, error: nil),
+            locationUploadCoordinator: uploader
+        )
+        _ = await session.prepareCurrentLocationContext(
+            requiresFreshLocation: false,
+            showsAuthorizationPrompt: false
+        )
+
+        await session.updateLocationSharingPreference(enabled: true)
+
+        #expect(authManager.requestAlwaysCount == 1)
+        #expect(await uploader.recordedEnqueueCount() == 1)
+        #expect(await uploader.recordedPreferenceSyncCount() == 0)
+        #expect(await uploader.recordedLastForceUpload() == true)
+        #expect(await uploader.recordedLastSource() == .settingsPreference)
+    }
+
+    @MainActor
+    @Test("updateLocationSharingPreference when disabling syncs preference without requesting always upgrade")
+    func updateLocationSharingPreference_whenDisabling_syncsPreferenceWithoutRequestingAlwaysUpgrade() async throws {
+        let provider = LocationProvider()
+        let authManager = LocationManagerTests.StubAuthorizationManager(status: .authorizedAlways)
+        let manager = LocationManager(manager: authManager, onUpdate: { _ in })
+        let resolver = StubResolver(context: nil, error: .locationTimeout)
+        let uploader = StubUploadCoordinator()
+        let session = LocationSession(
+            locationClient: makeLocationClient(provider: provider),
+            locationManager: manager,
+            locationContextResolver: resolver,
+            locationUploadCoordinator: uploader
+        )
+
+        try await Task.sleep(for: .milliseconds(20))
+        session.currentContext = nil
+        session.currentSnapshot = nil
+
+        await session.updateLocationSharingPreference(enabled: false)
+
+        #expect(authManager.requestAlwaysCount == 0)
+        #expect(await uploader.recordedEnqueueCount() == 0)
+        #expect(await uploader.recordedPreferenceSyncCount() == 1)
+        #expect(await uploader.recordedLastForceUpload() == true)
+        #expect(await uploader.recordedLastSource() == .settingsPreference)
+        #expect(await uploader.recordedLastPreferenceReason() == "location-sharing")
+    }
+
+    @MainActor
     @Test("syncLocationSharingPreference with no context or snapshot queues durable preference sync")
     func syncLocationSharingPreference_withoutContextOrSnapshot_queuesPreferenceSync() async throws {
         let provider = LocationProvider()

--- a/Tests/UnitTests/LocationProviderTests.swift
+++ b/Tests/UnitTests/LocationProviderTests.swift
@@ -78,6 +78,27 @@ struct LocationProviderTests {
         }
     }
 
+    private final class TokenBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var token: String
+
+        init(_ token: String) {
+            self.token = token
+        }
+
+        func value() -> String {
+            lock.lock()
+            defer { lock.unlock() }
+            return token
+        }
+
+        func set(_ newValue: String) {
+            lock.lock()
+            token = newValue
+            lock.unlock()
+        }
+    }
+
     private actor RacingGeocoder: LocationGeocoding {
         private var callCount = 0
         private var firstContinuation: CheckedContinuation<String, Never>?
@@ -315,6 +336,28 @@ struct LocationProviderTests {
 
         let payloads = await uploader.uploadedPayloads()
         #expect(payloads.isEmpty)
+    }
+
+    @Test("missing APNs token drops the attempted upload instead of replaying later")
+    func locationContextPusher_missingTokenDropsAttempt() async throws {
+        let uploader = MockSnapshotUploader()
+        let tokenState = TokenBox("")
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { tokenState.value() },
+            installationIdProvider: { "install-abc-123" },
+            retryDelaysSeconds: [0]
+        )
+        let context = makeContext()
+
+        await pusher.enqueue(context)
+        tokenState.set("apns-token-123")
+
+        // If the first attempt were persisted, this would now be 1 without a second enqueue.
+        #expect(await uploader.uploadedPayloads().isEmpty)
+
+        await pusher.enqueue(context)
+        #expect(await uploader.uploadedPayloads().count == 1)
     }
 
     @Test("snapshot pusher skips upload when location-to-signal is disabled")

--- a/Tests/UnitTests/LocationProviderTests.swift
+++ b/Tests/UnitTests/LocationProviderTests.swift
@@ -308,7 +308,7 @@ struct LocationProviderTests {
         )
 
         let context = makeContext()
-        await pusher.enqueue(context)
+        await pusher.enqueue(context, source: .manualRefresh)
         
         let payloads = await uploader.uploadedPayloads()
         let payload = try #require(payloads.first)
@@ -332,7 +332,7 @@ struct LocationProviderTests {
             retryDelaysSeconds: [0]
         )
 
-        await pusher.enqueue(makeContext())
+        await pusher.enqueue(makeContext(), source: .manualRefresh)
 
         let payloads = await uploader.uploadedPayloads()
         #expect(payloads.isEmpty)
@@ -350,13 +350,13 @@ struct LocationProviderTests {
         )
         let context = makeContext()
 
-        await pusher.enqueue(context)
+        await pusher.enqueue(context, source: .manualRefresh)
         tokenState.set("apns-token-123")
 
         // If the first attempt were persisted, this would now be 1 without a second enqueue.
         #expect(await uploader.uploadedPayloads().isEmpty)
 
-        await pusher.enqueue(context)
+        await pusher.enqueue(context, source: .manualRefresh)
         #expect(await uploader.uploadedPayloads().count == 1)
     }
 
@@ -377,7 +377,7 @@ struct LocationProviderTests {
             h3Cell: sampleH3Cell
         )
 
-        await pusher.enqueue(context)
+        await pusher.enqueue(context, source: .manualRefresh)
 
         let payloads = await uploader.uploadedPayloads()
         #expect(payloads.isEmpty)
@@ -401,7 +401,7 @@ struct LocationProviderTests {
             h3Cell: sampleH3Cell
         )
 
-        await pusher.enqueue(context, forceUpload: true)
+        await pusher.enqueue(context, source: .settingsPreference, forceUpload: true)
 
         let payloads = await uploader.uploadedPayloads()
         let payload = try #require(payloads.first)
@@ -723,18 +723,6 @@ struct LocationContextResolverTests {
         }
     }
 
-    private actor RecordingContextPusher: LocationContextPushing {
-        private var contexts: [LocationContext] = []
-
-        func enqueue(_ context: LocationContext, forceUpload: Bool) async {
-            contexts.append(context)
-        }
-
-        func count() -> Int {
-            contexts.count
-        }
-    }
-
     private actor RefreshRequestTracker {
         private var count = 0
 
@@ -811,7 +799,6 @@ struct LocationContextResolverTests {
     @Test("waits for authorization result before preparing a ready context")
     func waitsForAuthorizationResult() async throws {
         let authorizationState = AuthorizationState(status: .notDetermined)
-        let pusher = RecordingContextPusher()
         let locationProvider = LocationProvider(
             geocoder: TestGeocoder(result: .success("Norman, OK")),
             hasher: TestHasher(h3Cell: sampleH3Cell)
@@ -828,7 +815,6 @@ struct LocationContextResolverTests {
             locationClient: makeLocationClient(provider: locationProvider),
             locationProvider: locationProvider,
             gridPointProvider: gridPointProvider,
-            contextPusher: pusher,
             authorizationStatusProvider: { await authorizationState.current() },
             authorizationRequester: { _ in
                 Task {
@@ -858,13 +844,11 @@ struct LocationContextResolverTests {
         #expect(context.h3Cell == sampleH3Cell)
         #expect(context.grid.countyCode == "OKC109")
         #expect(context.grid.fireZone == "OKZ025")
-        #expect(await pusher.count() == 1)
     }
 
     @Test("uses the current snapshot immediately when one is already available")
     func usesCurrentSnapshotImmediatelyWhenAvailable() async throws {
         let authorizationState = AuthorizationState(status: .authorizedWhenInUse)
-        let pusher = RecordingContextPusher()
         let timestamp = Date()
         let cached = LocationSnapshot(
             coordinates: CLLocationCoordinate2D(latitude: 35.2226, longitude: -97.4395),
@@ -890,7 +874,6 @@ struct LocationContextResolverTests {
             locationClient: makeLocationClient(provider: locationProvider),
             locationProvider: locationProvider,
             gridPointProvider: gridPointProvider,
-            contextPusher: pusher,
             authorizationStatusProvider: { await authorizationState.current() },
             authorizationRequester: { _ in },
             refreshCurrentLocation: { _ in false }
@@ -908,13 +891,11 @@ struct LocationContextResolverTests {
         #expect(context.snapshot.timestamp == timestamp)
         #expect(context.h3Cell == sampleH3Cell)
         #expect(context.grid.countyCode == "OKC109")
-        #expect(await pusher.count() == 1)
     }
 
     @Test("reuses a recent snapshot when fresh location is requested")
     func reusesRecentSnapshotWhenFreshLocationIsRequested() async throws {
         let authorizationState = AuthorizationState(status: .authorizedWhenInUse)
-        let pusher = RecordingContextPusher()
         let refreshTracker = RefreshRequestTracker()
         let timestamp = Date()
         let cached = LocationSnapshot(
@@ -941,7 +922,6 @@ struct LocationContextResolverTests {
             locationClient: makeLocationClient(provider: locationProvider),
             locationProvider: locationProvider,
             gridPointProvider: gridPointProvider,
-            contextPusher: pusher,
             authorizationStatusProvider: { await authorizationState.current() },
             authorizationRequester: { _ in },
             refreshCurrentLocation: { _ in
@@ -962,13 +942,11 @@ struct LocationContextResolverTests {
         #expect(context.snapshot.timestamp == timestamp)
         #expect(context.h3Cell == sampleH3Cell)
         #expect(await refreshTracker.value() == 0)
-        #expect(await pusher.count() == 1)
     }
 
     @Test("requests a fresh location when the available snapshot is older than the startup reuse window")
     func requestsFreshLocationWhenAvailableSnapshotIsOlderThanReuseWindow() async throws {
         let authorizationState = AuthorizationState(status: .authorizedWhenInUse)
-        let pusher = RecordingContextPusher()
         let refreshTracker = RefreshRequestTracker()
         let staleTimestamp = Date().addingTimeInterval(-60)
         let refreshedTimestamp = Date()
@@ -996,7 +974,6 @@ struct LocationContextResolverTests {
             locationClient: makeLocationClient(provider: locationProvider),
             locationProvider: locationProvider,
             gridPointProvider: gridPointProvider,
-            contextPusher: pusher,
             authorizationStatusProvider: { await authorizationState.current() },
             authorizationRequester: { _ in },
             refreshCurrentLocation: { _ in
@@ -1022,13 +999,11 @@ struct LocationContextResolverTests {
 
         #expect(context.snapshot.timestamp == refreshedTimestamp)
         #expect(await refreshTracker.value() == 1)
-        #expect(await pusher.count() == 1)
     }
 
     @Test("waits for a streamed snapshot when none is immediately available")
     func waitsForStreamedSnapshotWhenUnavailable() async throws {
         let authorizationState = AuthorizationState(status: .authorizedWhenInUse)
-        let pusher = RecordingContextPusher()
         let locationProvider = LocationProvider(
             geocoder: TestGeocoder(result: .failure(.geocodeFailed)),
             hasher: TestHasher(h3Cell: sampleH3Cell)
@@ -1045,7 +1020,6 @@ struct LocationContextResolverTests {
             locationClient: makeLocationClient(provider: locationProvider),
             locationProvider: locationProvider,
             gridPointProvider: gridPointProvider,
-            contextPusher: pusher,
             authorizationStatusProvider: { await authorizationState.current() },
             authorizationRequester: { _ in },
             refreshCurrentLocation: { _ in false }
@@ -1074,7 +1048,6 @@ struct LocationContextResolverTests {
         let context = try await contextTask.value
         #expect(context.snapshot.timestamp == timestamp)
         #expect(context.h3Cell == sampleH3Cell)
-        #expect(await pusher.count() == 1)
     }
 
     @Test("times out cleanly while waiting for authorization resolution")
@@ -1119,7 +1092,6 @@ struct LocationContextResolverTests {
     @Test("times out when no accepted snapshot becomes available")
     func locationTimeoutIsReported() async {
         let authorizationState = AuthorizationState(status: .authorizedWhenInUse)
-        let pusher = RecordingContextPusher()
         let locationProvider = LocationProvider(
             geocoder: TestGeocoder(result: .success("Norman, OK")),
             hasher: TestHasher(h3Cell: sampleH3Cell)
@@ -1136,7 +1108,6 @@ struct LocationContextResolverTests {
             locationClient: makeLocationClient(provider: locationProvider),
             locationProvider: locationProvider,
             gridPointProvider: gridPointProvider,
-            contextPusher: pusher,
             authorizationStatusProvider: { await authorizationState.current() },
             authorizationRequester: { _ in },
             refreshCurrentLocation: { _ in false }
@@ -1155,8 +1126,6 @@ struct LocationContextResolverTests {
         } catch {
             #expect((error as? LocationContextError) == .locationTimeout)
         }
-
-        #expect(await pusher.count() == 0)
     }
 
     @Test("does not produce a ready context without h3")
@@ -1256,7 +1225,6 @@ struct LocationContextResolverTests {
     @Test("allows a ready context when placemark resolution fails")
     func missingPlacemarkDoesNotBlockReadyContext() async throws {
         let authorizationState = AuthorizationState(status: .authorizedWhenInUse)
-        let pusher = RecordingContextPusher()
         let locationProvider = LocationProvider(
             geocoder: TestGeocoder(result: .failure(.geocodeFailed)),
             hasher: TestHasher(h3Cell: sampleH3Cell)
@@ -1273,7 +1241,6 @@ struct LocationContextResolverTests {
             locationClient: makeLocationClient(provider: locationProvider),
             locationProvider: locationProvider,
             gridPointProvider: gridPointProvider,
-            contextPusher: pusher,
             authorizationStatusProvider: { await authorizationState.current() },
             authorizationRequester: { _ in },
             refreshCurrentLocation: { _ in
@@ -1297,7 +1264,6 @@ struct LocationContextResolverTests {
         )
 
         #expect(context.snapshot.placemarkSummary == nil)
-        #expect(await pusher.count() == 1)
     }
 
     private func makePointPayload(includeCounty: Bool, includeFireZone: Bool) -> Data {

--- a/Tests/UnitTests/LocationProviderTests.swift
+++ b/Tests/UnitTests/LocationProviderTests.swift
@@ -72,6 +72,48 @@ struct LocationProviderTests {
         }
     }
 
+    private actor FailFirstThenSucceedSnapshotUploader: LocationSnapshotUploading {
+        private var payloads: [LocationSnapshotPushPayload] = []
+        private var shouldFailNext: Bool
+
+        init(shouldFailFirst: Bool = true) {
+            self.shouldFailNext = shouldFailFirst
+        }
+
+        func upload(_ payload: LocationSnapshotPushPayload) async throws {
+            payloads.append(payload)
+            if shouldFailNext {
+                shouldFailNext = false
+                throw LocationPushError.invalidResponseStatus(503)
+            }
+        }
+
+        func uploadedPayloads() -> [LocationSnapshotPushPayload] {
+            payloads
+        }
+    }
+
+    private actor FailFirstThenSucceedPreferenceUploader: DevicePreferenceSyncUploading {
+        private var payloads: [DevicePreferenceSyncPayload] = []
+        private var shouldFailNext: Bool
+
+        init(shouldFailFirst: Bool = true) {
+            self.shouldFailNext = shouldFailFirst
+        }
+
+        func upload(_ payload: DevicePreferenceSyncPayload) async throws {
+            payloads.append(payload)
+            if shouldFailNext {
+                shouldFailNext = false
+                throw LocationPushError.invalidResponseStatus(503)
+            }
+        }
+
+        func uploadedPayloads() -> [DevicePreferenceSyncPayload] {
+            payloads
+        }
+    }
+
     private actor CompatibilitySnapshotUploader: LocationSnapshotUploading {
         private var payloads: [LocationSnapshotPushPayload] = []
         private let failingStatus: Int
@@ -112,6 +154,80 @@ struct LocationProviderTests {
             await withCheckedContinuation { continuation in
                 firstAttemptContinuation = continuation
             }
+        }
+
+        func attemptCount() -> Int {
+            payloads.count
+        }
+    }
+
+    private actor GateableSnapshotUploader: LocationSnapshotUploading {
+        private var payloads: [LocationSnapshotPushPayload] = []
+        private var isBlocked = true
+        private var firstAttemptContinuation: CheckedContinuation<Void, Never>?
+        private var unblockContinuation: CheckedContinuation<Void, Never>?
+
+        func upload(_ payload: LocationSnapshotPushPayload) async throws {
+            payloads.append(payload)
+            if payloads.count == 1 {
+                firstAttemptContinuation?.resume()
+                firstAttemptContinuation = nil
+            }
+            while isBlocked {
+                await withCheckedContinuation { continuation in
+                    unblockContinuation = continuation
+                }
+            }
+        }
+
+        func waitForFirstAttempt() async {
+            if payloads.isEmpty == false { return }
+            await withCheckedContinuation { continuation in
+                firstAttemptContinuation = continuation
+            }
+        }
+
+        func unblock() {
+            isBlocked = false
+            unblockContinuation?.resume()
+            unblockContinuation = nil
+        }
+
+        func attemptCount() -> Int {
+            payloads.count
+        }
+    }
+
+    private actor GateablePreferenceUploader: DevicePreferenceSyncUploading {
+        private var payloads: [DevicePreferenceSyncPayload] = []
+        private var isBlocked = true
+        private var firstAttemptContinuation: CheckedContinuation<Void, Never>?
+        private var unblockContinuation: CheckedContinuation<Void, Never>?
+
+        func upload(_ payload: DevicePreferenceSyncPayload) async throws {
+            payloads.append(payload)
+            if payloads.count == 1 {
+                firstAttemptContinuation?.resume()
+                firstAttemptContinuation = nil
+            }
+            while isBlocked {
+                await withCheckedContinuation { continuation in
+                    unblockContinuation = continuation
+                }
+            }
+        }
+
+        func waitForFirstAttempt() async {
+            if payloads.isEmpty == false { return }
+            await withCheckedContinuation { continuation in
+                firstAttemptContinuation = continuation
+            }
+        }
+
+        func unblock() {
+            isBlocked = false
+            unblockContinuation?.resume()
+            unblockContinuation = nil
         }
 
         func attemptCount() -> Int {
@@ -677,6 +793,118 @@ struct LocationProviderTests {
         #expect(await store.current().count == 1)
     }
 
+    @Test("preference sync failed upload remains pending across immediate drain inside dedupe window")
+    func preferenceSync_failedUploadImmediateDrain_doesNotDropPending() async throws {
+        struct AlwaysFailingPreferenceUploader: DevicePreferenceSyncUploading {
+            func upload(_ payload: DevicePreferenceSyncPayload) async throws {
+                throw LocationPushError.invalidResponseStatus(503)
+            }
+        }
+
+        let clock = ClockBox(Date(timeIntervalSince1970: 20_000))
+        let store = InMemoryUploadQueueStore()
+        let pusher = LocationSnapshotPusher(
+            locationUploader: MockSnapshotUploader(),
+            preferenceUploader: AlwaysFailingPreferenceUploader(),
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            nowProvider: { clock.now() },
+            retryDelaysSeconds: [0],
+            dedupeWindowSeconds: 15,
+            queueStore: store
+        )
+
+        await pusher.enqueuePreferenceSync(
+            source: .settingsPreference,
+            requestReason: .preferenceChanged,
+            forceUpload: true,
+            detail: "notification"
+        )
+        #expect(await store.current().count == 1)
+
+        await pusher.drainPendingUploads()
+        #expect(await store.current().count == 1)
+    }
+
+    @Test("snapshot failed upload remains pending across immediate drain inside dedupe window")
+    func snapshotPusher_failedUploadImmediateDrain_doesNotDropPending() async throws {
+        struct AlwaysFailingUploader: LocationSnapshotUploading {
+            func upload(_ payload: LocationSnapshotPushPayload) async throws {
+                throw LocationPushError.invalidResponseStatus(503)
+            }
+        }
+
+        let clock = ClockBox(Date(timeIntervalSince1970: 21_000))
+        let store = InMemoryUploadQueueStore()
+        let pusher = LocationSnapshotPusher(
+            uploader: AlwaysFailingUploader(),
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            nowProvider: { clock.now() },
+            retryDelaysSeconds: [0],
+            dedupeWindowSeconds: 15,
+            queueStore: store
+        )
+
+        await pusher.enqueue(makeContext(), source: .manualRefresh, reason: .locationResolved)
+        #expect(await store.current().count == 1)
+
+        await pusher.drainPendingUploads()
+        #expect(await store.current().count == 1)
+    }
+
+    @Test("preference sync failed upload retries on immediate drain and clears pending only after success")
+    func preferenceSync_failOnceThenDrainSuccess_clearsPendingAfterSuccess() async throws {
+        let uploader = FailFirstThenSucceedPreferenceUploader()
+        let clock = ClockBox(Date(timeIntervalSince1970: 22_000))
+        let store = InMemoryUploadQueueStore()
+        let pusher = LocationSnapshotPusher(
+            locationUploader: MockSnapshotUploader(),
+            preferenceUploader: uploader,
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            nowProvider: { clock.now() },
+            retryDelaysSeconds: [0],
+            dedupeWindowSeconds: 15,
+            queueStore: store
+        )
+
+        await pusher.enqueuePreferenceSync(
+            source: .settingsPreference,
+            requestReason: .preferenceChanged,
+            forceUpload: true,
+            detail: "notification"
+        )
+        #expect(await store.current().count == 1)
+
+        await pusher.drainPendingUploads()
+        #expect(await store.current().isEmpty)
+        #expect(await uploader.uploadedPayloads().count == 2)
+    }
+
+    @Test("snapshot failed upload retries on immediate drain and clears pending only after success")
+    func snapshotPusher_failOnceThenDrainSuccess_clearsPendingAfterSuccess() async throws {
+        let uploader = FailFirstThenSucceedSnapshotUploader()
+        let clock = ClockBox(Date(timeIntervalSince1970: 23_000))
+        let store = InMemoryUploadQueueStore()
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            nowProvider: { clock.now() },
+            retryDelaysSeconds: [0],
+            dedupeWindowSeconds: 15,
+            queueStore: store
+        )
+
+        await pusher.enqueue(makeContext(), source: .manualRefresh, reason: .locationResolved)
+        #expect(await store.current().count == 1)
+
+        await pusher.drainPendingUploads()
+        #expect(await store.current().isEmpty)
+        #expect(await uploader.uploadedPayloads().count == 2)
+    }
+
     @Test("preference sync drain removes persisted request on success")
     func preferenceSync_drainRemovesPersistedRequestOnSuccess() async throws {
         let uploader = MockPreferenceUploader()
@@ -856,6 +1084,28 @@ struct LocationProviderTests {
         #expect(await store.current().isEmpty)
     }
 
+    @Test("snapshot pusher coalesces identical upload while first matching upload is in flight")
+    func snapshotPusher_coalescesInFlightIdenticalUpload() async throws {
+        let uploader = GateableSnapshotUploader()
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            retryDelaysSeconds: [0]
+        )
+        let context = makeContext()
+
+        let firstTask = Task {
+            await pusher.enqueue(context, source: .foregroundPrime, reason: .locationResolved)
+        }
+        await uploader.waitForFirstAttempt()
+        await pusher.enqueue(context, source: .foregroundLocationChange, reason: .locationChanged)
+        await uploader.unblock()
+        await firstTask.value
+
+        #expect(await uploader.attemptCount() == 1)
+    }
+
     @Test("pending queue coalesces duplicate semantic keys deterministically")
     func snapshotPusher_pendingQueueCoalescesDuplicates() async throws {
         let uploader = MockSnapshotUploader()
@@ -977,6 +1227,40 @@ struct LocationProviderTests {
         #expect(payloads.map(\.isSubscribed) == [true, false])
     }
 
+    @Test("preference sync coalesces identical upload while first matching upload is in flight")
+    func preferenceSync_coalescesInFlightIdenticalUpload() async throws {
+        let uploader = GateablePreferenceUploader()
+        let pusher = LocationSnapshotPusher(
+            locationUploader: MockSnapshotUploader(),
+            preferenceUploader: uploader,
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            subscriptionStatusProvider: { true },
+            authorizationStatusProvider: { .authorizedWhenInUse },
+            retryDelaysSeconds: [0]
+        )
+
+        let firstTask = Task {
+            await pusher.enqueuePreferenceSync(
+                source: .settingsPreference,
+                requestReason: .preferenceChanged,
+                forceUpload: true,
+                detail: "notification"
+            )
+        }
+        await uploader.waitForFirstAttempt()
+        await pusher.enqueuePreferenceSync(
+            source: .settingsPreference,
+            requestReason: .preferenceChanged,
+            forceUpload: true,
+            detail: "notification"
+        )
+        await uploader.unblock()
+        await firstTask.value
+
+        #expect(await uploader.attemptCount() == 1)
+    }
+
     @Test("snapshot pusher dedupes identical forced uploads inside the dedupe window")
     func snapshotPusher_dedupesIdenticalForcedUploads() async throws {
         let uploader = MockSnapshotUploader()
@@ -998,6 +1282,38 @@ struct LocationProviderTests {
 
         let payloads = await uploader.uploadedPayloads()
         #expect(payloads.count == 1)
+    }
+
+    @Test("preference sync dedupes identical successful uploads inside the dedupe window")
+    func preferenceSync_dedupesIdenticalSuccessfulUploads() async throws {
+        let uploader = MockPreferenceUploader()
+        let clock = ClockBox(Date(timeIntervalSince1970: 24_000))
+        let pusher = LocationSnapshotPusher(
+            locationUploader: MockSnapshotUploader(),
+            preferenceUploader: uploader,
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            subscriptionStatusProvider: { true },
+            authorizationStatusProvider: { .authorizedWhenInUse },
+            nowProvider: { clock.now() },
+            retryDelaysSeconds: [0],
+            dedupeWindowSeconds: 15
+        )
+
+        await pusher.enqueuePreferenceSync(
+            source: .settingsPreference,
+            requestReason: .preferenceChanged,
+            forceUpload: true,
+            detail: "notification"
+        )
+        await pusher.enqueuePreferenceSync(
+            source: .settingsPreference,
+            requestReason: .preferenceChanged,
+            forceUpload: true,
+            detail: "notification"
+        )
+
+        #expect(await uploader.uploadedPayloads().count == 1)
     }
 
     @Test("snapshot pusher allows identical upload after dedupe window elapses")

--- a/Tests/UnitTests/LocationProviderTests.swift
+++ b/Tests/UnitTests/LocationProviderTests.swift
@@ -1125,6 +1125,37 @@ struct LocationProviderTests {
         #expect(await store.current().count == 1)
     }
 
+    @Test("persisted empty-token request coalesces with same semantic request after APNs token becomes available")
+    func snapshotPusher_coalescesPersistedRequestAcrossApnsTokenTransition() async throws {
+        let uploader = MockSnapshotUploader()
+        let context = makeContext()
+        let persisted = PersistedLocationUploadRequest(
+            source: .manualRefresh,
+            reason: .locationResolved,
+            forceUpload: false,
+            installationId: "install-abc-123",
+            requestedAt: Date(timeIntervalSince1970: 10_000),
+            isSubscribed: true,
+            authorizationState: "always",
+            apnsToken: "",
+            operation: .locationSnapshot(context: PersistedLocationContext(context))
+        )
+        let store = InMemoryUploadQueueStore(seed: [persisted])
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            retryDelaysSeconds: [0],
+            queueStore: store
+        )
+
+        await pusher.enqueue(context, source: .manualRefresh, reason: .locationResolved)
+        await pusher.drainPendingUploads()
+
+        #expect(await uploader.uploadedPayloads().count == 1)
+        #expect(await store.current().isEmpty)
+    }
+
     @Test("pending queue preserves distinct semantic keys")
     func snapshotPusher_pendingQueuePreservesDistinctKeys() async throws {
         let uploader = MockSnapshotUploader()

--- a/Tests/UnitTests/LocationProviderTests.swift
+++ b/Tests/UnitTests/LocationProviderTests.swift
@@ -451,6 +451,32 @@ struct LocationProviderTests {
         #expect(await store.current().isEmpty)
     }
 
+    @Test("onboarding upload survives delayed APNs token and drains deterministically")
+    func locationContextPusher_onboardingDelayedToken_drainUsesOnboardingSource() async throws {
+        let uploader = MockSnapshotUploader()
+        let store = InMemoryUploadQueueStore()
+        let tokenState = TokenBox("")
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { tokenState.value() },
+            installationIdProvider: { "install-abc-123" },
+            authorizationStatusProvider: { .authorizedWhenInUse },
+            retryDelaysSeconds: [0],
+            queueStore: store
+        )
+
+        await pusher.enqueue(makeContext(), source: .onboarding)
+        #expect(await store.current().count == 1)
+
+        tokenState.set("apns-token-123")
+        await pusher.drainPendingUploads()
+
+        let payload = try #require(await uploader.uploadedPayloads().first)
+        #expect(payload.source == LocationUploadSource.onboarding.rawValue)
+        #expect(payload.auth == "whenInUse")
+        #expect(await store.current().isEmpty)
+    }
+
     @Test("snapshot pusher persists pending request when upload fails after retry budget")
     func snapshotPusher_persistsOnRetryExhaustion() async throws {
         struct AlwaysFailingUploader: LocationSnapshotUploading {

--- a/Tests/UnitTests/LocationProviderTests.swift
+++ b/Tests/UnitTests/LocationProviderTests.swift
@@ -60,6 +60,18 @@ struct LocationProviderTests {
         }
     }
 
+    private actor MockPreferenceUploader: DevicePreferenceSyncUploading {
+        private var payloads: [DevicePreferenceSyncPayload] = []
+
+        func upload(_ payload: DevicePreferenceSyncPayload) async throws {
+            payloads.append(payload)
+        }
+
+        func uploadedPayloads() -> [DevicePreferenceSyncPayload] {
+            payloads
+        }
+    }
+
     private actor CompatibilitySnapshotUploader: LocationSnapshotUploading {
         private var payloads: [LocationSnapshotPushPayload] = []
         private let failingStatus: Int
@@ -478,10 +490,12 @@ struct LocationProviderTests {
 
     @Test("opt-out preference sync without location context persists when APNs token is missing")
     func locationContextPusher_preferenceSyncWithoutContext_missingTokenPersists() async throws {
-        let uploader = MockSnapshotUploader()
+        let locationUploader = MockSnapshotUploader()
+        let preferenceUploader = MockPreferenceUploader()
         let store = InMemoryUploadQueueStore()
         let pusher = LocationSnapshotPusher(
-            uploader: uploader,
+            locationUploader: locationUploader,
+            preferenceUploader: preferenceUploader,
             apnsTokenProvider: { "" },
             installationIdProvider: { "install-abc-123" },
             subscriptionStatusProvider: { false },
@@ -497,10 +511,11 @@ struct LocationProviderTests {
             detail: "location-sharing"
         )
 
-        #expect(await uploader.uploadedPayloads().isEmpty)
+        #expect(await locationUploader.uploadedPayloads().isEmpty)
+        #expect(await preferenceUploader.uploadedPayloads().isEmpty)
         #expect(await store.current().count == 1)
         let persisted = try #require(await store.current().first)
-        #expect(persisted.context == nil)
+        #expect(persisted.operation == .preferenceSync)
         #expect(persisted.reason == .preferenceChanged)
         #expect(persisted.isSubscribed == false)
         #expect(persisted.forceUpload == true)
@@ -508,11 +523,13 @@ struct LocationProviderTests {
 
     @Test("opt-out preference sync without location context drains when APNs token arrives")
     func locationContextPusher_preferenceSyncWithoutContext_drainsOnTokenArrival() async throws {
-        let uploader = MockSnapshotUploader()
+        let locationUploader = MockSnapshotUploader()
+        let preferenceUploader = MockPreferenceUploader()
         let store = InMemoryUploadQueueStore()
         let tokenState = TokenBox("")
         let pusher = LocationSnapshotPusher(
-            uploader: uploader,
+            locationUploader: locationUploader,
+            preferenceUploader: preferenceUploader,
             apnsTokenProvider: { tokenState.value() },
             installationIdProvider: { "install-abc-123" },
             subscriptionStatusProvider: { false },
@@ -532,11 +549,11 @@ struct LocationProviderTests {
         tokenState.set("apns-token-123")
         await pusher.drainPendingUploads()
 
-        let payload = try #require(await uploader.uploadedPayloads().first)
+        #expect(await locationUploader.uploadedPayloads().isEmpty)
+        let payload = try #require(await preferenceUploader.uploadedPayloads().first)
         #expect(payload.source == LocationUploadSource.settingsPreference.rawValue)
         #expect(payload.isSubscribed == false)
-        #expect(payload.h3Cell == nil)
-        #expect(payload.county == nil)
+        #expect(payload.reason == LocationUploadReason.preferenceChanged.rawValue)
         #expect(await store.current().isEmpty)
     }
 
@@ -606,6 +623,89 @@ struct LocationProviderTests {
         #expect(await store.current().count == 1)
     }
 
+    @Test("preference sync persists pending request when upload fails after retry budget")
+    func preferenceSync_persistsOnRetryExhaustion() async throws {
+        struct AlwaysFailingPreferenceUploader: DevicePreferenceSyncUploading {
+            func upload(_ payload: DevicePreferenceSyncPayload) async throws {
+                throw LocationPushError.invalidResponseStatus(503)
+            }
+        }
+
+        let store = InMemoryUploadQueueStore()
+        let pusher = LocationSnapshotPusher(
+            locationUploader: MockSnapshotUploader(),
+            preferenceUploader: AlwaysFailingPreferenceUploader(),
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            retryDelaysSeconds: [0],
+            queueStore: store
+        )
+
+        await pusher.enqueuePreferenceSync(
+            source: .settingsPreference,
+            requestReason: .preferenceChanged,
+            forceUpload: true,
+            detail: "notification"
+        )
+        #expect(await store.current().count == 1)
+    }
+
+    @Test("preference sync persists pending request when upload is cancelled")
+    func preferenceSync_persistsOnCancellation() async throws {
+        struct CancellingPreferenceUploader: DevicePreferenceSyncUploading {
+            func upload(_ payload: DevicePreferenceSyncPayload) async throws {
+                throw CancellationError()
+            }
+        }
+
+        let store = InMemoryUploadQueueStore()
+        let pusher = LocationSnapshotPusher(
+            locationUploader: MockSnapshotUploader(),
+            preferenceUploader: CancellingPreferenceUploader(),
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            retryDelaysSeconds: [0],
+            queueStore: store
+        )
+
+        await pusher.enqueuePreferenceSync(
+            source: .settingsPreference,
+            requestReason: .preferenceChanged,
+            forceUpload: true,
+            detail: "notification"
+        )
+        #expect(await store.current().count == 1)
+    }
+
+    @Test("preference sync drain removes persisted request on success")
+    func preferenceSync_drainRemovesPersistedRequestOnSuccess() async throws {
+        let uploader = MockPreferenceUploader()
+        let persisted = PersistedLocationUploadRequest(
+            source: .settingsPreference,
+            reason: .preferenceChanged,
+            forceUpload: true,
+            installationId: "install-abc-123",
+            requestedAt: Date(timeIntervalSince1970: 10_000),
+            isSubscribed: false,
+            authorizationState: "always",
+            apnsToken: "",
+            operation: .preferenceSync
+        )
+        let store = InMemoryUploadQueueStore(seed: [persisted])
+        let pusher = LocationSnapshotPusher(
+            locationUploader: MockSnapshotUploader(),
+            preferenceUploader: uploader,
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            retryDelaysSeconds: [0],
+            queueStore: store
+        )
+
+        await pusher.drainPendingUploads()
+        #expect(await uploader.uploadedPayloads().count == 1)
+        #expect(await store.current().isEmpty)
+    }
+
     @Test("snapshot pusher cancels retry during backoff and preserves pending request")
     func snapshotPusher_cancellationDuringBackoffStopsRetryAndPersistsPending() async throws {
         let uploader = BackoffCancellingUploader()
@@ -633,7 +733,6 @@ struct LocationProviderTests {
     func snapshotPusher_drainRemovesPersistedRequestOnSuccess() async throws {
         let uploader = MockSnapshotUploader()
         let persisted = PersistedLocationUploadRequest(
-            context: PersistedLocationContext(makeContext()),
             source: .manualRefresh,
             reason: .locationResolved,
             forceUpload: false,
@@ -641,7 +740,8 @@ struct LocationProviderTests {
             requestedAt: Date(timeIntervalSince1970: 10_000),
             isSubscribed: true,
             authorizationState: "always",
-            apnsToken: ""
+            apnsToken: "",
+            operation: .locationSnapshot(context: PersistedLocationContext(makeContext()))
         )
         let store = InMemoryUploadQueueStore(seed: [persisted])
         let pusher = LocationSnapshotPusher(
@@ -707,9 +807,11 @@ struct LocationProviderTests {
 
     @Test("snapshot pusher skips non-forced preference sync when location sharing is disabled")
     func snapshotPusher_skipsNonForcedPreferenceSyncWhenLocationSharingDisabled() async throws {
-        let uploader = MockSnapshotUploader()
+        let locationUploader = MockSnapshotUploader()
+        let preferenceUploader = MockPreferenceUploader()
         let pusher = LocationSnapshotPusher(
-            uploader: uploader,
+            locationUploader: locationUploader,
+            preferenceUploader: preferenceUploader,
             apnsTokenProvider: { "apns-token-123" },
             installationIdProvider: { "install-abc-123" },
             subscriptionStatusProvider: { false },
@@ -717,9 +819,15 @@ struct LocationProviderTests {
             retryDelaysSeconds: [0]
         )
 
-        await pusher.enqueue(makeContext(), source: .settingsPreference, reason: .preferenceChanged, forceUpload: false)
+        await pusher.enqueuePreferenceSync(
+            source: .settingsPreference,
+            requestReason: .preferenceChanged,
+            forceUpload: false,
+            detail: "notification"
+        )
 
-        #expect(await uploader.uploadedPayloads().isEmpty)
+        #expect(await locationUploader.uploadedPayloads().isEmpty)
+        #expect(await preferenceUploader.uploadedPayloads().isEmpty)
     }
 
     @Test("snapshot pusher dedupes identical non-forced uploads inside the dedupe window")
@@ -835,11 +943,12 @@ struct LocationProviderTests {
 
     @Test("snapshot pusher does not dedupe preference state changes")
     func snapshotPusher_doesNotDedupePreferenceStateChanges() async throws {
-        let uploader = MockSnapshotUploader()
+        let uploader = MockPreferenceUploader()
         let clock = ClockBox(Date(timeIntervalSince1970: 13_000))
         let subscribed = BoolBox(true)
         let pusher = LocationSnapshotPusher(
-            uploader: uploader,
+            locationUploader: MockSnapshotUploader(),
+            preferenceUploader: uploader,
             apnsTokenProvider: { "apns-token-123" },
             installationIdProvider: { "install-abc-123" },
             subscriptionStatusProvider: { subscribed.value() },
@@ -848,11 +957,20 @@ struct LocationProviderTests {
             retryDelaysSeconds: [0],
             dedupeWindowSeconds: 15
         )
-        let context = makeContext()
 
-        await pusher.enqueue(context, source: .settingsPreference, reason: .preferenceChanged, forceUpload: true)
+        await pusher.enqueuePreferenceSync(
+            source: .settingsPreference,
+            requestReason: .preferenceChanged,
+            forceUpload: true,
+            detail: "notification"
+        )
         subscribed.set(false)
-        await pusher.enqueue(context, source: .settingsPreference, reason: .preferenceChanged, forceUpload: true)
+        await pusher.enqueuePreferenceSync(
+            source: .settingsPreference,
+            requestReason: .preferenceChanged,
+            forceUpload: true,
+            detail: "notification"
+        )
 
         let payloads = await uploader.uploadedPayloads()
         #expect(payloads.count == 2)

--- a/Tests/UnitTests/LocationProviderTests.swift
+++ b/Tests/UnitTests/LocationProviderTests.swift
@@ -81,6 +81,26 @@ struct LocationProviderTests {
             payloads
         }
     }
+
+    private actor InMemoryUploadQueueStore: LocationUploadQueueStoring {
+        private var pending: [PersistedLocationUploadRequest]
+
+        init(seed: [PersistedLocationUploadRequest] = []) {
+            self.pending = seed
+        }
+
+        func loadPendingRequests() async -> [PersistedLocationUploadRequest] {
+            pending
+        }
+
+        func savePendingRequests(_ requests: [PersistedLocationUploadRequest]) async {
+            pending = requests
+        }
+
+        func current() async -> [PersistedLocationUploadRequest] {
+            pending
+        }
+    }
     
     private final class MockSnapshotCache: @unchecked Sendable, LocationSnapshotCaching {
         private(set) var storedSnapshot: LocationSnapshot?
@@ -392,39 +412,110 @@ struct LocationProviderTests {
     @Test("location context pusher skips upload when APNs token is missing")
     func locationContextPusher_skipsUploadWithoutApnsToken() async {
         let uploader = MockSnapshotUploader()
+        let store = InMemoryUploadQueueStore()
         let pusher = LocationSnapshotPusher(
             uploader: uploader,
             apnsTokenProvider: { " " },
             installationIdProvider: { "install-abc-123" },
-            retryDelaysSeconds: [0]
+            retryDelaysSeconds: [0],
+            queueStore: store
         )
 
         await pusher.enqueue(makeContext(), source: .manualRefresh)
 
         let payloads = await uploader.uploadedPayloads()
         #expect(payloads.isEmpty)
+        #expect(await store.current().count == 1)
     }
 
-    @Test("missing APNs token drops the attempted upload instead of replaying later")
-    func locationContextPusher_missingTokenDropsAttempt() async throws {
+    @Test("missing APNs token persists and later drains after token arrives")
+    func locationContextPusher_missingTokenPersistsAndDrainsOnRetry() async throws {
         let uploader = MockSnapshotUploader()
+        let store = InMemoryUploadQueueStore()
         let tokenState = TokenBox("")
         let pusher = LocationSnapshotPusher(
             uploader: uploader,
             apnsTokenProvider: { tokenState.value() },
             installationIdProvider: { "install-abc-123" },
-            retryDelaysSeconds: [0]
+            retryDelaysSeconds: [0],
+            queueStore: store
         )
         let context = makeContext()
 
         await pusher.enqueue(context, source: .manualRefresh)
+        #expect(await store.current().count == 1)
         tokenState.set("apns-token-123")
+        await pusher.drainPendingUploads()
 
-        // If the first attempt were persisted, this would now be 1 without a second enqueue.
-        #expect(await uploader.uploadedPayloads().isEmpty)
-
-        await pusher.enqueue(context, source: .manualRefresh)
         #expect(await uploader.uploadedPayloads().count == 1)
+        #expect(await store.current().isEmpty)
+    }
+
+    @Test("snapshot pusher persists pending request when upload fails after retry budget")
+    func snapshotPusher_persistsOnRetryExhaustion() async throws {
+        struct AlwaysFailingUploader: LocationSnapshotUploading {
+            func upload(_ payload: LocationSnapshotPushPayload) async throws {
+                throw LocationPushError.invalidResponseStatus(503)
+            }
+        }
+        let store = InMemoryUploadQueueStore()
+        let pusher = LocationSnapshotPusher(
+            uploader: AlwaysFailingUploader(),
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            retryDelaysSeconds: [0],
+            queueStore: store
+        )
+
+        await pusher.enqueue(makeContext(), source: .manualRefresh)
+        #expect(await store.current().count == 1)
+    }
+
+    @Test("snapshot pusher persists pending request when upload is cancelled")
+    func snapshotPusher_persistsOnCancellation() async throws {
+        struct CancellingUploader: LocationSnapshotUploading {
+            func upload(_ payload: LocationSnapshotPushPayload) async throws {
+                throw CancellationError()
+            }
+        }
+        let store = InMemoryUploadQueueStore()
+        let pusher = LocationSnapshotPusher(
+            uploader: CancellingUploader(),
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            retryDelaysSeconds: [0],
+            queueStore: store
+        )
+
+        await pusher.enqueue(makeContext(), source: .manualRefresh)
+        #expect(await store.current().count == 1)
+    }
+
+    @Test("drain removes persisted request on successful upload")
+    func snapshotPusher_drainRemovesPersistedRequestOnSuccess() async throws {
+        let uploader = MockSnapshotUploader()
+        let persisted = PersistedLocationUploadRequest(
+            context: PersistedLocationContext(makeContext()),
+            source: .manualRefresh,
+            forceUpload: false,
+            installationId: "install-abc-123",
+            requestedAt: Date(timeIntervalSince1970: 10_000),
+            isSubscribed: true,
+            authorizationState: "always",
+            apnsToken: ""
+        )
+        let store = InMemoryUploadQueueStore(seed: [persisted])
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            retryDelaysSeconds: [0],
+            queueStore: store
+        )
+
+        await pusher.drainPendingUploads()
+        #expect(await uploader.uploadedPayloads().count == 1)
+        #expect(await store.current().isEmpty)
     }
 
     @Test("snapshot pusher skips upload when location-to-signal is disabled")
@@ -478,6 +569,7 @@ struct LocationProviderTests {
     @Test("snapshot pusher dedupes identical non-forced uploads inside the dedupe window")
     func snapshotPusher_dedupesIdenticalNonForcedUploads() async throws {
         let uploader = MockSnapshotUploader()
+        let store = InMemoryUploadQueueStore()
         let clock = ClockBox(Date(timeIntervalSince1970: 10_000))
         let pusher = LocationSnapshotPusher(
             uploader: uploader,
@@ -487,7 +579,8 @@ struct LocationProviderTests {
             authorizationStatusProvider: { .authorizedWhenInUse },
             nowProvider: { clock.now() },
             retryDelaysSeconds: [0],
-            dedupeWindowSeconds: 15
+            dedupeWindowSeconds: 15,
+            queueStore: store
         )
         let context = makeContext()
 
@@ -496,11 +589,58 @@ struct LocationProviderTests {
 
         let payloads = await uploader.uploadedPayloads()
         #expect(payloads.count == 1)
+        #expect(await store.current().isEmpty)
+    }
+
+    @Test("pending queue coalesces duplicate semantic keys deterministically")
+    func snapshotPusher_pendingQueueCoalescesDuplicates() async throws {
+        let uploader = MockSnapshotUploader()
+        let store = InMemoryUploadQueueStore()
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { "" },
+            installationIdProvider: { "install-abc-123" },
+            retryDelaysSeconds: [0],
+            queueStore: store
+        )
+        let context = makeContext()
+
+        await pusher.enqueue(context, source: .manualRefresh)
+        await pusher.enqueue(context, source: .manualRefresh)
+
+        #expect(await store.current().count == 1)
+    }
+
+    @Test("pending queue preserves distinct semantic keys")
+    func snapshotPusher_pendingQueuePreservesDistinctKeys() async throws {
+        let uploader = MockSnapshotUploader()
+        let store = InMemoryUploadQueueStore()
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { "" },
+            installationIdProvider: { "install-abc-123" },
+            retryDelaysSeconds: [0],
+            queueStore: store
+        )
+        let first = makeContext(
+            h3Cell: sampleH3Cell,
+            grid: makeGridSnapshot(countyCode: "OKC109", fireZone: "OKZ025")
+        )
+        let second = makeContext(
+            h3Cell: sampleH3Cell + 1,
+            grid: makeGridSnapshot(countyCode: "OKC017", fireZone: "OKZ030")
+        )
+
+        await pusher.enqueue(first, source: .manualRefresh)
+        await pusher.enqueue(second, source: .manualRefresh)
+
+        #expect(await store.current().count == 2)
     }
 
     @Test("snapshot pusher does not dedupe when location scope changes")
     func snapshotPusher_doesNotDedupeScopeChanges() async throws {
         let uploader = MockSnapshotUploader()
+        let store = InMemoryUploadQueueStore()
         let clock = ClockBox(Date(timeIntervalSince1970: 12_000))
         let pusher = LocationSnapshotPusher(
             uploader: uploader,
@@ -510,7 +650,8 @@ struct LocationProviderTests {
             authorizationStatusProvider: { .authorizedWhenInUse },
             nowProvider: { clock.now() },
             retryDelaysSeconds: [0],
-            dedupeWindowSeconds: 15
+            dedupeWindowSeconds: 15,
+            queueStore: store
         )
 
         let first = makeContext(
@@ -533,6 +674,7 @@ struct LocationProviderTests {
 
         let payloads = await uploader.uploadedPayloads()
         #expect(payloads.count == 2)
+        #expect(await store.current().isEmpty)
     }
 
     @Test("snapshot pusher does not dedupe preference state changes")

--- a/Tests/UnitTests/LocationProviderTests.swift
+++ b/Tests/UnitTests/LocationProviderTests.swift
@@ -566,6 +566,23 @@ struct LocationProviderTests {
         #expect(payload.isSubscribed == false)
     }
 
+    @Test("snapshot pusher skips non-forced preference sync when location sharing is disabled")
+    func snapshotPusher_skipsNonForcedPreferenceSyncWhenLocationSharingDisabled() async throws {
+        let uploader = MockSnapshotUploader()
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            subscriptionStatusProvider: { false },
+            locationUploadEnabledProvider: { false },
+            retryDelaysSeconds: [0]
+        )
+
+        await pusher.enqueue(makeContext(), source: .settingsPreference, forceUpload: false)
+
+        #expect(await uploader.uploadedPayloads().isEmpty)
+    }
+
     @Test("snapshot pusher dedupes identical non-forced uploads inside the dedupe window")
     func snapshotPusher_dedupesIdenticalNonForcedUploads() async throws {
         let uploader = MockSnapshotUploader()

--- a/Tests/UnitTests/LocationProviderTests.swift
+++ b/Tests/UnitTests/LocationProviderTests.swift
@@ -418,7 +418,7 @@ struct LocationProviderTests {
         )
 
         let context = makeContext()
-        await pusher.enqueue(context, source: .manualRefresh)
+        await pusher.enqueue(context, source: .manualRefresh, reason: .locationResolved)
         
         let payloads = await uploader.uploadedPayloads()
         let payload = try #require(payloads.first)
@@ -446,7 +446,7 @@ struct LocationProviderTests {
             queueStore: store
         )
 
-        await pusher.enqueue(makeContext(), source: .manualRefresh)
+        await pusher.enqueue(makeContext(), source: .manualRefresh, reason: .locationResolved)
 
         let payloads = await uploader.uploadedPayloads()
         #expect(payloads.isEmpty)
@@ -467,7 +467,7 @@ struct LocationProviderTests {
         )
         let context = makeContext()
 
-        await pusher.enqueue(context, source: .manualRefresh)
+        await pusher.enqueue(context, source: .manualRefresh, reason: .locationResolved)
         #expect(await store.current().count == 1)
         tokenState.set("apns-token-123")
         await pusher.drainPendingUploads()
@@ -492,14 +492,16 @@ struct LocationProviderTests {
 
         await pusher.enqueuePreferenceSync(
             source: .settingsPreference,
+            requestReason: .preferenceChanged,
             forceUpload: true,
-            reason: "location-sharing"
+            detail: "location-sharing"
         )
 
         #expect(await uploader.uploadedPayloads().isEmpty)
         #expect(await store.current().count == 1)
         let persisted = try #require(await store.current().first)
         #expect(persisted.context == nil)
+        #expect(persisted.reason == .preferenceChanged)
         #expect(persisted.isSubscribed == false)
         #expect(persisted.forceUpload == true)
     }
@@ -521,8 +523,9 @@ struct LocationProviderTests {
 
         await pusher.enqueuePreferenceSync(
             source: .settingsPreference,
+            requestReason: .preferenceChanged,
             forceUpload: true,
-            reason: "notification"
+            detail: "notification"
         )
         #expect(await store.current().count == 1)
 
@@ -551,7 +554,7 @@ struct LocationProviderTests {
             queueStore: store
         )
 
-        await pusher.enqueue(makeContext(), source: .onboarding)
+        await pusher.enqueue(makeContext(), source: .onboarding, reason: .locationResolved)
         #expect(await store.current().count == 1)
 
         tokenState.set("apns-token-123")
@@ -579,7 +582,7 @@ struct LocationProviderTests {
             queueStore: store
         )
 
-        await pusher.enqueue(makeContext(), source: .manualRefresh)
+        await pusher.enqueue(makeContext(), source: .manualRefresh, reason: .locationResolved)
         #expect(await store.current().count == 1)
     }
 
@@ -599,7 +602,7 @@ struct LocationProviderTests {
             queueStore: store
         )
 
-        await pusher.enqueue(makeContext(), source: .manualRefresh)
+        await pusher.enqueue(makeContext(), source: .manualRefresh, reason: .locationResolved)
         #expect(await store.current().count == 1)
     }
 
@@ -616,7 +619,7 @@ struct LocationProviderTests {
         )
 
         let enqueueTask = Task {
-            await pusher.enqueue(makeContext(), source: .manualRefresh)
+            await pusher.enqueue(makeContext(), source: .manualRefresh, reason: .locationResolved)
         }
         await uploader.waitForFirstAttempt()
         enqueueTask.cancel()
@@ -632,6 +635,7 @@ struct LocationProviderTests {
         let persisted = PersistedLocationUploadRequest(
             context: PersistedLocationContext(makeContext()),
             source: .manualRefresh,
+            reason: .locationResolved,
             forceUpload: false,
             installationId: "install-abc-123",
             requestedAt: Date(timeIntervalSince1970: 10_000),
@@ -670,7 +674,7 @@ struct LocationProviderTests {
             h3Cell: sampleH3Cell
         )
 
-        await pusher.enqueue(context, source: .manualRefresh)
+        await pusher.enqueue(context, source: .manualRefresh, reason: .locationResolved)
 
         let payloads = await uploader.uploadedPayloads()
         #expect(payloads.isEmpty)
@@ -694,7 +698,7 @@ struct LocationProviderTests {
             h3Cell: sampleH3Cell
         )
 
-        await pusher.enqueue(context, source: .settingsPreference, forceUpload: true)
+        await pusher.enqueue(context, source: .settingsPreference, reason: .preferenceChanged, forceUpload: true)
 
         let payloads = await uploader.uploadedPayloads()
         let payload = try #require(payloads.first)
@@ -713,7 +717,7 @@ struct LocationProviderTests {
             retryDelaysSeconds: [0]
         )
 
-        await pusher.enqueue(makeContext(), source: .settingsPreference, forceUpload: false)
+        await pusher.enqueue(makeContext(), source: .settingsPreference, reason: .preferenceChanged, forceUpload: false)
 
         #expect(await uploader.uploadedPayloads().isEmpty)
     }
@@ -736,8 +740,8 @@ struct LocationProviderTests {
         )
         let context = makeContext()
 
-        await pusher.enqueue(context, source: .foregroundPrime)
-        await pusher.enqueue(context, source: .foregroundLocationChange)
+        await pusher.enqueue(context, source: .foregroundPrime, reason: .locationResolved)
+        await pusher.enqueue(context, source: .foregroundLocationChange, reason: .locationChanged)
 
         let payloads = await uploader.uploadedPayloads()
         #expect(payloads.count == 1)
@@ -757,8 +761,8 @@ struct LocationProviderTests {
         )
         let context = makeContext()
 
-        await pusher.enqueue(context, source: .manualRefresh)
-        await pusher.enqueue(context, source: .manualRefresh)
+        await pusher.enqueue(context, source: .manualRefresh, reason: .locationResolved)
+        await pusher.enqueue(context, source: .manualRefresh, reason: .locationResolved)
 
         #expect(await store.current().count == 1)
     }
@@ -783,8 +787,8 @@ struct LocationProviderTests {
             grid: makeGridSnapshot(countyCode: "OKC017", fireZone: "OKZ030")
         )
 
-        await pusher.enqueue(first, source: .manualRefresh)
-        await pusher.enqueue(second, source: .manualRefresh)
+        await pusher.enqueue(first, source: .manualRefresh, reason: .locationResolved)
+        await pusher.enqueue(second, source: .manualRefresh, reason: .locationResolved)
 
         #expect(await store.current().count == 2)
     }
@@ -821,8 +825,8 @@ struct LocationProviderTests {
             )
         )
 
-        await pusher.enqueue(first, source: .foregroundPrime)
-        await pusher.enqueue(second, source: .foregroundLocationChange)
+        await pusher.enqueue(first, source: .foregroundPrime, reason: .locationResolved)
+        await pusher.enqueue(second, source: .foregroundLocationChange, reason: .locationChanged)
 
         let payloads = await uploader.uploadedPayloads()
         #expect(payloads.count == 2)
@@ -846,9 +850,9 @@ struct LocationProviderTests {
         )
         let context = makeContext()
 
-        await pusher.enqueue(context, source: .settingsPreference, forceUpload: true)
+        await pusher.enqueue(context, source: .settingsPreference, reason: .preferenceChanged, forceUpload: true)
         subscribed.set(false)
-        await pusher.enqueue(context, source: .settingsPreference, forceUpload: true)
+        await pusher.enqueue(context, source: .settingsPreference, reason: .preferenceChanged, forceUpload: true)
 
         let payloads = await uploader.uploadedPayloads()
         #expect(payloads.count == 2)
@@ -871,8 +875,8 @@ struct LocationProviderTests {
         )
         let context = makeContext()
 
-        await pusher.enqueue(context, source: .settingsPreference, forceUpload: true)
-        await pusher.enqueue(context, source: .settingsPreference, forceUpload: true)
+        await pusher.enqueue(context, source: .settingsPreference, reason: .preferenceChanged, forceUpload: true)
+        await pusher.enqueue(context, source: .settingsPreference, reason: .preferenceChanged, forceUpload: true)
 
         let payloads = await uploader.uploadedPayloads()
         #expect(payloads.count == 1)
@@ -894,9 +898,9 @@ struct LocationProviderTests {
         )
         let context = makeContext()
 
-        await pusher.enqueue(context, source: .foregroundPrime)
+        await pusher.enqueue(context, source: .foregroundPrime, reason: .locationResolved)
         clock.advance(by: 16)
-        await pusher.enqueue(context, source: .foregroundLocationChange)
+        await pusher.enqueue(context, source: .foregroundLocationChange, reason: .locationChanged)
 
         let payloads = await uploader.uploadedPayloads()
         #expect(payloads.count == 2)
@@ -914,7 +918,7 @@ struct LocationProviderTests {
             retryDelaysSeconds: [0]
         )
 
-        await pusher.enqueue(makeContext(), source: .foregroundPrime)
+        await pusher.enqueue(makeContext(), source: .foregroundPrime, reason: .locationResolved)
 
         let payloads = await uploader.uploadedPayloads()
         #expect(payloads.count == 2)
@@ -933,7 +937,7 @@ struct LocationProviderTests {
             retryDelaysSeconds: [0]
         )
 
-        await pusher.enqueue(makeContext(), source: .foregroundPrime)
+        await pusher.enqueue(makeContext(), source: .foregroundPrime, reason: .locationResolved)
 
         let payloads = await uploader.uploadedPayloads()
         #expect(payloads.count == 1)

--- a/Tests/UnitTests/LocationProviderTests.swift
+++ b/Tests/UnitTests/LocationProviderTests.swift
@@ -451,6 +451,67 @@ struct LocationProviderTests {
         #expect(await store.current().isEmpty)
     }
 
+    @Test("opt-out preference sync without location context persists when APNs token is missing")
+    func locationContextPusher_preferenceSyncWithoutContext_missingTokenPersists() async throws {
+        let uploader = MockSnapshotUploader()
+        let store = InMemoryUploadQueueStore()
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { "" },
+            installationIdProvider: { "install-abc-123" },
+            subscriptionStatusProvider: { false },
+            locationUploadEnabledProvider: { false },
+            retryDelaysSeconds: [0],
+            queueStore: store
+        )
+
+        await pusher.enqueuePreferenceSync(
+            source: .settingsPreference,
+            forceUpload: true,
+            reason: "location-sharing"
+        )
+
+        #expect(await uploader.uploadedPayloads().isEmpty)
+        #expect(await store.current().count == 1)
+        let persisted = try #require(await store.current().first)
+        #expect(persisted.context == nil)
+        #expect(persisted.isSubscribed == false)
+        #expect(persisted.forceUpload == true)
+    }
+
+    @Test("opt-out preference sync without location context drains when APNs token arrives")
+    func locationContextPusher_preferenceSyncWithoutContext_drainsOnTokenArrival() async throws {
+        let uploader = MockSnapshotUploader()
+        let store = InMemoryUploadQueueStore()
+        let tokenState = TokenBox("")
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { tokenState.value() },
+            installationIdProvider: { "install-abc-123" },
+            subscriptionStatusProvider: { false },
+            locationUploadEnabledProvider: { false },
+            retryDelaysSeconds: [0],
+            queueStore: store
+        )
+
+        await pusher.enqueuePreferenceSync(
+            source: .settingsPreference,
+            forceUpload: true,
+            reason: "notification"
+        )
+        #expect(await store.current().count == 1)
+
+        tokenState.set("apns-token-123")
+        await pusher.drainPendingUploads()
+
+        let payload = try #require(await uploader.uploadedPayloads().first)
+        #expect(payload.source == LocationUploadSource.settingsPreference.rawValue)
+        #expect(payload.isSubscribed == false)
+        #expect(payload.h3Cell == nil)
+        #expect(payload.county == nil)
+        #expect(await store.current().isEmpty)
+    }
+
     @Test("onboarding upload survives delayed APNs token and drains deterministically")
     func locationContextPusher_onboardingDelayedToken_drainUsesOnboardingSource() async throws {
         let uploader = MockSnapshotUploader()

--- a/Tests/UnitTests/LocationProviderTests.swift
+++ b/Tests/UnitTests/LocationProviderTests.swift
@@ -82,6 +82,31 @@ struct LocationProviderTests {
         }
     }
 
+    private actor BackoffCancellingUploader: LocationSnapshotUploading {
+        private var payloads: [LocationSnapshotPushPayload] = []
+        private var firstAttemptContinuation: CheckedContinuation<Void, Never>?
+
+        func upload(_ payload: LocationSnapshotPushPayload) async throws {
+            payloads.append(payload)
+            if payloads.count == 1 {
+                firstAttemptContinuation?.resume()
+                firstAttemptContinuation = nil
+                throw LocationPushError.invalidResponseStatus(503)
+            }
+        }
+
+        func waitForFirstAttempt() async {
+            if payloads.isEmpty == false { return }
+            await withCheckedContinuation { continuation in
+                firstAttemptContinuation = continuation
+            }
+        }
+
+        func attemptCount() -> Int {
+            payloads.count
+        }
+    }
+
     private actor InMemoryUploadQueueStore: LocationUploadQueueStoring {
         private var pending: [PersistedLocationUploadRequest]
 
@@ -575,6 +600,29 @@ struct LocationProviderTests {
         )
 
         await pusher.enqueue(makeContext(), source: .manualRefresh)
+        #expect(await store.current().count == 1)
+    }
+
+    @Test("snapshot pusher cancels retry during backoff and preserves pending request")
+    func snapshotPusher_cancellationDuringBackoffStopsRetryAndPersistsPending() async throws {
+        let uploader = BackoffCancellingUploader()
+        let store = InMemoryUploadQueueStore()
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            retryDelaysSeconds: [0, 1],
+            queueStore: store
+        )
+
+        let enqueueTask = Task {
+            await pusher.enqueue(makeContext(), source: .manualRefresh)
+        }
+        await uploader.waitForFirstAttempt()
+        enqueueTask.cancel()
+        await enqueueTask.value
+
+        #expect(await uploader.attemptCount() == 1)
         #expect(await store.current().count == 1)
     }
 

--- a/Tests/UnitTests/LocationProviderTests.swift
+++ b/Tests/UnitTests/LocationProviderTests.swift
@@ -59,6 +59,28 @@ struct LocationProviderTests {
             payloads
         }
     }
+
+    private actor CompatibilitySnapshotUploader: LocationSnapshotUploading {
+        private var payloads: [LocationSnapshotPushPayload] = []
+        private let failingStatus: Int
+        private let fallbackSource: String
+
+        init(failingStatus: Int, fallbackSource: String = "unknown") {
+            self.failingStatus = failingStatus
+            self.fallbackSource = fallbackSource
+        }
+
+        func upload(_ payload: LocationSnapshotPushPayload) async throws {
+            payloads.append(payload)
+            if payload.source != fallbackSource {
+                throw LocationPushError.invalidResponseStatus(failingStatus)
+            }
+        }
+
+        func uploadedPayloads() -> [LocationSnapshotPushPayload] {
+            payloads
+        }
+    }
     
     private final class MockSnapshotCache: @unchecked Sendable, LocationSnapshotCaching {
         private(set) var storedSnapshot: LocationSnapshot?
@@ -95,6 +117,48 @@ struct LocationProviderTests {
         func set(_ newValue: String) {
             lock.lock()
             token = newValue
+            lock.unlock()
+        }
+    }
+
+    private final class ClockBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var current: Date
+
+        init(_ date: Date) {
+            self.current = date
+        }
+
+        func now() -> Date {
+            lock.lock()
+            defer { lock.unlock() }
+            return current
+        }
+
+        func advance(by seconds: TimeInterval) {
+            lock.lock()
+            current = current.addingTimeInterval(seconds)
+            lock.unlock()
+        }
+    }
+
+    private final class BoolBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var current: Bool
+
+        init(_ value: Bool) {
+            self.current = value
+        }
+
+        func value() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return current
+        }
+
+        func set(_ newValue: Bool) {
+            lock.lock()
+            current = newValue
             lock.unlock()
         }
     }
@@ -304,6 +368,7 @@ struct LocationProviderTests {
             apnsTokenProvider: { "apns-token-123" },
             installationIdProvider: { "install-abc-123" },
             subscriptionStatusProvider: { false },
+            authorizationStatusProvider: { .authorizedAlways },
             retryDelaysSeconds: [0]
         )
 
@@ -320,6 +385,8 @@ struct LocationProviderTests {
         #expect(payload.fireZone == "OKZ025")
         #expect(payload.h3Cell == sampleH3Cell)
         #expect(payload.isSubscribed == false)
+        #expect(payload.source == LocationUploadSource.manualRefresh.rawValue)
+        #expect(payload.auth == "always")
     }
 
     @Test("location context pusher skips upload when APNs token is missing")
@@ -406,6 +473,177 @@ struct LocationProviderTests {
         let payloads = await uploader.uploadedPayloads()
         let payload = try #require(payloads.first)
         #expect(payload.isSubscribed == false)
+    }
+
+    @Test("snapshot pusher dedupes identical non-forced uploads inside the dedupe window")
+    func snapshotPusher_dedupesIdenticalNonForcedUploads() async throws {
+        let uploader = MockSnapshotUploader()
+        let clock = ClockBox(Date(timeIntervalSince1970: 10_000))
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            subscriptionStatusProvider: { true },
+            authorizationStatusProvider: { .authorizedWhenInUse },
+            nowProvider: { clock.now() },
+            retryDelaysSeconds: [0],
+            dedupeWindowSeconds: 15
+        )
+        let context = makeContext()
+
+        await pusher.enqueue(context, source: .foregroundPrime)
+        await pusher.enqueue(context, source: .foregroundLocationChange)
+
+        let payloads = await uploader.uploadedPayloads()
+        #expect(payloads.count == 1)
+    }
+
+    @Test("snapshot pusher does not dedupe when location scope changes")
+    func snapshotPusher_doesNotDedupeScopeChanges() async throws {
+        let uploader = MockSnapshotUploader()
+        let clock = ClockBox(Date(timeIntervalSince1970: 12_000))
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            subscriptionStatusProvider: { true },
+            authorizationStatusProvider: { .authorizedWhenInUse },
+            nowProvider: { clock.now() },
+            retryDelaysSeconds: [0],
+            dedupeWindowSeconds: 15
+        )
+
+        let first = makeContext(
+            h3Cell: sampleH3Cell,
+            grid: makeGridSnapshot(
+                countyCode: "OKC109",
+                fireZone: "OKZ025"
+            )
+        )
+        let second = makeContext(
+            h3Cell: sampleH3Cell + 1,
+            grid: makeGridSnapshot(
+                countyCode: "OKC017",
+                fireZone: "OKZ030"
+            )
+        )
+
+        await pusher.enqueue(first, source: .foregroundPrime)
+        await pusher.enqueue(second, source: .foregroundLocationChange)
+
+        let payloads = await uploader.uploadedPayloads()
+        #expect(payloads.count == 2)
+    }
+
+    @Test("snapshot pusher does not dedupe preference state changes")
+    func snapshotPusher_doesNotDedupePreferenceStateChanges() async throws {
+        let uploader = MockSnapshotUploader()
+        let clock = ClockBox(Date(timeIntervalSince1970: 13_000))
+        let subscribed = BoolBox(true)
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            subscriptionStatusProvider: { subscribed.value() },
+            authorizationStatusProvider: { .authorizedWhenInUse },
+            nowProvider: { clock.now() },
+            retryDelaysSeconds: [0],
+            dedupeWindowSeconds: 15
+        )
+        let context = makeContext()
+
+        await pusher.enqueue(context, source: .settingsPreference, forceUpload: true)
+        subscribed.set(false)
+        await pusher.enqueue(context, source: .settingsPreference, forceUpload: true)
+
+        let payloads = await uploader.uploadedPayloads()
+        #expect(payloads.count == 2)
+        #expect(payloads.map(\.isSubscribed) == [true, false])
+    }
+
+    @Test("snapshot pusher dedupes identical forced uploads inside the dedupe window")
+    func snapshotPusher_dedupesIdenticalForcedUploads() async throws {
+        let uploader = MockSnapshotUploader()
+        let clock = ClockBox(Date(timeIntervalSince1970: 14_000))
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            subscriptionStatusProvider: { false },
+            authorizationStatusProvider: { .authorizedAlways },
+            nowProvider: { clock.now() },
+            retryDelaysSeconds: [0],
+            dedupeWindowSeconds: 15
+        )
+        let context = makeContext()
+
+        await pusher.enqueue(context, source: .settingsPreference, forceUpload: true)
+        await pusher.enqueue(context, source: .settingsPreference, forceUpload: true)
+
+        let payloads = await uploader.uploadedPayloads()
+        #expect(payloads.count == 1)
+    }
+
+    @Test("snapshot pusher allows identical upload after dedupe window elapses")
+    func snapshotPusher_allowsUploadAfterDedupeWindow() async throws {
+        let uploader = MockSnapshotUploader()
+        let clock = ClockBox(Date(timeIntervalSince1970: 15_000))
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            subscriptionStatusProvider: { true },
+            authorizationStatusProvider: { .authorizedWhenInUse },
+            nowProvider: { clock.now() },
+            retryDelaysSeconds: [0],
+            dedupeWindowSeconds: 15
+        )
+        let context = makeContext()
+
+        await pusher.enqueue(context, source: .foregroundPrime)
+        clock.advance(by: 16)
+        await pusher.enqueue(context, source: .foregroundLocationChange)
+
+        let payloads = await uploader.uploadedPayloads()
+        #expect(payloads.count == 2)
+    }
+
+    @Test("snapshot pusher retries with legacy source when server rejects explicit source")
+    func snapshotPusher_retriesWithLegacySourceForCompatibility() async throws {
+        let uploader = CompatibilitySnapshotUploader(failingStatus: 400)
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            subscriptionStatusProvider: { true },
+            authorizationStatusProvider: { .authorizedWhenInUse },
+            retryDelaysSeconds: [0]
+        )
+
+        await pusher.enqueue(makeContext(), source: .foregroundPrime)
+
+        let payloads = await uploader.uploadedPayloads()
+        #expect(payloads.count == 2)
+        #expect(payloads.map(\.source) == [LocationUploadSource.foregroundPrime.rawValue, "unknown"])
+    }
+
+    @Test("snapshot pusher does not use legacy fallback for non-compat response statuses")
+    func snapshotPusher_doesNotFallbackForNonCompatStatus() async throws {
+        let uploader = CompatibilitySnapshotUploader(failingStatus: 409)
+        let pusher = LocationSnapshotPusher(
+            uploader: uploader,
+            apnsTokenProvider: { "apns-token-123" },
+            installationIdProvider: { "install-abc-123" },
+            subscriptionStatusProvider: { true },
+            authorizationStatusProvider: { .authorizedWhenInUse },
+            retryDelaysSeconds: [0]
+        )
+
+        await pusher.enqueue(makeContext(), source: .foregroundPrime)
+
+        let payloads = await uploader.uploadedPayloads()
+        #expect(payloads.count == 1)
+        #expect(payloads.first?.source == LocationUploadSource.foregroundPrime.rawValue)
     }
 
     @Test("send suppresses rapid updates inside minSeconds window")

--- a/Tests/UnitTests/NwsHttpClientTests.swift
+++ b/Tests/UnitTests/NwsHttpClientTests.swift
@@ -422,3 +422,59 @@ struct HTTPLocationSnapshotUploaderTests {
         #expect(request.body?.isEmpty == false)
     }
 }
+
+@Suite("HTTPDevicePreferenceSyncUploader")
+struct HTTPDevicePreferenceSyncUploaderTests {
+    private func makePreferencePayload(isSubscribed: Bool, token: String) -> DevicePreferenceSyncPayload {
+        DevicePreferenceSyncPayload(
+            installationId: "install-1",
+            apnsDeviceToken: token,
+            apnsEnvironment: "sandbox",
+            platform: "iOS",
+            osVersion: "18.0",
+            appVersion: "1.0",
+            buildNumber: "1",
+            auth: "always",
+            isSubscribed: isSubscribed,
+            source: "settingsPreference",
+            reason: "preferenceChanged"
+        )
+    }
+
+    @Test("upload builds preferences endpoint from Arcus signal base URL")
+    func upload_buildsPreferencesURL() async throws {
+        let http = ArcusMockHTTPClient(response: HTTPResponse(status: 202, headers: [:], data: nil))
+        let uploader = HTTPDevicePreferenceSyncUploader(
+            baseURL: URL(string: "https://arcus.example.com")!,
+            http: http
+        )
+
+        let payload = makePreferencePayload(isSubscribed: true, token: "abc123")
+
+        try await uploader.upload(payload)
+
+        let request = try #require(await http.firstRequest())
+        #expect(request.method == "POST")
+        #expect(request.url.scheme == "https")
+        #expect(request.url.host == "arcus.example.com")
+        #expect(request.url.path == ArcusSignalConfiguration.devicePreferencesPath)
+        #expect(request.headers["Accept"] == "application/json")
+        #expect(request.headers["Content-Type"] == "application/json")
+        #expect(request.headers["User-Agent"]?.isEmpty == false)
+        #expect(request.body?.isEmpty == false)
+    }
+
+    @Test("non-2xx response throws status without embedding APNs token")
+    func upload_errorDoesNotExposeToken() async throws {
+        let http = ArcusMockHTTPClient(response: HTTPResponse(status: 500, headers: [:], data: nil))
+        let uploader = HTTPDevicePreferenceSyncUploader(
+            baseURL: URL(string: "https://arcus.example.com")!,
+            http: http
+        )
+        let payload = makePreferencePayload(isSubscribed: false, token: "super-secret-token")
+
+        await #expect(throws: LocationPushError.self) {
+            try await uploader.upload(payload)
+        }
+    }
+}

--- a/Tests/UnitTests/RemoteNotificationRegistrarTests.swift
+++ b/Tests/UnitTests/RemoteNotificationRegistrarTests.swift
@@ -4,6 +4,18 @@ import Testing
 
 @Suite("RemoteNotificationRegistrar")
 struct RemoteNotificationRegistrarTests {
+    private actor DrainCounter {
+        private var count = 0
+
+        func increment() {
+            count += 1
+        }
+
+        func value() -> Int {
+            count
+        }
+    }
+
     private final class MockInstallationStorage: @unchecked Sendable {
         private let lock = NSLock()
         private var storedValue: String?
@@ -93,6 +105,29 @@ struct RemoteNotificationRegistrarTests {
 
         let token = await tokenTask.value
         #expect(token == "00ab10")
+    }
+
+    @MainActor
+    @Test("storeDeviceToken notifies token observer once per store event")
+    func storeDeviceToken_notifiesObserverOncePerStoreEvent() async throws {
+        let suiteName = "RemoteNotificationRegistrarTests.storeDeviceToken_notifiesObserverOncePerStoreEvent"
+        let defaults = UserDefaults(suiteName: suiteName)
+        defaults?.removePersistentDomain(forName: suiteName)
+        let counter = DrainCounter()
+
+        let sut = RemoteNotificationRegistrar(
+            center: .current(),
+            userDefaults: defaults,
+            registerRemoteNotifications: {}
+        )
+        sut.setTokenStoredObserver { _ in
+            await counter.increment()
+        }
+
+        sut.storeDeviceToken(Data([0x01, 0x02, 0x03]))
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(await counter.value() == 1)
     }
 
     @Test("InstallationIdentityStore returns existing ID without writing")

--- a/Tests/UnitTests/RemoteNotificationRegistrarTests.swift
+++ b/Tests/UnitTests/RemoteNotificationRegistrarTests.swift
@@ -109,7 +109,7 @@ struct RemoteNotificationRegistrarTests {
 
     @MainActor
     @Test("storeDeviceToken notifies token observer once per store event")
-    func storeDeviceToken_notifiesObserverOncePerStoreEvent() async throws {
+    func storeDeviceToken_notifiesObserverOncePerStoreEvent() async {
         let suiteName = "RemoteNotificationRegistrarTests.storeDeviceToken_notifiesObserverOncePerStoreEvent"
         let defaults = UserDefaults(suiteName: suiteName)
         defaults?.removePersistentDomain(forName: suiteName)
@@ -120,13 +120,19 @@ struct RemoteNotificationRegistrarTests {
             userDefaults: defaults,
             registerRemoteNotifications: {}
         )
-        sut.setTokenStoredObserver { _ in
-            await counter.increment()
+        let observerCompletion = AsyncStream<Void> { continuation in
+            sut.setTokenStoredObserver { _ in
+                await counter.increment()
+                continuation.yield(())
+                continuation.finish()
+            }
         }
 
+        var observerEvents = observerCompletion.makeAsyncIterator()
         sut.storeDeviceToken(Data([0x01, 0x02, 0x03]))
-        try await Task.sleep(for: .milliseconds(50))
 
+        let observedEvent = await observerEvents.next()
+        #expect(observedEvent != nil)
         #expect(await counter.value() == 1)
     }
 

--- a/Tests/UnitTests/WidgetSnapshotRefreshCoordinatorTests.swift
+++ b/Tests/UnitTests/WidgetSnapshotRefreshCoordinatorTests.swift
@@ -9,7 +9,7 @@ struct WidgetSnapshotRefreshCoordinatorTests {
         let sandbox = try makeSandboxDirectory()
         let store = WidgetSnapshotStore(directoryURL: sandbox)
         let generatedAt = Date(timeIntervalSince1970: 1_700)
-        var reloadedKinds: [String] = []
+        let reloadedKinds = ReloadedKindsRecorder()
         let coordinator = WidgetSnapshotRefreshCoordinator(
             store: store,
             reloadTimeline: { reloadedKinds.append($0) }
@@ -29,7 +29,7 @@ struct WidgetSnapshotRefreshCoordinatorTests {
 
         #expect(store.load().snapshot?.freshness.timestamp == generatedAt)
         #expect(store.load().snapshot?.locationSummary == "Denver, CO")
-        #expect(reloadedKinds == [
+        #expect(reloadedKinds.values() == [
             SkyAwareWidgetKind.stormRisk,
             SkyAwareWidgetKind.severeRisk,
             SkyAwareWidgetKind.combined,
@@ -43,7 +43,7 @@ struct WidgetSnapshotRefreshCoordinatorTests {
         let sandbox = try makeSandboxDirectory()
         let store = WidgetSnapshotStore(directoryURL: sandbox)
         let generatedAt = Date(timeIntervalSince1970: 1_710)
-        var reloadedKinds: [String] = []
+        let reloadedKinds = ReloadedKindsRecorder()
         let coordinator = WidgetSnapshotRefreshCoordinator(
             store: store,
             reloadTimeline: { reloadedKinds.append($0) }
@@ -63,7 +63,7 @@ struct WidgetSnapshotRefreshCoordinatorTests {
 
         #expect(store.load().snapshot?.selectedAlert?.title == "Tornado Warning")
         #expect(store.load().snapshot?.locationSummary == "Norman, OK")
-        #expect(reloadedKinds == [
+        #expect(reloadedKinds.values() == [
             SkyAwareWidgetKind.combined
         ])
     }
@@ -72,7 +72,7 @@ struct WidgetSnapshotRefreshCoordinatorTests {
     func riskProjection_overwritesStaleTornadoStateWithAllClear() throws {
         let sandbox = try makeSandboxDirectory()
         let store = WidgetSnapshotStore(directoryURL: sandbox)
-        var reloadedKinds: [String] = []
+        let reloadedKinds = ReloadedKindsRecorder()
         let coordinator = WidgetSnapshotRefreshCoordinator(
             store: store,
             reloadTimeline: { reloadedKinds.append($0) }
@@ -102,7 +102,7 @@ struct WidgetSnapshotRefreshCoordinatorTests {
         )
 
         #expect(store.load().snapshot?.severeRisk == .init(label: "No Active Threats", severity: 0))
-        #expect(Array(reloadedKinds.suffix(5)) == [
+        #expect(Array(reloadedKinds.values().suffix(5)) == [
             SkyAwareWidgetKind.stormRisk,
             SkyAwareWidgetKind.severeRisk,
             SkyAwareWidgetKind.combined,
@@ -127,6 +127,23 @@ struct WidgetSnapshotRefreshCoordinatorTests {
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         return directory
+    }
+}
+
+private final class ReloadedKindsRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String] = []
+
+    func append(_ kind: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        storage.append(kind)
+    }
+
+    func values() -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
     }
 }
 

--- a/plans/Location Upload Hardening Plan.md
+++ b/plans/Location Upload Hardening Plan.md
@@ -370,3 +370,22 @@ Each sub-issue should include:
 - Acceptance criteria
 - Validation commands
 - Link back to this plan
+
+## Final Validation Follow-Up Findings
+
+The end-to-end validation review found the main architecture materially improved, but identified follow-up issues that
+must be resolved before the hardening effort should be considered complete.
+
+| Issue | Severity | Title | Required Outcome |
+| --- | --- | --- | --- |
+| #187 | P1 | Ensure opt-out preference sync cannot be dropped without location context | Opt-out/unsubscribe preference intent is sent or durably queued even when `currentContext` and `currentSnapshot` are unavailable. |
+| #188 | P1 | Make RemoteNotificationRegistrar token observer test deterministic under full unit runs | Full `SkyAwareTests` passes locally; token observer tests no longer depend on fixed sleep timing. |
+| #189 | P2 | Avoid duplicate Settings location-sharing enable uploads | Settings enable-sharing path emits one intentional server-facing request while the legacy preference adapter is still location-payload backed. |
+| #190 | P2 | Respect cancellation during location upload retry backoff | Cancellation during retry backoff stops further upload attempts and leaves pending work persisted. |
+| #191 | P2 | Add reason attribution to location upload requests | Upload request, persistence, and diagnostics include explicit reason attribution in addition to source and force semantics. |
+| #192 | P3 | Stop logging raw H3 cells on location upload success | Upload diagnostics no longer log raw H3 cells or other sensitive location identifiers. |
+
+Validation evidence from the review:
+- Focused location/upload/ingestion/registrar suites passed locally: 91 passed, 0 failed.
+- Full `SkyAwareTests` failed locally: 426 passed, 1 failed in `RemoteNotificationRegistrarTests/storeDeviceToken_notifiesObserverOncePerStoreEvent`.
+- Xcode Cloud validation remains pending until the full unit target is green.

--- a/plans/Location Upload Hardening Plan.md
+++ b/plans/Location Upload Hardening Plan.md
@@ -340,6 +340,7 @@ Acceptance Criteria:
 - Prefer protocol seams and fakes over live system services.
 - Keep each issue small and reviewable.
 - Run the smallest relevant tests before finishing.
+- Unit tests must also be validated in Xcode Cloud before considering implementation work fully done. Local focused tests are necessary for fast iteration, but Xcode Cloud is the source-of-truth validation environment for this hardening effort.
 - Do not claim a build or test passed unless it was actually run.
 - Treat `LocationContextResolver` and `LocationSnapshotPusher` as high-risk seams; avoid unrelated refactors.
 - For any SwiftUI/lifecycle-facing change, follow the SwiftUI Expert and SwiftUI UI Patterns guidance:

--- a/plans/Location Upload Hardening Plan.md
+++ b/plans/Location Upload Hardening Plan.md
@@ -1,0 +1,371 @@
+# Location Upload Hardening Plan
+
+## Purpose
+
+SkyAware depends on fresh server-side location registration for accurate, timely Arcus Signal notifications. The current pipeline usually works, but it mixes context resolution, upload side effects, preference synchronization, and ingestion orchestration in ways that make reliability hard to reason about and hard to test.
+
+This plan breaks the hardening work into reviewable sub-issues. Each sub-issue should be sized for Codex 5.3 medium and should leave the app compiling with focused unit tests.
+
+## Current Architecture Summary
+
+- `LocationManager` owns Core Location mode transitions:
+  - active scenes use live foreground updates
+  - background scenes with Always authorization use significant-location-change monitoring
+- `LocationProvider` accepts, throttles, hashes, caches, and placemark-enriches raw location updates.
+- `LocationSession` stores `currentSnapshot` and `currentContext`.
+- `HomeIngestionCoordinator` serializes foreground, background, location-change, and remote-alert ingestion.
+- `HomeIngestionExecutor` resolves a `LocationContext` based on the trigger's `HomeIngestionLocationRequest`.
+- `LocationContextResolver.resolveContext(...)` enriches a snapshot, resolves grid metadata, creates `LocationContext`, and currently enqueues an upload as a side effect.
+- `LocationSnapshotPusher` builds `LocationSnapshotPushPayload`, gates on APNs token and `sendL8ntoSignal`, then uploads with in-memory retries.
+
+## Critical Findings To Address
+
+1. Background significant-location-change ingestion can use stale `currentContext`.
+   - `.backgroundLocationChange` maps to `.currentPrepared`.
+   - `HomeIngestionExecutor` immediately returns existing `currentContext`.
+   - The freshly accepted SLC snapshot may not become the context used for server upload, alert sync, or watch evaluation.
+
+2. Context resolution has an implicit upload side effect.
+   - Any successful `resolveContext(...)` enqueues upload.
+   - This makes call sites harder to reason about, causes duplicate uploads, and makes tests assert incidental behavior.
+
+3. Preference updates can double enqueue.
+   - `pushServerNotificationPreferenceUpdate(...)` resolves missing context, which already enqueues, then explicitly enqueues again.
+
+4. Upload retry is memory-only.
+   - After `[0, 5, 15]` seconds, failed uploads are lost.
+   - Missing APNs token also drops the attempt permanently.
+
+5. Preference synchronization is coupled to location upload.
+   - Disabling sharing uses `forceUpload: true` with a full location payload.
+   - This may be deliberate for unregister semantics, but it is privacy-sensitive and operationally muddy.
+
+6. Server diagnostics are weak.
+   - Payload `source` is always `"unknown"`.
+   - Upload attempts do not expose a stable reason/source/result model that can be unit tested or logged consistently.
+
+## Target Architecture
+
+### Design Goals
+
+- Resolve location context explicitly.
+- Push location explicitly.
+- Never let a background location-change flow use stale context.
+- Make every upload attempt traceable by source and reason.
+- Persist retry intent across transient failures, APNs token delays, launches, and background refreshes.
+- Keep SwiftUI views thin; UI should trigger app services, not encode upload policy.
+- Preserve privacy controls and make opt-out semantics obvious.
+- Keep implementation incremental and testable.
+
+### Proposed Shape
+
+Introduce a small upload orchestration layer:
+
+```swift
+enum LocationUploadSource: String, Sendable, Codable {
+    case foregroundPrime
+    case foregroundActivate
+    case foregroundLocationChange
+    case manualRefresh
+    case backgroundRefresh
+    case backgroundLocationChange
+    case onboarding
+    case settingsPreference
+    case apnsTokenRefresh
+    case retry
+}
+
+enum LocationUploadReason: String, Sendable, Codable {
+    case locationResolved
+    case locationChanged
+    case preferenceChanged
+    case tokenBecameAvailable
+    case retry
+}
+
+struct LocationUploadRequest: Sendable, Codable, Equatable {
+    let context: LocationContext
+    let source: LocationUploadSource
+    let reason: LocationUploadReason
+    let forceUpload: Bool
+    let requestedAt: Date
+}
+```
+
+`LocationContextResolver` should only resolve context. A dedicated `LocationUploadCoordinator` or hardened `LocationSnapshotPusher` API should accept explicit upload requests, deduplicate them, persist pending work, and produce testable outcomes.
+
+Do not overbuild this. The goal is a clear seam, not a distributed system cosplay.
+
+## Implementation Sequence
+
+### Issue 1: Add Characterization Tests And Flow Matrix
+
+Goal: lock down current behavior before changing architecture.
+
+Scope:
+- Add unit tests around `HomeIngestionPlan` location request mapping.
+- Add tests proving `.backgroundLocationChange` currently returns existing `currentContext`.
+- Add tests proving foreground fresh prepare resolves and enqueues.
+- Add tests proving `pushServerNotificationPreferenceUpdate(...)` can double enqueue when resolving from snapshot.
+- Add tests proving missing APNs token drops upload.
+- Add a short markdown flow matrix under `plans/` or `docs/architecture/` if useful.
+
+Validation:
+- Run the smallest relevant Swift Testing suite, likely `LocationManagerTests`, `LocationProviderTests`, `HomeIngestionCoordinatorTests`, and `HomeRefreshPipelineTests`.
+
+Acceptance Criteria:
+- Tests demonstrate the current failure mode without changing production behavior.
+- Tests use fakes/stubs, no live network, no Core Location dependency.
+- No production code changes unless needed for test access and justified.
+
+### Issue 2: Fix Background Significant-Location-Change Freshness
+
+Goal: make background SLC ingestion resolve and push the fresh accepted snapshot, not stale `currentContext`.
+
+Recommended implementation:
+- Add a location request mode that resolves from the latest snapshot even when a current context exists, for example:
+  - `HomeIngestionLocationRequest.prepare(requiresFreshLocation: false, showsAuthorizationPrompt: false, preferCurrentContext: false)`, or
+  - `HomeIngestionLocationRequest.resolveCurrentSnapshot(maximumAcceptedLocationAge:)`
+- Map `.backgroundLocationChange` to this stronger request.
+- Consider mapping `.foregroundLocationChange` similarly if the current context is stale relative to the new snapshot.
+- Keep `.sessionTick`, remote-alert paths, and low-risk refreshes on `.currentPrepared`.
+
+Validation:
+- Add a unit test where `currentContext` is old, `currentSnapshot` has a new H3, and `.backgroundLocationChange` uses the new context.
+- Add a unit test that watch/background ingestion receives the new location snapshot.
+- Add a unit test that `.sessionTick` still reuses current prepared context.
+
+Acceptance Criteria:
+- Background SLC never short-circuits to stale context when a newer accepted snapshot exists.
+- Existing foreground/timer behavior does not become more chatty by accident.
+
+### Issue 3: Make Context Resolution Side-Effect Free
+
+Goal: separate `LocationContextResolver` from upload policy.
+
+Recommended implementation:
+- Remove `contextPusher.enqueue(context)` from `LocationContextResolver.resolveContext(...)`.
+- Add explicit upload calls at the orchestration points that should publish location.
+- Introduce a narrow protocol, such as:
+
+```swift
+protocol LocationUploadCoordinating: Sendable {
+    func enqueue(_ request: LocationUploadRequest) async
+}
+```
+
+- Keep `LocationContextResolver` focused on:
+  - authorization
+  - snapshot freshness
+  - placemark enrichment
+  - H3 and grid metadata validation
+
+Validation:
+- Update resolver tests to assert resolution returns context but does not push by itself.
+- Add executor/session tests proving intended triggers explicitly enqueue upload.
+- Add tests proving preference update does not double enqueue.
+
+Acceptance Criteria:
+- No hidden upload side effects remain in context resolution.
+- Every upload call site carries explicit `source`, `reason`, and `forceUpload`.
+
+### Issue 4: Add Upload Deduplication And Source Attribution
+
+Goal: avoid redundant uploads while preserving reliability.
+
+Recommended implementation:
+- Include `source` in `LocationSnapshotPushPayload` instead of `"unknown"`.
+- Deduplicate upload requests by semantic key:
+  - installation ID
+  - APNs token
+  - H3 cell
+  - county
+  - fire zone
+  - forecast zone
+  - subscription state
+  - authorization state
+  - force flag
+- Use a short dedupe window for non-forced uploads.
+- Never dedupe forced preference/unsubscribe uploads unless the full semantic key and preference state are identical.
+
+Validation:
+- Unit test foreground prime + follow-up coalescing.
+- Unit test different H3/county/fire zone is not deduped.
+- Unit test preference state changes are not deduped.
+- Unit test payload `source` matches request source.
+
+Acceptance Criteria:
+- Repeated identical location resolution does not spam the server.
+- Meaningful location/preference changes still upload immediately.
+
+### Issue 5: Persist Pending Uploads And Retry Intents
+
+Goal: make upload delivery survive transient failures, app suspension, relaunch, and missing APNs token.
+
+Recommended implementation:
+- Add a small persistence abstraction:
+
+```swift
+protocol LocationUploadQueueStoring: Sendable {
+    func loadPendingRequests() async -> [PersistedLocationUploadRequest]
+    func savePendingRequests(_ requests: [PersistedLocationUploadRequest]) async
+}
+```
+
+- Store minimal pending upload requests, not arbitrary runtime state.
+- Back with app-group `UserDefaults` or a small JSON file in app support/app group. Prefer the simplest implementation that is deterministic in tests.
+- Persist requests when:
+  - APNs token is missing
+  - network upload fails after immediate retry budget
+  - upload is cancelled
+- Drain pending requests on:
+  - foreground activation
+  - background refresh start
+  - APNs token registration
+  - settings preference update
+
+Validation:
+- Unit test missing APNs token persists request.
+- Unit test token arrival drains pending request.
+- Unit test network failure persists request.
+- Unit test successful retry removes request.
+- Unit test queue preserves latest meaningful location while coalescing obsolete duplicates.
+
+Acceptance Criteria:
+- No upload attempt disappears solely because token/network was temporarily unavailable.
+- Queue behavior is deterministic and fully fakeable in unit tests.
+
+### Issue 6: Split Preference Synchronization From Location Snapshot Upload
+
+Goal: make server subscription/privacy state explicit.
+
+Recommended implementation:
+- Add a dedicated registration/preferences request path if server support exists or can be added:
+  - installation ID
+  - APNs token
+  - server notification enabled
+  - location upload enabled
+  - authorization state
+  - app/build/environment
+- If server API is not ready, isolate the current forced full-location upload behind a named adapter with a TODO and tests.
+- Update settings/onboarding call sites so UI toggles call semantic methods:
+  - `syncNotificationPreference(...)`
+  - `syncLocationSharingPreference(...)`
+  - `enqueueCurrentLocationUpload(...)`
+
+Validation:
+- Unit test disabling location sharing does not accidentally enqueue a normal location upload.
+- Unit test unsubscribe/preference sync still reaches server even when `sendL8ntoSignal` is false.
+- Unit test enabling sharing requests upload only after context/token requirements are satisfied or queues pending work.
+
+Acceptance Criteria:
+- Preference sync semantics are understandable from method names.
+- Privacy-sensitive forced upload behavior is either removed or explicitly contained.
+
+### Issue 7: Wire Token And Lifecycle Drains
+
+Goal: close the obvious retry triggers.
+
+Recommended implementation:
+- Inject upload coordinator into `RemoteNotificationRegistrar` or notify a narrow callback when token changes.
+- On APNs token storage, drain pending uploads and enqueue current context if appropriate.
+- On scene active, drain pending uploads after token registration attempt.
+- On background refresh, drain pending uploads before/after fresh context resolution.
+- Avoid doing live service work directly in SwiftUI `body`; keep lifecycle actions in app/session services.
+
+Validation:
+- Unit test APNs token callback fires once per stored token.
+- Unit test scene-active registration path triggers queue drain through a fake coordinator.
+- Unit test no drain occurs when notifications are denied and no token exists, except persisted work remains queued.
+
+Acceptance Criteria:
+- Token arrival no longer leaves previous upload attempts stranded.
+- Lifecycle drains are idempotent and testable.
+
+### Issue 8: Add Diagnostics And Final End-To-End Validation
+
+Goal: make the hardened pipeline observable and prove the target flows.
+
+Recommended implementation:
+- Add structured logs for upload request accepted/skipped/deduped/persisted/drained/succeeded/failed.
+- Consider a lightweight diagnostics model for Settings diagnostics if existing patterns fit.
+- Add end-to-end unit tests with fakes for:
+  - foreground activation
+  - manual refresh
+  - foreground location change
+  - background app refresh
+  - background significant-location change
+  - onboarding with delayed APNs token
+  - settings opt in/out
+  - network failure then retry
+
+Validation:
+- Run focused unit tests.
+- Run full unit test suite if feasible.
+- Build the app.
+- Inspect any `.xcresult` if test execution creates one.
+
+Acceptance Criteria:
+- Each critical path has deterministic unit coverage.
+- Logs identify why an upload did or did not happen without exposing sensitive location details.
+- App compiles cleanly.
+
+## Recommended Test Matrix
+
+| Flow | Expected Upload Behavior | Required Tests |
+| --- | --- | --- |
+| Foreground activation | Fresh context resolved and upload requested once after dedupe | prime/follow-up dedupe, source attribution |
+| Manual refresh | Fresh context resolved and upload requested | explicit source/reason |
+| Foreground timer | Reuses current context; upload only if context must be resolved | no redundant upload |
+| Foreground location change | New accepted H3 resolves new context and uploads | new H3/new refresh key |
+| Background app refresh | Fresh context requested; upload queued or sent | background source, no prompt |
+| Background SLC | Fresh accepted snapshot resolves new context; upload requested | stale-context regression test |
+| Onboarding | waits for APNs token when possible; queues if missing | delayed token drain |
+| Settings enable server notifications | preference sync and current location upload if allowed | no duplicate enqueue |
+| Settings disable location sharing | preference sync survives location-upload gate | privacy/force semantics |
+| Network failure | persisted and retried later | retry persistence |
+
+## Non-Goals
+
+- Do not redesign alert sync, SPC sync, or WeatherKit refresh policy.
+- Do not introduce a database if a small deterministic queue store is sufficient.
+- Do not add broad UI redesign work.
+- Do not add live-network tests.
+- Do not rely on background execution being guaranteed by iOS.
+
+## Execution Notes For Agents
+
+- Read `AGENTS.md`, `Sources/AGENTS.md`, and this plan before starting.
+- Use Swift Testing (`import Testing`) for unit tests.
+- Prefer protocol seams and fakes over live system services.
+- Keep each issue small and reviewable.
+- Run the smallest relevant tests before finishing.
+- Do not claim a build or test passed unless it was actually run.
+- Treat `LocationContextResolver` and `LocationSnapshotPusher` as high-risk seams; avoid unrelated refactors.
+- For any SwiftUI/lifecycle-facing change, follow the SwiftUI Expert and SwiftUI UI Patterns guidance:
+  - keep views thin
+  - use environment-injected services intentionally
+  - keep async lifecycle work in `.task`, `onChange`, app/session services, or injected coordinators
+  - avoid deprecated SwiftUI APIs
+
+## GitHub Issue Breakdown
+
+Parent issue:
+- Location upload hardening and reliability
+
+Sub-issues:
+1. Characterize current location upload flows with tests
+2. Fix background significant-location-change context freshness
+3. Make location context resolution side-effect free
+4. Add upload deduplication and source attribution
+5. Persist pending uploads and retry intents
+6. Split preference sync from location snapshot upload
+7. Wire APNs token and lifecycle queue drains
+8. Add diagnostics and end-to-end validation coverage
+
+Each sub-issue should include:
+- Target agent: Codex 5.3 medium
+- Scope
+- Acceptance criteria
+- Validation commands
+- Link back to this plan

--- a/plans/LocationHardeningProgress.md
+++ b/plans/LocationHardeningProgress.md
@@ -1,0 +1,110 @@
+# Location Hardening Progress
+
+## Current Status
+
+Created the durable implementation plan and GitHub tracking structure for the location upload hardening work.
+
+Primary plan:
+- `plans/Location Upload Hardening Plan.md`
+
+GitHub tracking:
+- Parent: https://github.com/justinrooks/project-arcus/issues/178
+- Project: Project Arcus
+- Labels applied to parent and all sub-issues: `iOS`, `feature`
+
+No production code has been changed for this initiative yet.
+
+## Issue Map
+
+| Issue | Title | Status | Notes |
+| --- | --- | --- | --- |
+| #178 | Location upload hardening and reliability | Created | Parent issue with native GitHub sub-issues linked. |
+| #179 | Characterize current location upload flows with tests | Ready | First implementation issue. Add tests only unless minimal test seam changes are justified. |
+| #180 | Fix background significant-location-change context freshness | Pending | Depends on characterization coverage from #179. |
+| #181 | Make location context resolution side-effect free | Pending | Should happen after SLC freshness is locked down. |
+| #182 | Add location upload deduplication and source attribution | Pending | Depends on explicit upload seam from #181. |
+| #183 | Persist pending location uploads and retry intents | Pending | Depends on upload request model/dedupe semantics. |
+| #184 | Split preference sync from location snapshot upload | Pending | May need server contract decision. Keep adapter if backend endpoint is not ready. |
+| #185 | Wire APNs token and lifecycle upload queue drains | Pending | Depends on persisted queue and coordinator seam. |
+| #186 | Add location upload diagnostics and end-to-end validation coverage | Pending | Final hardening and verification pass. |
+
+## Key Findings To Preserve
+
+- Background significant-location-change ingestion currently maps to `.currentPrepared`, so it can reuse stale `LocationSession.currentContext` even after Core Location delivered a new background update.
+- `LocationContextResolver.resolveContext(...)` currently enqueues upload as a side effect.
+- `LocationSession.pushServerNotificationPreferenceUpdate(...)` can double enqueue when it resolves from `currentSnapshot`, because resolution already enqueues and the method then explicitly enqueues.
+- `LocationSnapshotPusher` skips upload when APNs token is missing, and that skipped attempt is not persisted.
+- Upload retry is in-memory only.
+- Payload `source` is currently `"unknown"`.
+- Settings preference sync and location snapshot upload are coupled through `forceUpload`, especially when disabling location sharing.
+
+## Relevant Files
+
+- `Sources/Infrastructure/Location/LocationContextResolver.swift`
+- `Sources/Infrastructure/Location/LocationSession.swift`
+- `Sources/Infrastructure/Location/LocationSnapshotPusher.swift`
+- `Sources/Infrastructure/Location/HTTPLocationSnapshotUploader.swift`
+- `Sources/Infrastructure/Location/LocationManager.swift`
+- `Sources/Providers/Location/LocationProvider.swift`
+- `Sources/App/HomeRefreshV2/HomeRefreshTrigger.swift`
+- `Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift`
+- `Sources/App/HomeRefreshV2/HomeIngestionCoordinator.swift`
+- `Sources/App/HomeRefreshPipeline.swift`
+- `Sources/Features/Background/BackgroundOrchestrator.swift`
+- `Sources/Features/Background/BackgroundLocationChangeHandler.swift`
+- `Sources/Features/Settings/SettingsView.swift`
+- `Sources/Features/Onboarding/OnboardingView.swift`
+- `Sources/Notifications/RemoteNotificationRegistrar.swift`
+
+## Relevant Tests
+
+Likely test files for the first few issues:
+- `Tests/UnitTests/LocationProviderTests.swift`
+- `Tests/UnitTests/LocationManagerTests.swift`
+- `Tests/UnitTests/HomeIngestionCoordinatorTests.swift`
+- `Tests/UnitTests/HomeRefreshPipelineTests.swift`
+- `Tests/UnitTests/BackgroundOrchestratorCadenceTests.swift`
+- `Tests/UnitTests/AlertNotificationTests.swift`
+- `Tests/UnitTests/RemoteNotificationRegistrarTests.swift`
+
+## Validation Expectations
+
+Use focused Swift Testing runs for each issue. Do not claim tests passed unless they were run.
+
+Preferred local simulator guidance from `AGENTS.md`:
+- iPhone 17 or iPhone 17 Pro where available.
+
+Example focused commands from the parent plan:
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:SkyAwareTests/LocationManagerTests test`
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:SkyAwareTests/LocationProviderTests test`
+
+If a test run creates an `.xcresult`, inspect failures before reporting status.
+
+## Working Tree Notes
+
+At the time this progress document was created:
+- `plans/Location Upload Hardening Plan.md` is new from this effort.
+- `plans/LocationHardeningProgress.md` is new from this effort.
+- `docs/audits/weekly-contract-drift-audit.md` was already modified before this planning work and should not be touched unless a later task explicitly requires it.
+
+## Quality Guidance
+
+Agents should follow:
+- `AGENTS.md`
+- `Sources/AGENTS.md`
+- `plans/Location Upload Hardening Plan.md`
+- SwiftUI Expert guidance when lifecycle or SwiftUI-facing code is touched.
+- SwiftUI UI Patterns guidance when Settings, onboarding, app lifecycle, or environment-injected services are touched.
+
+Keep views thin. Put upload policy in testable services/coordinators, not SwiftUI body logic.
+
+## Next Step
+
+Start with issue #179:
+- https://github.com/justinrooks/project-arcus/issues/179
+
+Objective:
+- Add characterization tests for current location upload behavior before changing production semantics.
+
+Important constraint:
+- #179 should not fix the behavior yet. It should prove and document the current behavior so #180 and later changes can be made with confidence.

--- a/plans/LocationHardeningProgress.md
+++ b/plans/LocationHardeningProgress.md
@@ -2,7 +2,9 @@
 
 ## Current Status
 
-Created the durable implementation plan and GitHub tracking structure for the location upload hardening work.
+The location upload hardening implementation has completed the original #179-#186 sequence and received an
+end-to-end validation review. The review found the architecture materially improved, but not ready to call complete
+until the follow-up findings below are addressed.
 
 Primary plan:
 - `plans/Location Upload Hardening Plan.md`
@@ -12,21 +14,35 @@ GitHub tracking:
 - Project: Project Arcus
 - Labels applied to parent and all sub-issues: `iOS`, `feature`
 
-No production code has been changed for this initiative yet.
+Validation status from review:
+- Focused location/upload/ingestion/registrar suites passed locally: 91 passed, 0 failed.
+- Full `SkyAwareTests` failed locally: 426 passed, 1 failed in `RemoteNotificationRegistrarTests/storeDeviceToken_notifiesObserverOncePerStoreEvent`.
+- Xcode Cloud validation remains pending until the full unit target is green.
 
 ## Issue Map
 
 | Issue | Title | Status | Notes |
 | --- | --- | --- | --- |
-| #178 | Location upload hardening and reliability | Created | Parent issue with native GitHub sub-issues linked. |
-| #179 | Characterize current location upload flows with tests | Ready | First implementation issue. Add tests only unless minimal test seam changes are justified. |
-| #180 | Fix background significant-location-change context freshness | Pending | Depends on characterization coverage from #179. |
-| #181 | Make location context resolution side-effect free | Pending | Should happen after SLC freshness is locked down. |
-| #182 | Add location upload deduplication and source attribution | Pending | Depends on explicit upload seam from #181. |
-| #183 | Persist pending location uploads and retry intents | Pending | Depends on upload request model/dedupe semantics. |
-| #184 | Split preference sync from location snapshot upload | Pending | May need server contract decision. Keep adapter if backend endpoint is not ready. |
-| #185 | Wire APNs token and lifecycle upload queue drains | Pending | Depends on persisted queue and coordinator seam. |
-| #186 | Add location upload diagnostics and end-to-end validation coverage | Pending | Final hardening and verification pass. |
+| #178 | Location upload hardening and reliability | Open | Parent issue with native GitHub sub-issues linked. |
+| #179 | Characterize current location upload flows with tests | Completed | Original characterization slice. |
+| #180 | Fix background significant-location-change context freshness | Completed | Background SLC now maps to latest accepted snapshot preparation. |
+| #181 | Make location context resolution side-effect free | Completed | Uploads are no longer resolver side effects. |
+| #182 | Add location upload deduplication and source attribution | Completed | Source attribution and dedupe are implemented; reason attribution remains #191. |
+| #183 | Persist pending location uploads and retry intents | Completed with follow-up | Missing-token and retry persistence are implemented; cancellation backoff follow-up is #190. |
+| #184 | Split preference sync from location snapshot upload | Completed with follow-up | Legacy adapter remains; opt-out/no-context gap is #187 and duplicate enable path is #189. |
+| #185 | Wire APNs token and lifecycle upload queue drains | Completed | Token, scene-active, and background-refresh drains are wired. |
+| #186 | Add location upload diagnostics and end-to-end validation coverage | Completed with follow-up | Focused suites pass; full unit target failure is #188 and H3 logging cleanup is #192. |
+
+## Final Review Follow-Up Issue Map
+
+| Issue | Severity | Title | Status | Notes |
+| --- | --- | --- | --- | --- |
+| #187 | P1 | Ensure opt-out preference sync cannot be dropped without location context | Created | `LocationSession` currently drops legacy preference sync when no context/snapshot can be resolved. |
+| #188 | P1 | Make RemoteNotificationRegistrar token observer test deterministic under full unit runs | Created | Full unit run failed due to a timing-sensitive observer assertion. |
+| #189 | P2 | Avoid duplicate Settings location-sharing enable uploads | Created | Settings enable-sharing path can call both legacy preference sync and normal current-location upload. |
+| #190 | P2 | Respect cancellation during location upload retry backoff | Created | Retry backoff uses `try? Task.sleep`, swallowing cancellation and continuing upload attempts. |
+| #191 | P2 | Add reason attribution to location upload requests | Created | Upload model has source/force but lacks the planned reason semantics. |
+| #192 | P3 | Stop logging raw H3 cells on location upload success | Created | `HTTPLocationSnapshotUploader` logs raw H3 cell values publicly. |
 
 ## Key Findings To Preserve
 
@@ -37,6 +53,12 @@ No production code has been changed for this initiative yet.
 - Upload retry is in-memory only.
 - Payload `source` is currently `"unknown"`.
 - Settings preference sync and location snapshot upload are coupled through `forceUpload`, especially when disabling location sharing.
+- Final review finding: opt-out/preference sync must not be dropped when no current location context exists.
+- Final review finding: token observer tests must be deterministic under full-suite contention.
+- Final review finding: Settings enable-sharing should not emit duplicate legacy location payloads.
+- Final review finding: upload retry backoff must respect cancellation.
+- Final review finding: upload requests need reason attribution, not only source attribution.
+- Final review finding: upload success logs must not expose raw H3 cells.
 
 ## Relevant Files
 
@@ -58,7 +80,7 @@ No production code has been changed for this initiative yet.
 
 ## Relevant Tests
 
-Likely test files for the first few issues:
+Relevant test files for the hardening and follow-up issues:
 - `Tests/UnitTests/LocationProviderTests.swift`
 - `Tests/UnitTests/LocationManagerTests.swift`
 - `Tests/UnitTests/HomeIngestionCoordinatorTests.swift`
@@ -82,9 +104,8 @@ If a test run creates an `.xcresult`, inspect failures before reporting status.
 
 ## Working Tree Notes
 
-At the time this progress document was created:
-- `plans/Location Upload Hardening Plan.md` is new from this effort.
-- `plans/LocationHardeningProgress.md` is new from this effort.
+- `plans/Location Upload Hardening Plan.md` tracks the original hardening plan plus final validation follow-ups.
+- `plans/LocationHardeningProgress.md` tracks issue status, review findings, and validation evidence.
 - `docs/audits/weekly-contract-drift-audit.md` was already modified before this planning work and should not be touched unless a later task explicitly requires it.
 
 ## Quality Guidance
@@ -100,11 +121,10 @@ Keep views thin. Put upload policy in testable services/coordinators, not SwiftU
 
 ## Next Step
 
-Start with issue #179:
-- https://github.com/justinrooks/project-arcus/issues/179
-
-Objective:
-- Add characterization tests for current location upload behavior before changing production semantics.
-
-Important constraint:
-- #179 should not fix the behavior yet. It should prove and document the current behavior so #180 and later changes can be made with confidence.
+Address the final review follow-up issues before considering #178 complete:
+- #187: Ensure opt-out preference sync cannot be dropped without location context.
+- #188: Make the APNs token observer test deterministic and restore full-unit validation.
+- #189: Avoid duplicate Settings location-sharing enable uploads.
+- #190: Respect cancellation during upload retry backoff.
+- #191: Add upload reason attribution.
+- #192: Stop logging raw H3 cells.


### PR DESCRIPTION
# Summary
This branch hardens location and preference upload reliability by separating responsibilities, improving retry/cancellation behavior, deduplicating uploads, and strengthening lifecycle-triggered queue draining, with broad unit-test coverage to validate end-to-end behavior.

# What Changed
- Split preference synchronization from location snapshot upload and introduced a dedicated HTTP device preference uploader path.
- Reworked location snapshot pushing with persistence for pending uploads, retry intent tracking, deduplication, and richer reason/source attribution.
- Improved lifecycle and background handling so upload queues are drained from APNs token registration, app lifecycle events, and refresh orchestration paths.
- Removed side effects from location context resolution and fixed significant-location-change context freshness behavior.
- Added diagnostics and logging adjustments, including avoiding raw H3 cell logging on successful uploads.
- Expanded automated coverage across location manager/provider behavior, refresh pipeline/coordinator orchestration, and remote notification registration.
- Added implementation planning/progress artifacts for location upload hardening.

# User Impact
Users should see more reliable delivery of location and preference updates, including fewer duplicate uploads and better resiliency when app lifecycle/background timing is unfavorable. No new user-facing UI workflows were introduced.

# Testing
- Added and updated Swift Testing coverage in `Tests/UnitTests`, including `LocationProviderTests`, `LocationManagerTests`, `HomeRefreshPipelineTests`, `RemoteNotificationRegistrarTests`, and related coordinator tests.
- I did not run the test suite in this Codex session.

# Notes
- This PR is scoped to committed branch changes (`origin/main...l8nUploadHardening`) and excludes current uncommitted local audit document edits.
