### PR TITLE
Add lightweight in-app web content viewer for trusted source links

### DIFF
--- a/Sources/Features/Settings/AttributionView.swift
+++ b/Sources/Features/Settings/AttributionView.swift
@@ -12,6 +12,7 @@ import OSLog
 struct AttributionView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.dependencies) private var dependencies
+    @Environment(\.openURL) private var openURL
     
     private let logger = Logger.uiHome
     
@@ -19,6 +20,7 @@ struct AttributionView: View {
     private var weatherClient: WeatherClient { dependencies.weatherClient }
     
     @State private var attribution: WeatherAttribution?
+    @State private var webRoute: WebContentRoute?
     
     var body: some View {
         VStack {
@@ -31,12 +33,26 @@ struct AttributionView: View {
                     } placeholder: {
                         ProgressView()
                     }
-                Text(.init("[\(attribution.serviceName)](\(attribution.legalPageURL))"))
-                    .font(.caption2)
-//                      .fontWeight(.semibold)
-//                      .textCase(.uppercase)
-                      .foregroundStyle(.secondary)
+                Button(attribution.serviceName) {
+                    switch WebContentPolicy.decision(for: attribution.legalPageURL) {
+                    case .inApp:
+                        webRoute = WebContentRoute(
+                            url: attribution.legalPageURL,
+                            title: "Attribution",
+                            sourceName: attribution.serviceName
+                        )
+                    case .external:
+                        openURL(attribution.legalPageURL)
+                    case .unsupported:
+                        break
+                    }
+                }
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
             }
+        }
+        .sheet(item: $webRoute) { route in
+            WebContentView(route: route)
         }
         .task {
             if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" { return }

--- a/Sources/Features/WebContent/WebContentView.swift
+++ b/Sources/Features/WebContent/WebContentView.swift
@@ -1,0 +1,240 @@
+//
+//  WebContentView.swift
+//  SkyAware
+//
+
+import SwiftUI
+import WebKit
+
+struct WebContentView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
+
+    let route: WebContentRoute
+
+    @State private var webView: WKWebView?
+    @State private var isLoading = false
+    @State private var estimatedProgress: Double = 0
+    @State private var canGoBack = false
+    @State private var canGoForward = false
+    @State private var currentURL: URL?
+    @State private var hasLoadError = false
+
+    private var navTitle: String {
+        route.title ?? route.sourceName ?? "Source"
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                if hasLoadError {
+                    errorState
+                } else {
+                    SkyAwareWebView(
+                        url: route.url,
+                        webView: $webView,
+                        isLoading: $isLoading,
+                        estimatedProgress: $estimatedProgress,
+                        canGoBack: $canGoBack,
+                        canGoForward: $canGoForward,
+                        currentURL: $currentURL,
+                        hasLoadError: $hasLoadError
+                    )
+                }
+            }
+            .navigationTitle(navTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Close") {
+                        dismiss()
+                    }
+                    .accessibilityLabel("Close page")
+                }
+
+                ToolbarItemGroup(placement: .bottomBar) {
+                    Button {
+                        webView?.goBack()
+                    } label: {
+                        Image(systemName: "chevron.backward")
+                    }
+                    .accessibilityLabel("Back")
+                    .disabled(canGoBack == false)
+
+                    Button {
+                        webView?.goForward()
+                    } label: {
+                        Image(systemName: "chevron.forward")
+                    }
+                    .accessibilityLabel("Forward")
+                    .disabled(canGoForward == false)
+
+                    Button {
+                        webView?.reload()
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                    .accessibilityLabel("Refresh")
+
+                    Spacer()
+
+                    ShareLink(item: currentURL ?? route.url) {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                    .accessibilityLabel("Share page")
+
+                    Button {
+                        openInSafari()
+                    } label: {
+                        Image(systemName: "safari")
+                    }
+                    .accessibilityLabel("Open in Safari")
+                }
+            }
+            .safeAreaInset(edge: .top) {
+                if isLoading {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Opening page…")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        ProgressView(value: estimatedProgress)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .background(.thinMaterial)
+                }
+            }
+        }
+    }
+
+    private var errorState: some View {
+        ContentUnavailableView {
+            Label("This page couldn’t be opened.", systemImage: "exclamationmark.triangle")
+        } description: {
+            Text("Open it in Safari instead.")
+        } actions: {
+            Button("Open in Safari") {
+                openInSafari()
+            }
+            .accessibilityLabel("Open this page in Safari")
+            Button("Close") {
+                dismiss()
+            }
+            .accessibilityLabel("Close page")
+        }
+        .padding(.horizontal, 16)
+    }
+
+    private func openInSafari() {
+        openURL(currentURL ?? route.url)
+    }
+}
+
+private struct SkyAwareWebView: UIViewRepresentable {
+    let url: URL
+
+    @Binding var webView: WKWebView?
+    @Binding var isLoading: Bool
+    @Binding var estimatedProgress: Double
+    @Binding var canGoBack: Bool
+    @Binding var canGoForward: Bool
+    @Binding var currentURL: URL?
+    @Binding var hasLoadError: Bool
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let view = WKWebView(frame: .zero)
+        view.allowsBackForwardNavigationGestures = true
+        view.navigationDelegate = context.coordinator
+        context.coordinator.bind(to: view)
+
+        webView = view
+        view.load(URLRequest(url: url))
+        return view
+    }
+
+    func updateUIView(_ view: WKWebView, context: Context) {
+        guard view.url == nil else { return }
+        view.load(URLRequest(url: url))
+    }
+
+    static func dismantleUIView(_ uiView: WKWebView, coordinator: Coordinator) {
+        coordinator.unbind()
+        uiView.navigationDelegate = nil
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        private var parent: SkyAwareWebView
+        private var progressObservation: NSKeyValueObservation?
+        private var loadingObservation: NSKeyValueObservation?
+        private var backObservation: NSKeyValueObservation?
+        private var forwardObservation: NSKeyValueObservation?
+        private var urlObservation: NSKeyValueObservation?
+
+        init(_ parent: SkyAwareWebView) {
+            self.parent = parent
+        }
+
+        func bind(to webView: WKWebView) {
+            progressObservation = webView.observe(\.estimatedProgress, options: [.initial, .new]) { [weak self] _, _ in
+                guard let self else { return }
+                Task { @MainActor in
+                    self.parent.estimatedProgress = webView.estimatedProgress
+                }
+            }
+            loadingObservation = webView.observe(\.isLoading, options: [.initial, .new]) { [weak self] _, _ in
+                guard let self else { return }
+                Task { @MainActor in
+                    self.parent.isLoading = webView.isLoading
+                }
+            }
+            backObservation = webView.observe(\.canGoBack, options: [.initial, .new]) { [weak self] _, _ in
+                guard let self else { return }
+                Task { @MainActor in
+                    self.parent.canGoBack = webView.canGoBack
+                }
+            }
+            forwardObservation = webView.observe(\.canGoForward, options: [.initial, .new]) { [weak self] _, _ in
+                guard let self else { return }
+                Task { @MainActor in
+                    self.parent.canGoForward = webView.canGoForward
+                }
+            }
+            urlObservation = webView.observe(\.url, options: [.initial, .new]) { [weak self] _, _ in
+                guard let self else { return }
+                Task { @MainActor in
+                    self.parent.currentURL = webView.url
+                }
+            }
+        }
+
+        func unbind() {
+            progressObservation = nil
+            loadingObservation = nil
+            backObservation = nil
+            forwardObservation = nil
+            urlObservation = nil
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            Task { @MainActor in
+                parent.hasLoadError = false
+            }
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            Task { @MainActor in
+                parent.hasLoadError = true
+            }
+        }
+
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            Task { @MainActor in
+                parent.hasLoadError = true
+            }
+        }
+    }
+}

--- a/Sources/Features/WebContent/WebContentView.swift
+++ b/Sources/Features/WebContent/WebContentView.swift
@@ -32,6 +32,7 @@ struct WebContentView: View {
                 } else {
                     SkyAwareWebView(
                         url: route.url,
+                        onExternalURL: { url in openURL(url) },
                         webView: $webView,
                         isLoading: $isLoading,
                         estimatedProgress: $estimatedProgress,
@@ -132,6 +133,7 @@ struct WebContentView: View {
 
 private struct SkyAwareWebView: UIViewRepresentable {
     let url: URL
+    let onExternalURL: (URL) -> Void
 
     @Binding var webView: WKWebView?
     @Binding var isLoading: Bool
@@ -234,6 +236,27 @@ private struct SkyAwareWebView: UIViewRepresentable {
         func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
             Task { @MainActor in
                 parent.hasLoadError = true
+            }
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void
+        ) {
+            guard let requestURL = navigationAction.request.url else {
+                decisionHandler(.cancel)
+                return
+            }
+
+            switch WebContentPolicy.decision(for: requestURL) {
+            case .inApp:
+                decisionHandler(.allow)
+            case .external:
+                parent.onExternalURL(requestURL)
+                decisionHandler(.cancel)
+            case .unsupported:
+                decisionHandler(.cancel)
             }
         }
     }

--- a/Sources/Utilities/Core/SpcProductFooter.swift
+++ b/Sources/Utilities/Core/SpcProductFooter.swift
@@ -9,9 +9,11 @@ import SwiftUI
 
 struct SpcProductFooter: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.openURL) private var openURL
 
     let link: URL
     let validEnd: Date
+    @State private var webRoute: WebContentRoute?
 
     private var adaptiveLayout: SkyAwareAdaptiveLayout {
         SkyAwareAdaptiveLayout(dynamicTypeSize: dynamicTypeSize)
@@ -38,11 +40,27 @@ struct SpcProductFooter: View {
     }
 
     private var openInBrowserLink: some View {
-        Link(destination: link) {
+        Button {
+            switch WebContentPolicy.decision(for: link) {
+            case .inApp:
+                webRoute = WebContentRoute(
+                    url: link,
+                    title: "SPC Product",
+                    sourceName: "Storm Prediction Center"
+                )
+            case .external:
+                openURL(link)
+            case .unsupported:
+                break
+            }
+        } label: {
             Label("Open in browser", systemImage: "arrow.up.right.square")
                 .font(.footnote.weight(.semibold))
         }
         .skyAwareGlassButtonStyle()
+        .sheet(item: $webRoute) { route in
+            WebContentView(route: route)
+        }
     }
 }
 

--- a/Sources/Utilities/Core/WebContentRoute.swift
+++ b/Sources/Utilities/Core/WebContentRoute.swift
@@ -1,0 +1,61 @@
+//
+//  WebContentRoute.swift
+//  SkyAware
+//
+
+import Foundation
+
+struct WebContentRoute: Identifiable, Hashable, Sendable {
+    let id: UUID
+    let url: URL
+    let title: String?
+    let sourceName: String?
+
+    init(
+        id: UUID = UUID(),
+        url: URL,
+        title: String? = nil,
+        sourceName: String? = nil
+    ) {
+        self.id = id
+        self.url = url
+        self.title = title
+        self.sourceName = sourceName
+    }
+}
+
+enum WebContentNavigationDecision: Sendable, Equatable {
+    case inApp
+    case external
+    case unsupported
+}
+
+enum WebContentPolicy {
+    private static let inAppSchemes: Set<String> = ["http", "https"]
+    private static let externalSchemes: Set<String> = [
+        "mailto", "tel", "sms", "maps", "facetime", "facetime-audio", "itms-apps", "itms-appss"
+    ]
+
+    static func decision(for url: URL) -> WebContentNavigationDecision {
+        guard let scheme = url.scheme?.lowercased(), scheme.isEmpty == false else {
+            return .unsupported
+        }
+
+        if inAppSchemes.contains(scheme) {
+            guard url.host?.isEmpty == false else {
+                return .unsupported
+            }
+            return .inApp
+        }
+
+        if externalSchemes.contains(scheme) {
+            return .external
+        }
+
+        return .external
+    }
+
+    static func canOpenInApp(_ url: URL) -> Bool {
+        decision(for: url) == .inApp
+    }
+}

--- a/Tests/UnitTests/WidgetRouteURLTests.swift
+++ b/Tests/UnitTests/WidgetRouteURLTests.swift
@@ -39,3 +39,53 @@ struct WidgetRouteURLTests {
         #expect(HomeView.tabSelection(forIncomingURL: url) == nil)
     }
 }
+
+@Suite("Web content policy")
+struct WebContentPolicyTests {
+    @Test("allows https URLs in-app")
+    func allowsHTTPSInApp() throws {
+        let url = try #require(URL(string: "https://www.spc.noaa.gov/products/outlook/day1otlk.html"))
+
+        #expect(WebContentPolicy.decision(for: url) == .inApp)
+        #expect(WebContentPolicy.canOpenInApp(url))
+    }
+
+    @Test("allows http URLs in-app")
+    func allowsHTTPInApp() throws {
+        let url = try #require(URL(string: "http://example.com/reference"))
+
+        #expect(WebContentPolicy.decision(for: url) == .inApp)
+        #expect(WebContentPolicy.canOpenInApp(url))
+    }
+
+    @Test("rejects malformed web URL")
+    func rejectsMalformedWebURL() throws {
+        let url = try #require(URL(string: "https:///missing-host"))
+
+        #expect(WebContentPolicy.decision(for: url) == .unsupported)
+        #expect(WebContentPolicy.canOpenInApp(url) == false)
+    }
+
+    @Test("routes non-web schemes externally")
+    func routesNonWebSchemesExternally() throws {
+        let mail = try #require(URL(string: "mailto:help@skyaware.app"))
+        let phone = try #require(URL(string: "tel:+13035551234"))
+
+        #expect(WebContentPolicy.decision(for: mail) == .external)
+        #expect(WebContentPolicy.decision(for: phone) == .external)
+        #expect(WebContentPolicy.canOpenInApp(mail) == false)
+        #expect(WebContentPolicy.canOpenInApp(phone) == false)
+    }
+
+    @Test("supports deterministic route values")
+    func routeSupportsDeterministicValues() throws {
+        let url = try #require(URL(string: "https://www.weather.gov"))
+        let id = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!
+        let route = WebContentRoute(id: id, url: url, title: "NWS", sourceName: "National Weather Service")
+
+        #expect(route.id == id)
+        #expect(route.url == url)
+        #expect(route.title == "NWS")
+        #expect(route.sourceName == "National Weather Service")
+    }
+}


### PR DESCRIPTION
# Summary
Adds a lightweight in-app web content viewer for trusted external pages and routes eligible links through a small URL policy layer, while preserving external handoff for non-web schemes.

# What Changed
- Added `WebContentRoute` and `WebContentPolicy` to centralize in-app vs external URL decisions.
- Added a reusable `WebContentView` backed by `WKWebView` with loading/progress state, back/forward, refresh, share, open-in-Safari, and failure fallback UI.
- Updated `SpcProductFooter` link handling to present the in-app viewer for eligible web URLs and fall back to system open behavior otherwise.
- Updated `AttributionView` legal/source link handling to use the same in-app routing and external fallback behavior.
- Added `WebContentPolicyTests` covering scheme classification, in-app eligibility checks, fallback behavior, and deterministic route initialization.

# User Impact
Users can open trusted source/read-more pages inside SkyAware with calm native controls and quick fallback to Safari, instead of always being context-switched out of the app.

# Testing
- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build`
- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" test`

# Notes
- Non-web schemes (`mailto:`, `tel:`, `maps:`, app-store schemes, and other unknown schemes) remain external by design.
- The worktree currently contains unrelated local docs changes that are not part of this PR scope.
