### PR TITLE
Polish resolve-forward Summary and Local Alerts state transitions

### DIFF
--- a/Sources/Features/Badges/AtmosphereRailView.swift
+++ b/Sources/Features/Badges/AtmosphereRailView.swift
@@ -22,7 +22,7 @@ struct AtmosphereRailView: View {
 
     private var atmosphereSummary: String {
         guard let weather else {
-            return "Loading atmospheric metrics…"
+            return "Atmospheric details are still resolving."
         }
 
         let condition = weather.conditionText.isEmpty ? "Atmospheric conditions" : weather.conditionText

--- a/Sources/Features/Badges/AtmosphereRailView.swift
+++ b/Sources/Features/Badges/AtmosphereRailView.swift
@@ -22,7 +22,7 @@ struct AtmosphereRailView: View {
 
     private var atmosphereSummary: String {
         guard let weather else {
-            return "Atmospheric details are still resolving."
+            return "Getting atmospheric details…"
         }
 
         let condition = weather.conditionText.isEmpty ? "Atmospheric conditions" : weather.conditionText
@@ -168,7 +168,7 @@ struct AtmosphereRailView: View {
         VStack(alignment: .leading, spacing: 8) {
             Label("Offline", systemImage: "wifi.slash")
                 .sectionLabel()
-            Text("Atmospheric conditions are unavailable while the server is offline.")
+            Text("SkyAware is showing saved local data. Atmospheric details will update when your connection returns.")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
         }

--- a/Sources/Features/Badges/FireWeatherRailView.swift
+++ b/Sources/Features/Badges/FireWeatherRailView.swift
@@ -43,10 +43,10 @@ struct FireWeatherRailView: View {
 
     private var resolvingBackground: LinearGradient {
         let colors: [Color] = colorScheme == .dark
-        ? [Color(red: 0.22, green: 0.22, blue: 0.24).opacity(0.92),
-           Color(red: 0.13, green: 0.13, blue: 0.15).opacity(0.92)]
-        : [Color(red: 0.94, green: 0.93, blue: 0.91),
-           Color(red: 0.90, green: 0.89, blue: 0.87)]
+        ? [Color(red: 0.17, green: 0.22, blue: 0.30).opacity(0.93),
+           Color(red: 0.10, green: 0.14, blue: 0.20).opacity(0.93)]
+        : [Color(red: 0.87, green: 0.91, blue: 0.96),
+           Color(red: 0.82, green: 0.87, blue: 0.93)]
 
         return LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing)
     }
@@ -58,7 +58,7 @@ struct FireWeatherRailView: View {
             VStack(alignment: .leading, spacing: 3) {
                 Text("Fire Risk")
                     .formatMessageText()
-                Text("Resolving local fire-weather conditions.")
+                Text("Getting fire risk…")
                     .formatSummaryText(for: colorScheme)
             }
         }
@@ -69,7 +69,7 @@ struct FireWeatherRailView: View {
         VStack(alignment: .leading, spacing: 8) {
             Label("Offline", systemImage: "wifi.slash")
                 .sectionLabel()
-            Text("Fire risk is unavailable while the server is offline.")
+            Text("SkyAware is showing saved local data. Fire risk will update when your connection returns.")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
         }

--- a/Sources/Features/Badges/FireWeatherRailView.swift
+++ b/Sources/Features/Badges/FireWeatherRailView.swift
@@ -11,6 +11,7 @@ struct FireWeatherRailView: View {
     @Environment(\.colorScheme) var colorScheme
     let level: FireRiskLevel
     var isOffline: Bool = false
+    var showsResolvingPlaceholder: Bool = false
     var label: String {
         switch level {
         case .clear: return "No"
@@ -22,6 +23,8 @@ struct FireWeatherRailView: View {
         Group {
             if isOffline {
                 offlineContent
+            } else if showsResolvingPlaceholder {
+                resolvingContent
             } else {
                 HStack(spacing: 12) {
                     Image(systemName: level.symbol)
@@ -36,6 +39,30 @@ struct FireWeatherRailView: View {
                 .railStyle(background: level.iconColor(for: colorScheme))
             }
         }
+    }
+
+    private var resolvingBackground: LinearGradient {
+        let colors: [Color] = colorScheme == .dark
+        ? [Color(red: 0.22, green: 0.22, blue: 0.24).opacity(0.92),
+           Color(red: 0.13, green: 0.13, blue: 0.15).opacity(0.92)]
+        : [Color(red: 0.94, green: 0.93, blue: 0.91),
+           Color(red: 0.90, green: 0.89, blue: 0.87)]
+
+        return LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing)
+    }
+
+    private var resolvingContent: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "flame")
+                .formatBadgeImage()
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Fire Risk")
+                    .formatMessageText()
+                Text("Resolving local fire-weather conditions.")
+                    .formatSummaryText(for: colorScheme)
+            }
+        }
+        .railStyle(background: resolvingBackground)
     }
 
     private var offlineContent: some View {
@@ -56,6 +83,7 @@ struct FireWeatherRailView: View {
 #Preview {
     VStack {
         FireWeatherRailView(level: .clear)
+        FireWeatherRailView(level: .clear, showsResolvingPlaceholder: true)
         FireWeatherRailView(level: .elevated)
         FireWeatherRailView(level: .critical)
         FireWeatherRailView(level: .extreme)

--- a/Sources/Features/Badges/SevereWeatherBadgeView.swift
+++ b/Sources/Features/Badges/SevereWeatherBadgeView.swift
@@ -48,7 +48,7 @@ struct SevereWeatherBadgeView: View {
 
     private var resolvingContent: some View {
         VStack(spacing: 4) {
-            Image(systemName: "exclamationmark.triangle.badge.clock")
+            Image(systemName: "clock.arrow.trianglehead.2.counterclockwise.rotate.90")
                 .formatBadgeImage()
                 .opacity(0.92)
             Text("Severe Risk")

--- a/Sources/Features/Badges/SevereWeatherBadgeView.swift
+++ b/Sources/Features/Badges/SevereWeatherBadgeView.swift
@@ -10,25 +10,61 @@ import SwiftUI
 struct SevereWeatherBadgeView: View {
     let threat: SevereWeatherThreat
     var isOffline: Bool = false
+    var isResolving: Bool = false
+    var showsResolvingPlaceholder: Bool = false
+
     @Environment(\.colorScheme) var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     
     var body: some View {
         Group {
             if isOffline {
                 offlineContent
+            } else if showsResolvingPlaceholder {
+                resolvingContent
             } else {
-                VStack(spacing: 4) {
-                    Image(systemName: threat.iconName)
-                        .formatBadgeImage()
-                    Text(threat.message)
-                        .formatMessageText()
-                    Text(threat.dynamicSummary != "" ? threat.dynamicSummary : threat.summary)
-                        .formatSummaryText(for: colorScheme)
-                        .monospacedDigit()
-                }
-                .badgeStyle(background: threat.iconColor(for: colorScheme))
+                resolvedContent
             }
         }
+    }
+
+    private var resolvedContent: some View {
+        VStack(spacing: 4) {
+            Image(systemName: threat.iconName)
+                .formatBadgeImage()
+                .contentTransition(.opacity)
+            Text(threat.message)
+                .formatMessageText()
+                .contentTransition(.opacity)
+            Text(threat.dynamicSummary != "" ? threat.dynamicSummary : threat.summary)
+                .formatSummaryText(for: colorScheme)
+                .monospacedDigit()
+                .contentTransition(.opacity)
+        }
+        .badgeStyle(background: threat.iconColor(for: colorScheme))
+        .animation(SkyAwareMotion.settle(reduceMotion), value: threat.message)
+        .animation(SkyAwareMotion.settle(reduceMotion), value: threat.dynamicSummary)
+    }
+
+    private var resolvingContent: some View {
+        VStack(spacing: 4) {
+            Image(systemName: "exclamationmark.triangle.badge.clock")
+                .formatBadgeImage()
+                .opacity(0.92)
+            Text("Severe Risk")
+                .formatMessageText()
+            Text(isResolving ? "Refining severe threat…" : "Resolving severe threat…")
+                .formatSummaryText(for: colorScheme)
+        }
+        .badgeStyle(background: resolvingBackground)
+        .transition(.opacity)
+        .animation(SkyAwareMotion.settle(reduceMotion), value: isResolving)
+    }
+
+    private var resolvingBackground: LinearGradient {
+        let top = colorScheme == .dark ? Color.white.opacity(0.18) : Color.white.opacity(0.52)
+        let bottom = colorScheme == .dark ? Color.white.opacity(0.10) : Color.white.opacity(0.30)
+        return LinearGradient(colors: [top, bottom], startPoint: .topLeading, endPoint: .bottomTrailing)
     }
 
     private var offlineContent: some View {
@@ -57,6 +93,10 @@ struct SevereWeatherBadgeView: View {
             SevereWeatherBadgeView(threat: .hail(probability: 0.02))
             SevereWeatherBadgeView(threat: .tornado(probability: 0.05))
                 .preferredColorScheme(.dark)
+        }
+        HStack {
+            SevereWeatherBadgeView(threat: .allClear, isResolving: true, showsResolvingPlaceholder: true)
+            SevereWeatherBadgeView(threat: .wind(probability: 0.15), isResolving: true)
         }
     }
     .background(.skyAwareBackground)

--- a/Sources/Features/Badges/SevereWeatherBadgeView.swift
+++ b/Sources/Features/Badges/SevereWeatherBadgeView.swift
@@ -53,17 +53,20 @@ struct SevereWeatherBadgeView: View {
                 .opacity(0.92)
             Text("Severe Risk")
                 .formatMessageText()
-            Text(isResolving ? "Refining severe threat…" : "Resolving severe threat…")
+            Text("Getting severe risk…")
                 .formatSummaryText(for: colorScheme)
         }
         .badgeStyle(background: resolvingBackground)
         .transition(.opacity)
-        .animation(SkyAwareMotion.settle(reduceMotion), value: isResolving)
     }
 
     private var resolvingBackground: LinearGradient {
-        let top = colorScheme == .dark ? Color.white.opacity(0.18) : Color.white.opacity(0.52)
-        let bottom = colorScheme == .dark ? Color.white.opacity(0.10) : Color.white.opacity(0.30)
+        let top = colorScheme == .dark
+            ? Color(red: 0.17, green: 0.22, blue: 0.30).opacity(0.93)
+            : Color(red: 0.87, green: 0.91, blue: 0.96)
+        let bottom = colorScheme == .dark
+            ? Color(red: 0.10, green: 0.14, blue: 0.20).opacity(0.93)
+            : Color(red: 0.82, green: 0.87, blue: 0.93)
         return LinearGradient(colors: [top, bottom], startPoint: .topLeading, endPoint: .bottomTrailing)
     }
 
@@ -71,7 +74,7 @@ struct SevereWeatherBadgeView: View {
         VStack(alignment: .leading, spacing: 8) {
             Label("Offline", systemImage: "wifi.slash")
                 .sectionLabel()
-            Text("Severe threat details are unavailable while the server is offline.")
+            Text("SkyAware is showing saved local data. Severe risk details will update when your connection returns.")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
         }

--- a/Sources/Features/Badges/StormRiskBadgeView.swift
+++ b/Sources/Features/Badges/StormRiskBadgeView.swift
@@ -10,24 +10,60 @@ import SwiftUI
 struct StormRiskBadgeView: View {
     let level: StormRiskLevel
     var isOffline: Bool = false
+    var isResolving: Bool = false
+    var showsResolvingPlaceholder: Bool = false
+
     @Environment(\.colorScheme) var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     
     var body: some View {
         Group {
             if isOffline {
                 offlineContent
+            } else if showsResolvingPlaceholder {
+                resolvingContent
             } else {
-                VStack(spacing: 4) {
-                    Image(systemName: level.iconName)
-                        .formatBadgeImage()
-                    Text(level.message)
-                        .formatMessageText()
-                    Text(level.summary)
-                        .formatSummaryText(for: colorScheme)
-                }
-                .badgeStyle(background: level.iconColor(for: colorScheme))
+                resolvedContent
             }
         }
+    }
+
+    private var resolvedContent: some View {
+        VStack(spacing: 4) {
+            Image(systemName: level.iconName)
+                .formatBadgeImage()
+                .contentTransition(.opacity)
+            Text(level.message)
+                .formatMessageText()
+                .contentTransition(.opacity)
+            Text(level.summary)
+                .formatSummaryText(for: colorScheme)
+                .contentTransition(.opacity)
+        }
+        .badgeStyle(background: level.iconColor(for: colorScheme))
+        .animation(SkyAwareMotion.settle(reduceMotion), value: level.message)
+        .animation(SkyAwareMotion.settle(reduceMotion), value: level.summary)
+    }
+
+    private var resolvingContent: some View {
+        VStack(spacing: 4) {
+            Image(systemName: "bolt.badge.clock")
+                .formatBadgeImage()
+                .opacity(0.92)
+            Text("Storm Risk")
+                .formatMessageText()
+            Text(isResolving ? "Refining local risk…" : "Resolving local risk…")
+                .formatSummaryText(for: colorScheme)
+        }
+        .badgeStyle(background: resolvingBackground)
+        .transition(.opacity)
+        .animation(SkyAwareMotion.settle(reduceMotion), value: isResolving)
+    }
+
+    private var resolvingBackground: LinearGradient {
+        let top = colorScheme == .dark ? Color.white.opacity(0.18) : Color.white.opacity(0.52)
+        let bottom = colorScheme == .dark ? Color.white.opacity(0.10) : Color.white.opacity(0.30)
+        return LinearGradient(colors: [top, bottom], startPoint: .topLeading, endPoint: .bottomTrailing)
     }
 
     private var offlineContent: some View {
@@ -63,6 +99,10 @@ struct StormRiskBadgeView: View {
             StormRiskBadgeView(level: .moderate)
             StormRiskBadgeView(level: .high)
                 .preferredColorScheme(.dark)
+        }
+        HStack {
+            StormRiskBadgeView(level: .allClear, isResolving: true, showsResolvingPlaceholder: true)
+            StormRiskBadgeView(level: .moderate, isResolving: true)
         }
     }.background(.skyAwareBackground)
 }

--- a/Sources/Features/Badges/StormRiskBadgeView.swift
+++ b/Sources/Features/Badges/StormRiskBadgeView.swift
@@ -52,17 +52,20 @@ struct StormRiskBadgeView: View {
                 .opacity(0.92)
             Text("Storm Risk")
                 .formatMessageText()
-            Text(isResolving ? "Refining local risk…" : "Resolving local risk…")
+            Text("Getting storm risk…")
                 .formatSummaryText(for: colorScheme)
         }
         .badgeStyle(background: resolvingBackground)
         .transition(.opacity)
-        .animation(SkyAwareMotion.settle(reduceMotion), value: isResolving)
     }
 
     private var resolvingBackground: LinearGradient {
-        let top = colorScheme == .dark ? Color.white.opacity(0.18) : Color.white.opacity(0.52)
-        let bottom = colorScheme == .dark ? Color.white.opacity(0.10) : Color.white.opacity(0.30)
+        let top = colorScheme == .dark
+            ? Color(red: 0.17, green: 0.22, blue: 0.30).opacity(0.93)
+            : Color(red: 0.87, green: 0.91, blue: 0.96)
+        let bottom = colorScheme == .dark
+            ? Color(red: 0.10, green: 0.14, blue: 0.20).opacity(0.93)
+            : Color(red: 0.82, green: 0.87, blue: 0.93)
         return LinearGradient(colors: [top, bottom], startPoint: .topLeading, endPoint: .bottomTrailing)
     }
 
@@ -70,7 +73,7 @@ struct StormRiskBadgeView: View {
         VStack(alignment: .leading, spacing: 8) {
             Label("Offline", systemImage: "wifi.slash")
                 .sectionLabel()
-            Text("Storm risk is unavailable while the server is offline.")
+            Text("SkyAware is showing saved local data. Storm risk will update when your connection returns.")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
         }

--- a/Sources/Features/Badges/StormRiskBadgeView.swift
+++ b/Sources/Features/Badges/StormRiskBadgeView.swift
@@ -47,7 +47,7 @@ struct StormRiskBadgeView: View {
 
     private var resolvingContent: some View {
         VStack(spacing: 4) {
-            Image(systemName: "bolt.badge.clock")
+            Image(systemName: "clock.arrow.trianglehead.2.counterclockwise.rotate.90")
                 .formatBadgeImage()
                 .opacity(0.92)
             Text("Storm Risk")

--- a/Sources/Features/Loading/LoadingView.swift
+++ b/Sources/Features/Loading/LoadingView.swift
@@ -9,80 +9,56 @@ import SwiftUI
 
 struct LoadingView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
 
-    var message: String = "Checking current conditions..."
+    var message: String = "Bringing in your conditions…"
 
     @State private var glowDrift = CGSize.zero
-    @State private var glowOpacity: Double = 0.18
-    @State private var glowPulseOpacity: Double = 0.72
-    @State private var glowPulseScale: CGFloat = 0.98
-    @State private var ghostOpacity: Double = 0.32
+    @State private var glowOpacity: Double = 0.24
+    @State private var glowPulseOpacity: Double = 0.74
+    @State private var glowPulseScale: CGFloat = 1.0
+    @State private var ghostOpacity: Double = 0.58
 
     var body: some View {
-        ZStack(alignment: .top) {
+        ZStack {
+            atmosphericBackground
             summaryGhost
 
-            VStack(spacing: 14) {
-                ZStack {
-                    UnevenRoundedRectangle(
-                        cornerRadii: .init(
-                            topLeading: 38,
-                            bottomLeading: 30,
-                            bottomTrailing: 42,
-                            topTrailing: 34
-                        ),
-                        style: .continuous
-                    )
-                        .fill(Color.skyAwareAccent.opacity(glowOpacity))
-                        .frame(width: 112, height: 96)
-                        .blur(radius: 34)
-                        .scaleEffect(glowPulseScale)
-                        .opacity(glowPulseOpacity)
-                        .offset(x: -6 + glowDrift.width, y: 4 + glowDrift.height)
-                        .rotationEffect(.degrees(-8))
-
-                    Ellipse()
-                        .fill(Color.skyAwareAccent.opacity(glowOpacity * 0.55))
-                        .frame(width: 84, height: 66)
-                        .blur(radius: 30)
-                        .scaleEffect(glowPulseScale * 1.01)
-                        .opacity(glowPulseOpacity)
-                        .offset(x: 10 - (glowDrift.width * 0.7), y: -6 - (glowDrift.height * 0.7))
-                        .rotationEffect(.degrees(12))
-
-                    Circle()
-                        .fill(Color.white.opacity(0.05))
-                        .frame(width: 50, height: 50)
-
-                    Image(systemName: "cloud.sun.fill")
-                        .font(.title2.weight(.semibold))
-                        .foregroundStyle(.skyAwareAccent)
-                }
-
-                VStack(spacing: 6) {
-                    Text("Getting your conditions ready")
-                        .font(.headline.weight(.medium))
-                        .foregroundStyle(.primary.opacity(0.9))
-
-                    Text(message)
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                }
+            VStack(spacing: 10) {
+                Text("Getting your conditions ready")
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(.primary.opacity(0.96))
+                    .multilineTextAlignment(.center)
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary.opacity(0.95))
+                    .multilineTextAlignment(.center)
             }
-            .padding(.top, 36)
+            .padding(.horizontal, 24)
+            .padding(.vertical, 26)
+            .background {
+                RoundedRectangle(cornerRadius: SkyAwareRadius.content, style: .continuous)
+                    .fill(.ultraThinMaterial.opacity(colorScheme == .dark ? 0.30 : 0.78))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: SkyAwareRadius.content, style: .continuous)
+                            .strokeBorder(.white.opacity(colorScheme == .dark ? 0.12 : 0.24), lineWidth: 0.9)
+                    }
+            }
+            .padding(.horizontal, 18)
         }
+        .frame(maxWidth: .infinity, minHeight: 560)
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 18)
+        .padding(.vertical, 14)
+        .clipShape(RoundedRectangle(cornerRadius: SkyAwareRadius.hero, style: .continuous))
         .transition(.opacity)
         .animation(SkyAwareMotion.message(reduceMotion), value: message)
         .task(id: reduceMotion) {
             guard reduceMotion == false else {
                 glowDrift = .zero
-                glowOpacity = 0.18
-                glowPulseOpacity = 0.72
+                glowOpacity = 0.24
+                glowPulseOpacity = 0.74
                 glowPulseScale = 1
-                ghostOpacity = 0.32
+                ghostOpacity = 0.58
                 return
             }
 
@@ -90,9 +66,9 @@ struct LoadingView: View {
                 .easeInOut(duration: SkyAwareMotion.ambientDriftDuration)
                     .repeatForever(autoreverses: true)
             ) {
-                glowDrift = CGSize(width: 4, height: -3)
-                glowOpacity = 0.22
-                ghostOpacity = 0.37
+                glowDrift = CGSize(width: 6, height: -5)
+                glowOpacity = 0.30
+                ghostOpacity = 0.62
             }
 
             withAnimation(
@@ -100,47 +76,89 @@ struct LoadingView: View {
                     .repeatForever(autoreverses: true)
             ) {
                 glowPulseOpacity = 0.88
-                glowPulseScale = 1.03
+                glowPulseScale = 1.07
             }
         }
     }
 
+    private var atmosphericBackground: some View {
+        ZStack {
+            LinearGradient(
+                colors: colorScheme == .dark
+                    ? [
+                        Color(red: 0.045, green: 0.074, blue: 0.118),
+                        Color(red: 0.060, green: 0.091, blue: 0.142),
+                        Color(red: 0.032, green: 0.050, blue: 0.082)
+                    ]
+                    : [
+                        Color(red: 0.955, green: 0.972, blue: 0.995),
+                        Color(red: 0.930, green: 0.955, blue: 0.990),
+                        Color(red: 0.905, green: 0.934, blue: 0.978)
+                    ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+
+            RadialGradient(
+                colors: [
+                    Color.skyAwareAccent.opacity(glowOpacity * (colorScheme == .dark ? 1.05 : 0.54)),
+                    Color.skyAwareAccent.opacity(glowOpacity * (colorScheme == .dark ? 0.44 : 0.24)),
+                    .clear
+                ],
+                center: UnitPoint(x: 0.80 + glowDrift.width / 120, y: 0.24 + glowDrift.height / 120),
+                startRadius: 8,
+                endRadius: colorScheme == .dark ? 260 : 220
+            )
+            .opacity(glowPulseOpacity)
+            .scaleEffect(glowPulseScale)
+
+            LinearGradient(
+                colors: [
+                    .white.opacity(colorScheme == .dark ? 0.07 : 0.30),
+                    .clear
+                ],
+                startPoint: .topLeading,
+                endPoint: .center
+            )
+        }
+        .overlay {
+            LinearGradient(
+                colors: [
+                    .clear,
+                    .black.opacity(colorScheme == .dark ? 0.16 : 0.04)
+                ],
+                startPoint: .center,
+                endPoint: .bottomTrailing
+            )
+        }
+    }
+
     private var summaryGhost: some View {
-        VStack(spacing: 18) {
+        VStack(spacing: 16) {
             RoundedRectangle(cornerRadius: SkyAwareRadius.section, style: .continuous)
-                .fill(Color.white.opacity(0.06))
-                .frame(height: 78)
+                .fill(.white.opacity(colorScheme == .dark ? 0.10 : 0.22))
+                .frame(height: 72)
 
-            RoundedRectangle(cornerRadius: SkyAwareRadius.hero, style: .continuous)
-                .fill(Color.white.opacity(0.05))
-                .frame(height: 332)
-                .overlay(alignment: .top) {
-                    VStack(spacing: 16) {
-                        HStack(spacing: 14) {
-                            RoundedRectangle(cornerRadius: SkyAwareRadius.large, style: .continuous)
-                                .fill(Color.white.opacity(0.07))
-                                .frame(height: 160)
-                            RoundedRectangle(cornerRadius: SkyAwareRadius.large, style: .continuous)
-                                .fill(Color.white.opacity(0.07))
-                                .frame(height: 160)
-                        }
+            HStack(spacing: 12) {
+                RoundedRectangle(cornerRadius: SkyAwareRadius.large, style: .continuous)
+                    .fill(.white.opacity(colorScheme == .dark ? 0.10 : 0.21))
+                    .frame(height: 126)
+                RoundedRectangle(cornerRadius: SkyAwareRadius.large, style: .continuous)
+                    .fill(.white.opacity(colorScheme == .dark ? 0.09 : 0.18))
+                    .frame(height: 126)
+            }
 
-                        RoundedRectangle(cornerRadius: SkyAwareRadius.row, style: .continuous)
-                            .fill(Color.white.opacity(0.06))
-                            .frame(height: 76)
-
-                        RoundedRectangle(cornerRadius: SkyAwareRadius.card, style: .continuous)
-                            .fill(Color.white.opacity(0.05))
-                            .frame(height: 150)
-                    }
-                    .padding(18)
-                }
+            RoundedRectangle(cornerRadius: SkyAwareRadius.row, style: .continuous)
+                .fill(.white.opacity(colorScheme == .dark ? 0.09 : 0.19))
+                .frame(height: 70)
 
             RoundedRectangle(cornerRadius: SkyAwareRadius.card, style: .continuous)
-                .fill(Color.white.opacity(0.05))
-                .frame(height: 128)
+                .fill(.white.opacity(colorScheme == .dark ? 0.09 : 0.17))
+                .frame(height: 110)
         }
-        .blur(radius: 8)
+        .padding(.horizontal, 18)
+        .padding(.vertical, 28)
+        .blur(radius: colorScheme == .dark ? 14 : 10)
         .opacity(ghostOpacity)
         .allowsHitTesting(false)
         .accessibilityHidden(true)
@@ -148,7 +166,20 @@ struct LoadingView: View {
 }
 
 #Preview {
-    LoadingView(message: "Checking current conditions...")
+    LoadingView(message: "Bringing in local conditions…")
+        .padding(.horizontal, 16)
+        .background(.skyAwareBackground)
+}
+
+#Preview("Dark") {
+    LoadingView(message: "Bringing in local conditions…")
+        .padding(.horizontal, 16)
+        .background(.skyAwareBackground)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Reduce Motion") {
+    LoadingView(message: "Bringing in local conditions…")
         .padding(.horizontal, 16)
         .background(.skyAwareBackground)
 }

--- a/Sources/Features/Loading/LoadingView.swift
+++ b/Sources/Features/Loading/LoadingView.swift
@@ -35,18 +35,11 @@ struct LoadingView: View {
                     .multilineTextAlignment(.center)
             }
             .padding(.horizontal, 24)
-            .padding(.vertical, 26)
-            .background {
-                RoundedRectangle(cornerRadius: SkyAwareRadius.content, style: .continuous)
-                    .fill(.ultraThinMaterial.opacity(colorScheme == .dark ? 0.30 : 0.78))
-                    .overlay {
-                        RoundedRectangle(cornerRadius: SkyAwareRadius.content, style: .continuous)
-                            .strokeBorder(.white.opacity(colorScheme == .dark ? 0.12 : 0.24), lineWidth: 0.9)
-                    }
-            }
+            .padding(.vertical, 20)
             .padding(.horizontal, 18)
+            .shadow(color: .black.opacity(colorScheme == .dark ? 0.20 : 0.08), radius: 6, x: 0, y: 3)
         }
-        .frame(maxWidth: .infinity, minHeight: 560)
+        .frame(maxWidth: .infinity, minHeight: 500)
         .frame(maxWidth: .infinity)
         .padding(.vertical, 14)
         .clipShape(RoundedRectangle(cornerRadius: SkyAwareRadius.hero, style: .continuous))
@@ -178,7 +171,7 @@ struct LoadingView: View {
         .preferredColorScheme(.dark)
 }
 
-#Preview("Reduce Motion") {
+#Preview("Reduce Motion (Name Only)") {
     LoadingView(message: "Bringing in local conditions…")
         .padding(.horizontal, 16)
         .background(.skyAwareBackground)

--- a/Sources/Features/Summary/ActiveAlertSummaryView.swift
+++ b/Sources/Features/Summary/ActiveAlertSummaryView.swift
@@ -211,7 +211,7 @@ struct ActiveAlertSummaryView: View {
         VStack(alignment: .leading, spacing: 8) {
             Label("Offline", systemImage: "wifi.slash")
                 .sectionLabel()
-            Text("Local alert details are unavailable while the server is offline.")
+            Text("SkyAware is showing saved local data. Local alerts will update when your connection returns.")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
         }

--- a/Sources/Features/Summary/ActiveAlertSummaryView.swift
+++ b/Sources/Features/Summary/ActiveAlertSummaryView.swift
@@ -69,7 +69,7 @@ struct ActiveAlertSummaryView: View {
     @ViewBuilder
     private var alertsContent: some View {
         ActiveAlertSection(
-            label: "Watches & Warningso",
+            label: "Watches & Warnings",
             items: sortedAlerts,
             limit: 2,
             onSelect: {
@@ -159,25 +159,24 @@ struct ActiveAlertSummaryView: View {
     private var innerContent: some View {
         if #available(iOS 26, *) {
             GlassEffectContainer(spacing: 12) {
-                contentStateView
-                    .id(contentState)
-                    .transition(.opacity)
-                    .frame(
-                        maxWidth: .infinity,
-                        minHeight: usesFlexibleAlertHeight ? nil : 72,
-                        alignment: .topLeading
-                    )
+                contentStateContainer
             }
         } else {
+            contentStateContainer
+        }
+    }
+
+    private var contentStateContainer: some View {
+        ZStack(alignment: .topLeading) {
             contentStateView
                 .id(contentState)
                 .transition(.opacity)
-                .frame(
-                    maxWidth: .infinity,
-                    minHeight: usesFlexibleAlertHeight ? nil : 72,
-                    alignment: .topLeading
-                )
         }
+        .frame(
+            maxWidth: .infinity,
+            minHeight: usesFlexibleAlertHeight ? nil : 72,
+            alignment: .topLeading
+        )
     }
 
     @ViewBuilder
@@ -204,6 +203,7 @@ struct ActiveAlertSummaryView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(2)
+        .accessibilityElement(children: .combine)
     }
 
     private var emptyContent: some View {

--- a/Sources/Features/Summary/ActiveAlertSummaryView.swift
+++ b/Sources/Features/Summary/ActiveAlertSummaryView.swift
@@ -29,7 +29,8 @@ struct ActiveAlertSummaryView: View {
     @State private var selectedAlert: AlertDTO? = nil
     @State private var selectedMesoDetent: PresentationDetent = .medium
     @State private var selectedAlertDetent: PresentationDetent = .medium
-    @State private var keepsFlexibleHeightDuringTransition = false
+    @State private var lastStableContentState: ContentState? = nil
+    @State private var isLeavingAlertsHeightHoldActive = false
     @State private var flexibleHeightResetTask: Task<Void, Never>? = nil
     init(
         mesos: [MdDTO],
@@ -64,8 +65,13 @@ struct ActiveAlertSummaryView: View {
         return .empty
     }
 
+    private var isLeavingAlertsTransition: Bool {
+        guard let lastStableContentState else { return false }
+        return lastStableContentState == .alerts && contentState != .alerts && isLeavingAlertsHeightHoldActive
+    }
+
     private var usesFlexibleAlertHeight: Bool {
-        contentState == .alerts || keepsFlexibleHeightDuringTransition
+        Self.usesFlexibleAlertHeight(currentState: contentState, isLeavingAlerts: isLeavingAlertsTransition)
     }
 
     private var transitionHoldDurationNanoseconds: UInt64 {
@@ -162,6 +168,11 @@ struct ActiveAlertSummaryView: View {
         }
         .onChange(of: contentState) { oldValue, newValue in
             handleContentStateTransition(from: oldValue, to: newValue)
+        }
+        .onAppear {
+            if lastStableContentState == nil {
+                lastStableContentState = contentState
+            }
         }
         .onDisappear {
             flexibleHeightResetTask?.cancel()
@@ -275,20 +286,32 @@ struct ActiveAlertSummaryView: View {
     private func handleContentStateTransition(from oldState: ContentState, to newState: ContentState) {
         if newState == .alerts {
             flexibleHeightResetTask?.cancel()
-            keepsFlexibleHeightDuringTransition = false
+            isLeavingAlertsHeightHoldActive = false
+            lastStableContentState = .alerts
             return
         }
 
-        guard oldState == .alerts else { return }
+        guard oldState == .alerts, newState != .alerts else {
+            flexibleHeightResetTask?.cancel()
+            isLeavingAlertsHeightHoldActive = false
+            lastStableContentState = newState
+            return
+        }
 
         flexibleHeightResetTask?.cancel()
-        keepsFlexibleHeightDuringTransition = true
+        isLeavingAlertsHeightHoldActive = true
+        lastStableContentState = .alerts
         flexibleHeightResetTask = Task { @MainActor in
             try? await Task.sleep(for: .nanoseconds(transitionHoldDurationNanoseconds))
             guard Task.isCancelled == false else { return }
-            keepsFlexibleHeightDuringTransition = false
+            isLeavingAlertsHeightHoldActive = false
+            lastStableContentState = contentState
             flexibleHeightResetTask = nil
         }
+    }
+
+    private static func usesFlexibleAlertHeight(currentState: ContentState, isLeavingAlerts: Bool) -> Bool {
+        currentState == .alerts || isLeavingAlerts
     }
 }
 

--- a/Sources/Features/Summary/ActiveAlertSummaryView.swift
+++ b/Sources/Features/Summary/ActiveAlertSummaryView.swift
@@ -17,6 +17,12 @@ struct ActiveAlertSummaryView: View {
         case offline
     }
 
+    private enum HeightPhase: Equatable {
+        case uninitialized
+        case stable(ContentState)
+        case leavingAlerts
+    }
+
     let mesos: [MdDTO]
     let alerts: [AlertDTO]
     let isLoading: Bool
@@ -29,8 +35,7 @@ struct ActiveAlertSummaryView: View {
     @State private var selectedAlert: AlertDTO? = nil
     @State private var selectedMesoDetent: PresentationDetent = .medium
     @State private var selectedAlertDetent: PresentationDetent = .medium
-    @State private var lastStableContentState: ContentState? = nil
-    @State private var isLeavingAlertsHeightHoldActive = false
+    @State private var heightPhase: HeightPhase = .uninitialized
     @State private var flexibleHeightResetTask: Task<Void, Never>? = nil
     init(
         mesos: [MdDTO],
@@ -66,8 +71,12 @@ struct ActiveAlertSummaryView: View {
     }
 
     private var isLeavingAlertsTransition: Bool {
-        guard let lastStableContentState else { return false }
-        return lastStableContentState == .alerts && contentState != .alerts && isLeavingAlertsHeightHoldActive
+        switch heightPhase {
+        case .stable(.alerts), .leavingAlerts:
+            return contentState != .alerts
+        case .stable, .uninitialized:
+            return false
+        }
     }
 
     private var usesFlexibleAlertHeight: Bool {
@@ -170,8 +179,8 @@ struct ActiveAlertSummaryView: View {
             handleContentStateTransition(from: oldValue, to: newValue)
         }
         .onAppear {
-            if lastStableContentState == nil {
-                lastStableContentState = contentState
+            if heightPhase == .uninitialized {
+                heightPhase = .stable(contentState)
             }
         }
         .onDisappear {
@@ -286,26 +295,22 @@ struct ActiveAlertSummaryView: View {
     private func handleContentStateTransition(from oldState: ContentState, to newState: ContentState) {
         if newState == .alerts {
             flexibleHeightResetTask?.cancel()
-            isLeavingAlertsHeightHoldActive = false
-            lastStableContentState = .alerts
+            heightPhase = .stable(.alerts)
             return
         }
 
         guard oldState == .alerts, newState != .alerts else {
             flexibleHeightResetTask?.cancel()
-            isLeavingAlertsHeightHoldActive = false
-            lastStableContentState = newState
+            heightPhase = .stable(newState)
             return
         }
 
         flexibleHeightResetTask?.cancel()
-        isLeavingAlertsHeightHoldActive = true
-        lastStableContentState = .alerts
+        heightPhase = .leavingAlerts
         flexibleHeightResetTask = Task { @MainActor in
             try? await Task.sleep(for: .nanoseconds(transitionHoldDurationNanoseconds))
             guard Task.isCancelled == false else { return }
-            isLeavingAlertsHeightHoldActive = false
-            lastStableContentState = contentState
+            heightPhase = .stable(contentState)
             flexibleHeightResetTask = nil
         }
     }

--- a/Sources/Features/Summary/ActiveAlertSummaryView.swift
+++ b/Sources/Features/Summary/ActiveAlertSummaryView.swift
@@ -29,6 +29,8 @@ struct ActiveAlertSummaryView: View {
     @State private var selectedAlert: AlertDTO? = nil
     @State private var selectedMesoDetent: PresentationDetent = .medium
     @State private var selectedAlertDetent: PresentationDetent = .medium
+    @State private var keepsFlexibleHeightDuringTransition = false
+    @State private var flexibleHeightResetTask: Task<Void, Never>? = nil
     init(
         mesos: [MdDTO],
         alerts: [AlertDTO],
@@ -63,7 +65,12 @@ struct ActiveAlertSummaryView: View {
     }
 
     private var usesFlexibleAlertHeight: Bool {
-        contentState == .alerts
+        contentState == .alerts || keepsFlexibleHeightDuringTransition
+    }
+
+    private var transitionHoldDurationNanoseconds: UInt64 {
+        let seconds = reduceMotion ? 0.01 : 0.32
+        return UInt64(seconds * 1_000_000_000)
     }
 
     @ViewBuilder
@@ -152,6 +159,13 @@ struct ActiveAlertSummaryView: View {
                     .padding(.horizontal, 6)
             }
             .accessibilityIdentifier("summary-watch-detail-sheet")
+        }
+        .onChange(of: contentState) { oldValue, newValue in
+            handleContentStateTransition(from: oldValue, to: newValue)
+        }
+        .onDisappear {
+            flexibleHeightResetTask?.cancel()
+            flexibleHeightResetTask = nil
         }
     }
 
@@ -256,6 +270,25 @@ struct ActiveAlertSummaryView: View {
         }
         .presentationDetents([.medium, .large], selection: selection)
         .presentationDragIndicator(.visible)
+    }
+
+    private func handleContentStateTransition(from oldState: ContentState, to newState: ContentState) {
+        if newState == .alerts {
+            flexibleHeightResetTask?.cancel()
+            keepsFlexibleHeightDuringTransition = false
+            return
+        }
+
+        guard oldState == .alerts else { return }
+
+        flexibleHeightResetTask?.cancel()
+        keepsFlexibleHeightDuringTransition = true
+        flexibleHeightResetTask = Task { @MainActor in
+            try? await Task.sleep(for: .nanoseconds(transitionHoldDurationNanoseconds))
+            guard Task.isCancelled == false else { return }
+            keepsFlexibleHeightDuringTransition = false
+            flexibleHeightResetTask = nil
+        }
     }
 }
 

--- a/Sources/Features/Summary/OutlookSummaryCard.swift
+++ b/Sources/Features/Summary/OutlookSummaryCard.swift
@@ -30,7 +30,7 @@ struct OutlookSummaryCard: View {
     }
 
     private var titleText: String {
-        isPending ? "Outlook Pending" : "Outlook Summary"
+        "Outlook Summary"
     }
 
     private var summaryText: String {
@@ -38,9 +38,9 @@ struct OutlookSummaryCard: View {
             return summary
         }
         if isPending {
-            return "Convective outlook text has not been synced yet."
+            return "Outlook details are still resolving for your area."
         }
-        return "A convective outlook summary will appear here once syncing is complete."
+        return "Outlook details will appear here as your summary resolves."
     }
 
     private var adaptiveLayout: SkyAwareAdaptiveLayout {
@@ -84,7 +84,7 @@ struct OutlookSummaryCard: View {
 
     private var headerRow: some View {
         HStack(alignment: .center, spacing: 12) {
-            Label(titleText, systemImage: isPending ? "clock.arrow.circlepath" : "sun.max.fill")
+            Label(titleText, systemImage: isPending ? "sun.horizon.fill" : "sun.max.fill")
                 .sectionLabel()
 
             Spacer(minLength: 12)
@@ -133,5 +133,19 @@ struct OutlookSummaryCard: View {
     
     return NavigationStack {
         OutlookSummaryCard(outlook: dto)
+    }
+}
+
+#Preview("Outlook Summary - Resolving") {
+    NavigationStack {
+        OutlookSummaryCard(outlook: nil, isPending: true)
+            .padding()
+    }
+}
+
+#Preview("Outlook Summary - Initial Resolve") {
+    NavigationStack {
+        OutlookSummaryCard(outlook: nil, isLoading: true)
+            .padding()
     }
 }

--- a/Sources/Features/Summary/OutlookSummaryCard.swift
+++ b/Sources/Features/Summary/OutlookSummaryCard.swift
@@ -38,9 +38,9 @@ struct OutlookSummaryCard: View {
             return summary
         }
         if isPending {
-            return "Outlook details are still resolving for your area."
+            return "Getting outlook details…"
         }
-        return "Outlook details will appear here as your summary resolves."
+        return "Getting outlook details…"
     }
 
     private var adaptiveLayout: SkyAwareAdaptiveLayout {

--- a/Sources/Features/Summary/OutlookSummaryCard.swift
+++ b/Sources/Features/Summary/OutlookSummaryCard.swift
@@ -74,7 +74,7 @@ struct OutlookSummaryCard: View {
         }
         .padding(18)
         .cardBackground(cornerRadius: SkyAwareRadius.card, shadowOpacity: 0.08, shadowRadius: 8, shadowY: 3)
-        .placeholder(isLoading)
+        .placeholder(isLoading, animated: true)
         .navigationDestination(isPresented: $navigateToFull) {
             if let outlook {
                 ConvectiveOutlookDetailView(outlook: outlook)

--- a/Sources/Features/Summary/SummaryResolving.swift
+++ b/Sources/Features/Summary/SummaryResolving.swift
@@ -88,11 +88,14 @@ struct SummaryResolutionState: Equatable {
             return nil
         }
 
-        guard lastCompletedTask != .finalizing else {
-            return nil
+        switch lastCompletedTask {
+        case .location, .weather, .finalizing:
+            return "Updated conditions"
+        case .stormRisk:
+            return "Got storm risk"
+        case .alerts:
+            return "Checked local alerts"
         }
-
-        return "Updating your conditions…"
     }
 
     func isResolving(_ section: SummarySection) -> Bool {

--- a/Sources/Features/Summary/SummaryResolving.swift
+++ b/Sources/Features/Summary/SummaryResolving.swift
@@ -176,22 +176,48 @@ private extension SummaryProviderTask {
     }
 }
 
+enum SummaryResolveForwardStyle {
+    case subtle
+    case blurLift
+
+    var opacity: Double {
+        switch self {
+        case .subtle:
+            SkyAwareMotion.resolvingSubtleOpacity
+        case .blurLift:
+            SkyAwareMotion.resolvingOpacity
+        }
+    }
+
+    var blur: CGFloat {
+        switch self {
+        case .subtle:
+            0
+        case .blurLift:
+            SkyAwareMotion.resolvingBlur
+        }
+    }
+}
+
 private struct SummaryResolvingModifier: ViewModifier {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let isResolving: Bool
-    let appliesBlur: Bool
+    let style: SummaryResolveForwardStyle
 
     func body(content: Content) -> some View {
         content
-            .blur(radius: isResolving && appliesBlur ? SkyAwareMotion.resolvingBlur : 0)
-            .opacity(isResolving ? SkyAwareMotion.resolvingOpacity : 1)
+            .blur(radius: isResolving && reduceMotion == false ? style.blur : 0)
+            .opacity(isResolving ? style.opacity : 1)
             .animation(SkyAwareMotion.resolve(reduceMotion), value: isResolving)
     }
 }
 
 extension View {
-    func summaryResolving(_ isResolving: Bool, appliesBlur: Bool = true) -> some View {
-        modifier(SummaryResolvingModifier(isResolving: isResolving, appliesBlur: appliesBlur))
+    func summaryResolving(
+        _ isResolving: Bool,
+        style: SummaryResolveForwardStyle = .blurLift
+    ) -> some View {
+        modifier(SummaryResolvingModifier(isResolving: isResolving, style: style))
     }
 }

--- a/Sources/Features/Summary/SummaryResolving.swift
+++ b/Sources/Features/Summary/SummaryResolving.swift
@@ -40,7 +40,7 @@ enum SummaryProviderTask: Hashable {
     var statusMessage: String {
         switch self {
         case .location:
-            "Getting your location…"
+            "Getting your conditions ready…"
         case .weather:
             "Updating your conditions…"
         case .stormRisk:
@@ -48,7 +48,7 @@ enum SummaryProviderTask: Hashable {
         case .alerts:
             "Bringing in local alerts…"
         case .finalizing:
-            "Getting everything ready…"
+            "Updating your conditions…"
         }
     }
 }
@@ -62,6 +62,12 @@ struct SummaryResolutionState: Equatable {
 
     var isRefreshing: Bool {
         activeTasks.isEmpty == false
+    }
+
+    var primaryActiveMessage: String? {
+        activeTasks
+            .min(by: { $0.priority < $1.priority })?
+            .statusMessage
     }
 
     var activeMessages: [String] {
@@ -82,7 +88,11 @@ struct SummaryResolutionState: Equatable {
             return nil
         }
 
-        return lastCompletedTask.statusMessage
+        guard lastCompletedTask != .finalizing else {
+            return nil
+        }
+
+        return "Updating your conditions…"
     }
 
     func isResolving(_ section: SummarySection) -> Bool {
@@ -146,6 +156,23 @@ struct SummaryResolutionState: Equatable {
         taskSections.removeAll()
         lastCompletedTask = completedTask
         lastCompletedAt = completedAt
+    }
+}
+
+private extension SummaryProviderTask {
+    var priority: Int {
+        switch self {
+        case .location:
+            0
+        case .weather:
+            1
+        case .stormRisk:
+            2
+        case .alerts:
+            3
+        case .finalizing:
+            4
+        }
     }
 }
 

--- a/Sources/Features/Summary/SummaryStatus.swift
+++ b/Sources/Features/Summary/SummaryStatus.swift
@@ -230,8 +230,10 @@ struct SummaryStatus: View {
                     Text("00°")
                         .monospacedDigit()
                         .hidden()
+                        .accessibilityHidden(true)
                     Image(systemName: "sun.max.fill")
                         .hidden()
+                        .accessibilityHidden(true)
                 }
             }
             .frame(minHeight: 20, alignment: adaptiveLayout.usesStackedHeroTiles ? .leading : .trailing)

--- a/Sources/Features/Summary/SummaryStatus.swift
+++ b/Sources/Features/Summary/SummaryStatus.swift
@@ -51,13 +51,19 @@ struct SummaryStatus: View {
         return formatter
     }()
 
-    private var effectiveWeather: SummaryWeather? {
-        weather ?? displayedWeather
+    private var visibleWeather: SummaryWeather? {
+        Self.resolveDisplayedWeather(
+            liveWeather: weather,
+            displayedWeather: displayedWeather,
+            isRefreshing: resolutionState.isRefreshing,
+            displayedWeatherLocationIdentity: displayedWeatherLocationIdentity,
+            weatherLocationIdentity: weatherLocationIdentity
+        ).weather
     }
 
     private var formattedTemperature: String? {
-        guard let effectiveWeather else { return nil }
-        return formatTemperature(effectiveWeather.temperature)
+        guard let visibleWeather else { return nil }
+        return formatTemperature(visibleWeather.temperature)
     }
 
     private var clampedCondenseProgress: CGFloat {
@@ -219,11 +225,11 @@ struct SummaryStatus: View {
     private var weatherContent: some View {
         VStack(alignment: adaptiveLayout.usesStackedHeroTiles ? .leading : .trailing, spacing: 2) {
             HStack(spacing: 6) {
-                if let effectiveWeather, let formattedTemperature {
+                if let visibleWeather, let formattedTemperature {
                     Text(formattedTemperature)
                         .monospacedDigit()
-                        .contentTransition(.numericText(value: effectiveWeather.temperature.value))
-                    Image(systemName: effectiveWeather.symbolName)
+                        .contentTransition(.numericText(value: visibleWeather.temperature.value))
+                    Image(systemName: visibleWeather.symbolName)
                         .symbolVariant(.fill)
                         .contentTransition(.opacity)
                 } else {
@@ -240,7 +246,7 @@ struct SummaryStatus: View {
 
             Group {
                 SummarySettledConditionLine(
-                    conditionText: effectiveWeather?.conditionText,
+                    conditionText: visibleWeather?.conditionText,
                     isRefreshing: resolutionState.isRefreshing
                 )
             }
@@ -258,8 +264,8 @@ struct SummaryStatus: View {
         )
         .contentTransition(.opacity)
         .animation(SkyAwareMotion.message(reduceMotion), value: formattedTemperature)
-        .animation(SkyAwareMotion.message(reduceMotion), value: effectiveWeather?.symbolName)
-        .animation(SkyAwareMotion.message(reduceMotion), value: effectiveWeather?.conditionText)
+        .animation(SkyAwareMotion.message(reduceMotion), value: visibleWeather?.symbolName)
+        .animation(SkyAwareMotion.message(reduceMotion), value: visibleWeather?.conditionText)
     }
 
     private var weatherTaskState: WeatherTaskState {

--- a/Sources/Features/Summary/SummaryStatus.swift
+++ b/Sources/Features/Summary/SummaryStatus.swift
@@ -12,6 +12,7 @@ struct SummaryStatus: View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var showsOfflineExplanation = false
+    @State private var displayedWeather: SummaryWeather?
 
     let statusText: String
     let weather: SummaryWeather?
@@ -26,9 +27,13 @@ struct SummaryStatus: View {
         return formatter
     }()
 
+    private var effectiveWeather: SummaryWeather? {
+        weather ?? displayedWeather
+    }
+
     private var formattedTemperature: String? {
-        guard let weather else { return nil }
-        return formatTemperature(weather.temperature)
+        guard let effectiveWeather else { return nil }
+        return formatTemperature(effectiveWeather.temperature)
     }
 
     private var clampedCondenseProgress: CGFloat {
@@ -97,6 +102,9 @@ struct SummaryStatus: View {
             shadowY: cardShadowY
         )
         .animation(SkyAwareMotion.settle(reduceMotion), value: clampedCondenseProgress)
+        .task(id: weatherTaskState) {
+            updateDisplayedWeather()
+        }
     }
 
     private var locationUnavailableCard: some View {
@@ -172,7 +180,8 @@ struct SummaryStatus: View {
                 .font(locationFont)
                 .foregroundStyle(.primary)
                 .contentTransition(.opacity)
-                .lineLimit(clampedCondenseProgress > 0.55 ? 1 : 2)
+                .lineLimit(adaptiveLayout.usesStackedHeroTiles ? 2 : 1)
+                .truncationMode(.tail)
 
             SummaryStatusSecondaryLine(
                 resolutionState: resolutionState
@@ -186,19 +195,27 @@ struct SummaryStatus: View {
     private var weatherContent: some View {
         VStack(alignment: adaptiveLayout.usesStackedHeroTiles ? .leading : .trailing, spacing: 2) {
             HStack(spacing: 6) {
-                if let weather, let formattedTemperature {
+                if let effectiveWeather, let formattedTemperature {
                     Text(formattedTemperature)
                         .monospacedDigit()
-                    Image(systemName: weather.symbolName)
+                        .contentTransition(.numericText(value: effectiveWeather.temperature.value))
+                    Image(systemName: effectiveWeather.symbolName)
                         .symbolVariant(.fill)
+                        .contentTransition(.opacity)
+                } else {
+                    Text("00°")
+                        .monospacedDigit()
+                        .hidden()
+                    Image(systemName: "sun.max.fill")
+                        .hidden()
                 }
             }
-            .frame(minHeight: 20, alignment: .trailing)
+            .frame(minHeight: 20, alignment: adaptiveLayout.usesStackedHeroTiles ? .leading : .trailing)
 
             Group {
                 SummarySettledConditionLine(
-                    conditionText: weather?.conditionText,
-                    resolutionState: resolutionState
+                    conditionText: effectiveWeather?.conditionText,
+                    isRefreshing: resolutionState.isRefreshing
                 )
             }
             .font(.footnote)
@@ -215,7 +232,28 @@ struct SummaryStatus: View {
         )
         .contentTransition(.opacity)
         .animation(SkyAwareMotion.message(reduceMotion), value: formattedTemperature)
-        .animation(SkyAwareMotion.message(reduceMotion), value: weather?.symbolName)
+        .animation(SkyAwareMotion.message(reduceMotion), value: effectiveWeather?.symbolName)
+        .animation(SkyAwareMotion.message(reduceMotion), value: effectiveWeather?.conditionText)
+    }
+
+    private var weatherTaskState: WeatherTaskState {
+        WeatherTaskState(
+            liveWeather: weather,
+            isRefreshing: resolutionState.isRefreshing
+        )
+    }
+
+    private func updateDisplayedWeather() {
+        if let weather {
+            displayedWeather = weather
+            return
+        }
+
+        if resolutionState.isRefreshing {
+            return
+        }
+
+        displayedWeather = nil
     }
 
     private func formatTemperature(_ temperature: Measurement<UnitTemperature>) -> String {
@@ -374,11 +412,11 @@ private struct SummarySettledConditionLine: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let conditionText: String?
-    let resolutionState: SummaryResolutionState
+    let isRefreshing: Bool
 
     var body: some View {
         Group {
-            if shouldShowCondition, let conditionText {
+            if let conditionText {
                 Text(conditionText)
                     .foregroundStyle(.secondary)
             } else {
@@ -387,13 +425,16 @@ private struct SummarySettledConditionLine: View {
                     .accessibilityHidden(true)
             }
         }
+        .opacity(isRefreshing ? 0.86 : 1)
         .contentTransition(.opacity)
-        .animation(SkyAwareMotion.message(reduceMotion), value: shouldShowCondition)
+        .animation(SkyAwareMotion.message(reduceMotion), value: conditionText)
+        .animation(SkyAwareMotion.message(reduceMotion), value: isRefreshing)
     }
+}
 
-    private var shouldShowCondition: Bool {
-        resolutionState.isRefreshing == false
-    }
+private struct WeatherTaskState: Equatable {
+    let liveWeather: SummaryWeather?
+    let isRefreshing: Bool
 }
 
 #Preview {

--- a/Sources/Features/Summary/SummaryStatus.swift
+++ b/Sources/Features/Summary/SummaryStatus.swift
@@ -7,15 +7,39 @@
 
 import SwiftUI
 
+struct SummaryWeatherLocationIdentity: Equatable, Sendable {
+    let latitudeE4: Int
+    let longitudeE4: Int
+    let placemarkSummary: String?
+
+    init(snapshot: LocationSnapshot?) {
+        if let snapshot {
+            latitudeE4 = Self.quantize(snapshot.coordinates.latitude)
+            longitudeE4 = Self.quantize(snapshot.coordinates.longitude)
+            placemarkSummary = snapshot.placemarkSummary
+        } else {
+            latitudeE4 = 0
+            longitudeE4 = 0
+            placemarkSummary = nil
+        }
+    }
+
+    private static func quantize(_ value: Double) -> Int {
+        Int((value * 10_000).rounded(.towardZero))
+    }
+}
+
 struct SummaryStatus: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var showsOfflineExplanation = false
     @State private var displayedWeather: SummaryWeather?
+    @State private var displayedWeatherLocationIdentity: SummaryWeatherLocationIdentity?
 
     let statusText: String
     let weather: SummaryWeather?
+    let weatherLocationIdentity: SummaryWeatherLocationIdentity?
     let resolutionState: SummaryResolutionState
     let showsOfflineToken: Bool
     let isLocationUnavailable: Bool
@@ -239,25 +263,47 @@ struct SummaryStatus: View {
     private var weatherTaskState: WeatherTaskState {
         WeatherTaskState(
             liveWeather: weather,
-            isRefreshing: resolutionState.isRefreshing
+            isRefreshing: resolutionState.isRefreshing,
+            weatherLocationIdentity: weatherLocationIdentity
         )
     }
 
     private func updateDisplayedWeather() {
-        if let weather {
-            displayedWeather = weather
-            return
-        }
-
-        if resolutionState.isRefreshing {
-            return
-        }
-
-        displayedWeather = nil
+        let updatedWeather = Self.resolveDisplayedWeather(
+            liveWeather: weather,
+            displayedWeather: displayedWeather,
+            isRefreshing: resolutionState.isRefreshing,
+            displayedWeatherLocationIdentity: displayedWeatherLocationIdentity,
+            weatherLocationIdentity: weatherLocationIdentity
+        )
+        displayedWeather = updatedWeather.weather
+        displayedWeatherLocationIdentity = updatedWeather.locationIdentity
     }
 
     private func formatTemperature(_ temperature: Measurement<UnitTemperature>) -> String {
         Self.temperatureFormatter.string(from: temperature)
+    }
+}
+
+extension SummaryStatus {
+    static func resolveDisplayedWeather(
+        liveWeather: SummaryWeather?,
+        displayedWeather: SummaryWeather?,
+        isRefreshing: Bool,
+        displayedWeatherLocationIdentity: SummaryWeatherLocationIdentity?,
+        weatherLocationIdentity: SummaryWeatherLocationIdentity?
+    ) -> (weather: SummaryWeather?, locationIdentity: SummaryWeatherLocationIdentity?) {
+        if let liveWeather {
+            return (liveWeather, weatherLocationIdentity)
+        }
+
+        guard isRefreshing,
+              displayedWeather != nil,
+              displayedWeatherLocationIdentity == weatherLocationIdentity else {
+            return (nil, nil)
+        }
+
+        return (displayedWeather, displayedWeatherLocationIdentity)
     }
 }
 
@@ -435,6 +481,7 @@ private struct SummarySettledConditionLine: View {
 private struct WeatherTaskState: Equatable {
     let liveWeather: SummaryWeather?
     let isRefreshing: Bool
+    let weatherLocationIdentity: SummaryWeatherLocationIdentity?
 }
 
 #Preview {
@@ -459,6 +506,15 @@ private struct WeatherTaskState: Equatable {
                 windDirection: "NNW",
                 pressure: .init(value: 0.25, unit: .inchesOfMercury),
                 pressureTrend: "climbing"
+            ),
+            weatherLocationIdentity: .init(
+                snapshot: .init(
+                    coordinates: .init(latitude: 39.7392, longitude: -104.9903),
+                    timestamp: .now,
+                    accuracy: 20,
+                    placemarkSummary: "Denver, CO",
+                    h3Cell: nil
+                )
             ),
             resolutionState: SummaryResolutionState(),
             showsOfflineToken: false,
@@ -486,6 +542,15 @@ private struct WeatherTaskState: Equatable {
                 pressure: .init(value: 0.25, unit: .inchesOfMercury),
                 pressureTrend: "falling"
             ),
+            weatherLocationIdentity: .init(
+                snapshot: .init(
+                    coordinates: .init(latitude: 39.0473, longitude: -95.6752),
+                    timestamp: .now,
+                    accuracy: 20,
+                    placemarkSummary: "Topeka, KS",
+                    h3Cell: nil
+                )
+            ),
             resolutionState: SummaryResolutionState(),
             showsOfflineToken: true,
             isLocationUnavailable: false,
@@ -494,6 +559,7 @@ private struct WeatherTaskState: Equatable {
         SummaryStatus(
             statusText: "Location not available",
             weather: nil,
+            weatherLocationIdentity: nil,
             resolutionState: SummaryResolutionState(),
             showsOfflineToken: false,
             isLocationUnavailable: true,

--- a/Sources/Features/Summary/SummaryStatus.swift
+++ b/Sources/Features/Summary/SummaryStatus.swift
@@ -331,23 +331,8 @@ private struct SummaryStatusSecondaryLine: View {
 
     @MainActor
     private func updateDisplayedMessage() async {
-        let activeMessages = resolutionState.activeMessages
-        if activeMessages.isEmpty == false {
-            if activeMessages.count == 1 {
-                setDisplayedMessage(activeMessages[0])
-                return
-            }
-
-            var index = 0
-            setDisplayedMessage(activeMessages[index])
-
-            while Task.isCancelled == false {
-                try? await Task.sleep(for: .seconds(3))
-                if Task.isCancelled { return }
-                index = (index + 1) % activeMessages.count
-                setDisplayedMessage(activeMessages[index])
-            }
-
+        if let primaryActiveMessage = resolutionState.primaryActiveMessage {
+            setDisplayedMessage(primaryActiveMessage)
             return
         }
 
@@ -407,7 +392,7 @@ private struct SummarySettledConditionLine: View {
     }
 
     private var shouldShowCondition: Bool {
-        resolutionState.isRefreshing == false && resolutionState.recentCompletedMessage == nil
+        resolutionState.isRefreshing == false
     }
 }
 

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -189,11 +189,17 @@ struct SummaryView: View {
     }
 
     private var stormRiskButton: some View {
-        Button {
+        let stormRiskIsUnresolved = stormRisk == nil && showsOfflineToken == false
+
+        return Button {
             onOpenMapLayer(.categorical)
         } label: {
-            StormRiskBadgeView(level: stormRisk ?? .allClear, isOffline: showsOfflineToken)
-                .placeholder(stormRisk == nil && showsOfflineToken == false, animated: true)
+            StormRiskBadgeView(
+                level: stormRisk ?? .allClear,
+                isOffline: showsOfflineToken,
+                isResolving: resolutionState.isResolving(.stormRisk),
+                showsResolvingPlaceholder: stormRiskIsUnresolved
+            )
                 .contentShape(RoundedRectangle(cornerRadius: SkyAwareRadius.large, style: .continuous))
         }
         .buttonStyle(
@@ -203,16 +209,25 @@ struct SummaryView: View {
                 pressedOverlayOpacity: 0.06
             )
         )
-        .summaryResolving(resolutionState.isResolving(.stormRisk) && showsOfflineToken == false)
+        .summaryResolving(
+            resolutionState.isResolving(.stormRisk) && stormRiskIsUnresolved == false && showsOfflineToken == false,
+            style: .subtle
+        )
         .accessibilityHint("Opens the severe risk map.")
     }
 
     private var severeRiskButton: some View {
-        Button {
+        let severeRiskIsUnresolved = severeRisk == nil && showsOfflineToken == false
+
+        return Button {
             onOpenMapLayer(severeMapLayer)
         } label: {
-            SevereWeatherBadgeView(threat: severeRisk ?? .allClear, isOffline: showsOfflineToken)
-                .placeholder(severeRisk == nil && showsOfflineToken == false, animated: true)
+            SevereWeatherBadgeView(
+                threat: severeRisk ?? .allClear,
+                isOffline: showsOfflineToken,
+                isResolving: resolutionState.isResolving(.severeRisk),
+                showsResolvingPlaceholder: severeRiskIsUnresolved
+            )
                 .contentShape(RoundedRectangle(cornerRadius: SkyAwareRadius.large, style: .continuous))
         }
         .buttonStyle(
@@ -222,7 +237,10 @@ struct SummaryView: View {
                 pressedOverlayOpacity: 0.06
             )
         )
-        .summaryResolving(resolutionState.isResolving(.severeRisk) && showsOfflineToken == false)
+        .summaryResolving(
+            resolutionState.isResolving(.severeRisk) && severeRiskIsUnresolved == false && showsOfflineToken == false,
+            style: .subtle
+        )
         .accessibilityHint("Opens the highlighted severe threat map.")
     }
 

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -91,6 +91,11 @@ struct SummaryView: View {
         readinessState == .locationUnavailable
     }
 
+    private var weatherLocationIdentity: SummaryWeatherLocationIdentity? {
+        guard let snap else { return nil }
+        return SummaryWeatherLocationIdentity(snapshot: snap)
+    }
+
     private var localAlertsPresentationState: LocalAlertsPresentationState {
         Self.localAlertsPresentationState(
             readinessState: readinessState,
@@ -255,6 +260,7 @@ struct SummaryView: View {
         SummaryStatus(
             statusText: statusText,
             weather: weather,
+            weatherLocationIdentity: weatherLocationIdentity,
             resolutionState: resolutionState,
             showsOfflineToken: showsOfflineToken,
             isLocationUnavailable: isLocationUnavailable,

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -155,7 +155,12 @@ struct SummaryView: View {
                 FireWeatherRailView(
                     level: fireRisk ?? .clear,
                     isOffline: showsOfflineToken,
-                    showsResolvingPlaceholder: fireRisk == nil && showsOfflineToken == false
+                    showsResolvingPlaceholder: Self.showsRiskResolvingPlaceholder(
+                        hasRiskValue: fireRisk != nil,
+                        readinessState: readinessState,
+                        isSectionResolving: resolutionState.isResolving(.fireRisk),
+                        showsOfflineToken: showsOfflineToken
+                    )
                 )
                     .contentShape(RoundedRectangle(cornerRadius: SkyAwareRadius.large, style: .continuous))
             }
@@ -200,7 +205,12 @@ struct SummaryView: View {
     }
 
     private var stormRiskButton: some View {
-        let stormRiskIsUnresolved = stormRisk == nil && showsOfflineToken == false
+        let stormRiskShowsResolvingPlaceholder = Self.showsRiskResolvingPlaceholder(
+            hasRiskValue: stormRisk != nil,
+            readinessState: readinessState,
+            isSectionResolving: resolutionState.isResolving(.stormRisk),
+            showsOfflineToken: showsOfflineToken
+        )
 
         return Button {
             onOpenMapLayer(.categorical)
@@ -209,7 +219,7 @@ struct SummaryView: View {
                 level: stormRisk ?? .allClear,
                 isOffline: showsOfflineToken,
                 isResolving: resolutionState.isResolving(.stormRisk),
-                showsResolvingPlaceholder: stormRiskIsUnresolved
+                showsResolvingPlaceholder: stormRiskShowsResolvingPlaceholder
             )
                 .contentShape(RoundedRectangle(cornerRadius: SkyAwareRadius.large, style: .continuous))
         }
@@ -221,14 +231,19 @@ struct SummaryView: View {
             )
         )
         .summaryResolving(
-            resolutionState.isResolving(.stormRisk) && stormRiskIsUnresolved == false && showsOfflineToken == false,
+            resolutionState.isResolving(.stormRisk) && stormRiskShowsResolvingPlaceholder == false && showsOfflineToken == false,
             style: .subtle
         )
         .accessibilityHint("Opens the severe risk map.")
     }
 
     private var severeRiskButton: some View {
-        let severeRiskIsUnresolved = severeRisk == nil && showsOfflineToken == false
+        let severeRiskShowsResolvingPlaceholder = Self.showsRiskResolvingPlaceholder(
+            hasRiskValue: severeRisk != nil,
+            readinessState: readinessState,
+            isSectionResolving: resolutionState.isResolving(.severeRisk),
+            showsOfflineToken: showsOfflineToken
+        )
 
         return Button {
             onOpenMapLayer(severeMapLayer)
@@ -237,7 +252,7 @@ struct SummaryView: View {
                 threat: severeRisk ?? .allClear,
                 isOffline: showsOfflineToken,
                 isResolving: resolutionState.isResolving(.severeRisk),
-                showsResolvingPlaceholder: severeRiskIsUnresolved
+                showsResolvingPlaceholder: severeRiskShowsResolvingPlaceholder
             )
                 .contentShape(RoundedRectangle(cornerRadius: SkyAwareRadius.large, style: .continuous))
         }
@@ -249,7 +264,7 @@ struct SummaryView: View {
             )
         )
         .summaryResolving(
-            resolutionState.isResolving(.severeRisk) && severeRiskIsUnresolved == false && showsOfflineToken == false,
+            resolutionState.isResolving(.severeRisk) && severeRiskShowsResolvingPlaceholder == false && showsOfflineToken == false,
             style: .subtle
         )
         .accessibilityHint("Opens the highlighted severe threat map.")
@@ -425,6 +440,28 @@ struct SummaryView: View {
         hasMeaningfulContent == false &&
         ((readinessState == .loadingLocation || readinessState == .resolvingLocalContext || readinessState == .loadingLocalData)
             || resolutionState.isRefreshing)
+    }
+
+    static func showsRiskResolvingPlaceholder(
+        hasRiskValue: Bool,
+        readinessState: SummaryReadinessState,
+        isSectionResolving: Bool,
+        showsOfflineToken: Bool
+    ) -> Bool {
+        guard showsOfflineToken == false, hasRiskValue == false else {
+            return false
+        }
+
+        if isSectionResolving {
+            return true
+        }
+
+        switch readinessState {
+        case .loadingLocation, .resolvingLocalContext, .loadingLocalData:
+            return true
+        case .ready, .locationUnavailable:
+            return false
+        }
     }
 }
 

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -148,7 +148,7 @@ struct SummaryView: View {
                 onOpenMapLayer(.fire)
             } label: {
                 FireWeatherRailView(level: fireRisk ?? .clear, isOffline: showsOfflineToken)
-                    .placeholder(fireRisk == nil && showsOfflineToken == false)
+                    .placeholder(fireRisk == nil && showsOfflineToken == false, animated: true)
                     .contentShape(RoundedRectangle(cornerRadius: SkyAwareRadius.large, style: .continuous))
             }
             .buttonStyle(
@@ -162,8 +162,11 @@ struct SummaryView: View {
             .accessibilityHint("Opens the fire risk map.")
             AtmosphereRailView(weather: weather, isOffline: showsOfflineToken)
                 .allowsHitTesting(!isWeatherLoading)
-                .placeholder(isWeatherLoading && showsOfflineToken == false)
-                .summaryResolving(resolutionState.isResolving(.atmosphere) && showsOfflineToken == false)
+                .placeholder(isWeatherLoading && showsOfflineToken == false, animated: true)
+                .summaryResolving(
+                    resolutionState.isResolving(.atmosphere) && showsOfflineToken == false,
+                    style: .subtle
+                )
         }
     }
 
@@ -190,7 +193,7 @@ struct SummaryView: View {
             onOpenMapLayer(.categorical)
         } label: {
             StormRiskBadgeView(level: stormRisk ?? .allClear, isOffline: showsOfflineToken)
-                .placeholder(stormRisk == nil && showsOfflineToken == false)
+                .placeholder(stormRisk == nil && showsOfflineToken == false, animated: true)
                 .contentShape(RoundedRectangle(cornerRadius: SkyAwareRadius.large, style: .continuous))
         }
         .buttonStyle(
@@ -209,7 +212,7 @@ struct SummaryView: View {
             onOpenMapLayer(severeMapLayer)
         } label: {
             SevereWeatherBadgeView(threat: severeRisk ?? .allClear, isOffline: showsOfflineToken)
-                .placeholder(severeRisk == nil && showsOfflineToken == false)
+                .placeholder(severeRisk == nil && showsOfflineToken == false, animated: true)
                 .contentShape(RoundedRectangle(cornerRadius: SkyAwareRadius.large, style: .continuous))
         }
         .buttonStyle(
@@ -287,7 +290,7 @@ struct SummaryView: View {
                     resolutionState: resolutionState,
                     showsOfflineToken: showsOfflineToken
                 ),
-                appliesBlur: false
+                style: .subtle
             )
         }
 
@@ -297,7 +300,7 @@ struct SummaryView: View {
             isPending: outlook == nil && !(readinessState == .loadingLocation || readinessState == .resolvingLocalContext),
             onBrowseAllOutlooks: onOpenOutlooks
         )
-        .summaryResolving(resolutionState.isResolving(.outlook))
+        .summaryResolving(resolutionState.isResolving(.outlook), style: .subtle)
 
         AttributionView()
     }

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -305,7 +305,7 @@ struct SummaryView: View {
     var body: some View {
         VStack(spacing: 18) {
             if showsEmptyResolving {
-                LoadingView(message: resolutionState.activeMessages.first ?? readinessState.statusText)
+                LoadingView(message: resolutionState.primaryActiveMessage ?? readinessState.statusText)
             } else {
                 summaryContent
                     .transition(.summaryContentEntrance(reduceMotion: reduceMotion))

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -147,8 +147,11 @@ struct SummaryView: View {
             Button {
                 onOpenMapLayer(.fire)
             } label: {
-                FireWeatherRailView(level: fireRisk ?? .clear, isOffline: showsOfflineToken)
-                    .placeholder(fireRisk == nil && showsOfflineToken == false, animated: true)
+                FireWeatherRailView(
+                    level: fireRisk ?? .clear,
+                    isOffline: showsOfflineToken,
+                    showsResolvingPlaceholder: fireRisk == nil && showsOfflineToken == false
+                )
                     .contentShape(RoundedRectangle(cornerRadius: SkyAwareRadius.large, style: .continuous))
             }
             .buttonStyle(
@@ -158,7 +161,10 @@ struct SummaryView: View {
                     pressedOverlayOpacity: 0.06
                 )
             )
-            .summaryResolving(resolutionState.isResolving(.fireRisk) && showsOfflineToken == false)
+            .summaryResolving(
+                resolutionState.isResolving(.fireRisk) && fireRisk != nil && showsOfflineToken == false,
+                style: .subtle
+            )
             .accessibilityHint("Opens the fire risk map.")
             AtmosphereRailView(weather: weather, isOffline: showsOfflineToken)
                 .allowsHitTesting(!isWeatherLoading)

--- a/Sources/Utilities/Core/SkyAwareMotion.swift
+++ b/Sources/Utilities/Core/SkyAwareMotion.swift
@@ -8,9 +8,10 @@
 import SwiftUI
 
 enum SkyAwareMotion {
-    static let resolvingBlur: CGFloat = 2.5
-    static let resolvingOpacity: Double = 0.86
-    static let placeholderOpacity: Double = 0.84
+    static let resolvingBlur: CGFloat = 1.8
+    static let resolvingOpacity: Double = 0.90
+    static let resolvingSubtleOpacity: Double = 0.94
+    static let placeholderOpacity: Double = 0.90
 
     static let ambientPulseDuration: Double = 3.0
     static let ambientDriftDuration: Double = 10.0

--- a/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
+++ b/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
@@ -713,7 +713,7 @@ struct SummaryResolutionStateTests {
         #expect(state.isRefreshing == false)
         #expect(state.isResolving(.conditions) == false)
         #expect(state.isResolving(.atmosphere) == false)
-        #expect(state.recentCompletedMessage == "Updating your conditions…")
+        #expect(state.recentCompletedMessage == "Updated conditions")
     }
 
     @Test("reset clears active tasks and sections")
@@ -743,7 +743,7 @@ struct SummaryResolutionStateTests {
         for section in SummarySection.resolveForwardSections {
             #expect(state.isResolving(section) == false)
         }
-        #expect(state.recentCompletedMessage == nil)
+        #expect(state.recentCompletedMessage == "Updated conditions")
     }
 
     @Test("primary active message prefers location readiness over other active tasks")
@@ -859,6 +859,59 @@ struct SummaryStatusWeatherRetentionTests {
         #expect(resolved.locationIdentity == nil)
     }
 
+    @Test("clears displayed weather when refresh is inactive even if identity matches")
+    func clearsDisplayedWeather_sameIdentityNotRefreshing() {
+        let weather = makeWeather()
+        let identity = makeIdentity(latitude: 39.7392, longitude: -104.9903, placemark: "Denver, CO")
+
+        let resolved = SummaryStatus.resolveDisplayedWeather(
+            liveWeather: nil,
+            displayedWeather: weather,
+            isRefreshing: false,
+            displayedWeatherLocationIdentity: identity,
+            weatherLocationIdentity: identity
+        )
+
+        #expect(resolved.weather == nil)
+        #expect(resolved.locationIdentity == nil)
+    }
+
+    @Test("prefers live weather and current location identity")
+    func prefersLiveWeatherAndCurrentIdentity() {
+        let liveWeather = makeWeather(temperatureF: 64)
+        let previousWeather = makeWeather(temperatureF: 72)
+        let previousIdentity = makeIdentity(latitude: 39.7392, longitude: -104.9903, placemark: "Denver, CO")
+        let currentIdentity = makeIdentity(latitude: 34.0522, longitude: -118.2437, placemark: "Los Angeles, CA")
+
+        let resolved = SummaryStatus.resolveDisplayedWeather(
+            liveWeather: liveWeather,
+            displayedWeather: previousWeather,
+            isRefreshing: true,
+            displayedWeatherLocationIdentity: previousIdentity,
+            weatherLocationIdentity: currentIdentity
+        )
+
+        #expect(resolved.weather == liveWeather)
+        #expect(resolved.locationIdentity == currentIdentity)
+    }
+
+    @Test("rendered weather clears immediately when location identity changes during refresh")
+    func renderedWeather_clearsImmediatelyOnIdentityChange() {
+        let retainedWeather = makeWeather()
+        let oldIdentity = makeIdentity(latitude: 39.7392, longitude: -104.9903, placemark: "Denver, CO")
+        let newIdentity = makeIdentity(latitude: 47.6062, longitude: -122.3321, placemark: "Seattle, WA")
+
+        let rendered = SummaryStatus.resolveDisplayedWeather(
+            liveWeather: nil,
+            displayedWeather: retainedWeather,
+            isRefreshing: true,
+            displayedWeatherLocationIdentity: oldIdentity,
+            weatherLocationIdentity: newIdentity
+        )
+
+        #expect(rendered.weather == nil)
+    }
+
     private func makeIdentity(latitude: Double, longitude: Double, placemark: String) -> SummaryWeatherLocationIdentity {
         SummaryWeatherLocationIdentity(
             snapshot: .init(
@@ -871,9 +924,9 @@ struct SummaryStatusWeatherRetentionTests {
         )
     }
 
-    private func makeWeather() -> SummaryWeather {
+    private func makeWeather(temperatureF: Double = 72) -> SummaryWeather {
         SummaryWeather(
-            temperature: Measurement(value: 72, unit: .fahrenheit),
+            temperature: Measurement(value: temperatureF, unit: .fahrenheit),
             symbolName: "sun.max.fill",
             conditionText: "Clear",
             asOf: .now,

--- a/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
+++ b/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
@@ -769,3 +769,69 @@ struct WeatherKitRefreshPolicyTests {
         #expect(policy.shouldSync(now: now, lastSync: recent, force: true))
     }
 }
+
+@Suite("SummaryStatus Weather Retention")
+struct SummaryStatusWeatherRetentionTests {
+    @Test("keeps displayed weather during refresh when location identity is unchanged")
+    func keepsDisplayedWeather_sameIdentityRefreshing() {
+        let weather = makeWeather()
+        let identity = makeIdentity(latitude: 39.7392, longitude: -104.9903, placemark: "Denver, CO")
+
+        let resolved = SummaryStatus.resolveDisplayedWeather(
+            liveWeather: nil,
+            displayedWeather: weather,
+            isRefreshing: true,
+            displayedWeatherLocationIdentity: identity,
+            weatherLocationIdentity: identity
+        )
+
+        #expect(resolved.weather == weather)
+        #expect(resolved.locationIdentity == identity)
+    }
+
+    @Test("clears displayed weather during refresh when location identity changes")
+    func clearsDisplayedWeather_changedIdentityRefreshing() {
+        let weather = makeWeather()
+        let previousIdentity = makeIdentity(latitude: 39.7392, longitude: -104.9903, placemark: "Denver, CO")
+        let newIdentity = makeIdentity(latitude: 34.0522, longitude: -118.2437, placemark: "Los Angeles, CA")
+
+        let resolved = SummaryStatus.resolveDisplayedWeather(
+            liveWeather: nil,
+            displayedWeather: weather,
+            isRefreshing: true,
+            displayedWeatherLocationIdentity: previousIdentity,
+            weatherLocationIdentity: newIdentity
+        )
+
+        #expect(resolved.weather == nil)
+        #expect(resolved.locationIdentity == nil)
+    }
+
+    private func makeIdentity(latitude: Double, longitude: Double, placemark: String) -> SummaryWeatherLocationIdentity {
+        SummaryWeatherLocationIdentity(
+            snapshot: .init(
+                coordinates: .init(latitude: latitude, longitude: longitude),
+                timestamp: .now,
+                accuracy: 20,
+                placemarkSummary: placemark,
+                h3Cell: nil
+            )
+        )
+    }
+
+    private func makeWeather() -> SummaryWeather {
+        SummaryWeather(
+            temperature: Measurement(value: 72, unit: .fahrenheit),
+            symbolName: "sun.max.fill",
+            conditionText: "Clear",
+            asOf: .now,
+            dewPoint: Measurement(value: 50, unit: .fahrenheit),
+            humidity: 0.35,
+            windSpeed: Measurement(value: 8, unit: .milesPerHour),
+            windGust: nil,
+            windDirection: "NW",
+            pressure: Measurement(value: 29.92, unit: .inchesOfMercury),
+            pressureTrend: "steady"
+        )
+    }
+}

--- a/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
+++ b/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
@@ -590,6 +590,58 @@ struct SummaryViewEmptyResolvingTests {
     }
 }
 
+@Suite("SummaryView Risk Placeholder Presentation")
+@MainActor
+struct SummaryViewRiskPlaceholderPresentationTests {
+    @Test("nil risk shows resolving placeholder while section is actively resolving")
+    func riskPlaceholder_nilRiskWhileSectionResolving() {
+        #expect(
+            SummaryView.showsRiskResolvingPlaceholder(
+                hasRiskValue: false,
+                readinessState: .ready,
+                isSectionResolving: true,
+                showsOfflineToken: false
+            )
+        )
+    }
+
+    @Test("nil risk allows resolving placeholder during local data loading")
+    func riskPlaceholder_nilRiskDuringLoadingLocalData() {
+        #expect(
+            SummaryView.showsRiskResolvingPlaceholder(
+                hasRiskValue: false,
+                readinessState: .loadingLocalData,
+                isSectionResolving: false,
+                showsOfflineToken: false
+            )
+        )
+    }
+
+    @Test("nil risk does not show resolving placeholder after completed local data attempt")
+    func riskPlaceholder_nilRiskWhenReadyAfterCompletedAttempt() {
+        #expect(
+            SummaryView.showsRiskResolvingPlaceholder(
+                hasRiskValue: false,
+                readinessState: .ready,
+                isSectionResolving: false,
+                showsOfflineToken: false
+            ) == false
+        )
+    }
+
+    @Test("offline bypasses resolving placeholder behavior")
+    func riskPlaceholder_offlineBypassesResolvingPlaceholder() {
+        #expect(
+            SummaryView.showsRiskResolvingPlaceholder(
+                hasRiskValue: false,
+                readinessState: .loadingLocalData,
+                isSectionResolving: true,
+                showsOfflineToken: true
+            ) == false
+        )
+    }
+}
+
 @Suite("Foreground Refresh Policies")
 struct ForegroundRefreshPolicyTests {
     private let alertPolicy = AlertRefreshPolicy(minimumSyncInterval: 120)

--- a/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
+++ b/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
@@ -633,6 +633,7 @@ struct SummaryResolutionStateTests {
 
         #expect(state.isRefreshing)
         #expect(state.activeMessages == ["Bringing in local alerts…"])
+        #expect(state.primaryActiveMessage == "Bringing in local alerts…")
         #expect(state.isResolving(.alerts))
     }
 
@@ -645,6 +646,7 @@ struct SummaryResolutionStateTests {
 
         #expect(state.isRefreshing)
         #expect(state.activeMessages == ["Getting storm risk…"])
+        #expect(state.primaryActiveMessage == "Getting storm risk…")
         #expect(state.isResolving(.stormRisk) == false)
         #expect(state.isResolving(.severeRisk))
     }
@@ -671,6 +673,7 @@ struct SummaryResolutionStateTests {
 
         #expect(state.isRefreshing == false)
         #expect(state.activeMessages.isEmpty)
+        #expect(state.primaryActiveMessage == nil)
         #expect(state.isResolving(.conditions) == false)
     }
 
@@ -684,10 +687,22 @@ struct SummaryResolutionStateTests {
 
         #expect(state.isRefreshing == false)
         #expect(state.activeMessages.isEmpty)
+        #expect(state.primaryActiveMessage == nil)
         for section in SummarySection.resolveForwardSections {
             #expect(state.isResolving(section) == false)
         }
-        #expect(state.recentCompletedMessage == "Getting everything ready…")
+        #expect(state.recentCompletedMessage == nil)
+    }
+
+    @Test("primary active message prefers location readiness over other active tasks")
+    func primaryActiveMessage_prioritizesLocationTask() {
+        var state = SummaryResolutionState()
+
+        state.begin(task: .alerts, sections: [.alerts])
+        state.begin(task: .weather, sections: [.conditions])
+        state.begin(task: .location, sections: [.conditions])
+
+        #expect(state.primaryActiveMessage == "Getting your conditions ready…")
     }
 }
 

--- a/docs/audits/resolve-forward-ui-polish-issues.md
+++ b/docs/audits/resolve-forward-ui-polish-issues.md
@@ -1,0 +1,411 @@
+# Resolve-Forward UI Polish Issue Drafts
+
+GitHub CLI was available locally, but the active token was invalid, so these are draft issues ready to paste into GitHub.
+
+Suggested labels, where available: `design`, `ui-polish`, `summary`, `tech-debt`, `codex-ready`.
+
+## Issue 1
+
+Title: `[UI Polish] Standardize Summary resolving header language`
+
+## Recommended model
+Codex 5.3
+
+## Recommended reasoning
+Medium
+
+## Problem
+The Summary header currently carries multiple responsibilities at once: location, readiness, active resolving messages, recent completion messages, offline state, and settled condition text. `SummaryStatusSecondaryLine` can rotate between active messages every few seconds, then briefly repeat the last task message after completion. During refresh, the settled condition line is hidden, which can make the header feel like it is reloading instead of becoming more accurate.
+
+## Why now
+The resolve-forward model is correct, but the header should feel like one calm global status surface. A more stable hierarchy would improve trust, reduce visual churn, and avoid the sense that unrelated sections are competing to narrate themselves.
+
+## Scope
+Likely files/components:
+- `Sources/Features/Summary/SummaryStatus.swift`
+- `Sources/Features/Summary/SummaryResolving.swift`
+- `Sources/Features/Summary/SummaryView.swift`
+- `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+
+## Non-goals
+- Do not change data flow.
+- Do not change provider behavior.
+- Do not change refresh timing.
+- Do not change business logic.
+- Do not redesign the whole Summary screen.
+- Do not add new status sources or new network dependencies.
+
+## Proposed approach
+Audit the current header text hierarchy and make the active resolving line behave as one calm global message. Prefer a single visible resolving message at a time, with less message rotation and no developer/system phrasing. Keep the location as the primary settled identity. Use existing `SummaryResolutionState` and existing readiness state only.
+
+Recommended copy direction:
+- `Getting your conditions ready`
+- `Updating your conditions`
+- `Getting storm risk`
+- `Bringing in local alerts`
+
+Avoid adding provider names, feed names, or generic `Loading`/`Fetching` language.
+
+## Acceptance criteria
+- The Summary header shows one calm resolving/status line, not several competing status concepts.
+- Active resolving text does not rotate so frequently that it reads as jitter.
+- Recent-completion behavior does not make the same section appear to start loading again.
+- Settled condition text returns cleanly after resolving completes.
+- Location unavailable and offline states remain clearly distinct.
+- Existing readiness and resolving semantics remain unchanged.
+
+## Validation
+- Build `SkyAware` for an iOS Simulator target.
+- Inspect Summary previews that exercise ready, loading, offline, and location-unavailable states.
+- Run focused unit tests for Summary readiness/loading helpers if touched.
+- Manually inspect the Today tab during cold start, cached start, manual refresh, and foreground refresh.
+- Inspect light mode, dark mode, Reduce Motion, and larger Dynamic Type.
+
+## Risks / edge cases
+- Over-suppressing status can hide useful activity.
+- Over-animation can make the header feel nervous.
+- Long location names plus status text can truncate poorly.
+- Offline and stale-ish copy can imply data is fresh when only cached content is visible.
+
+## Issue 2
+
+Title: `[UI Polish] Add consistent Summary resolve-forward transition primitives`
+
+## Recommended model
+Codex 5.3
+
+## Recommended reasoning
+Medium
+
+## Problem
+Summary sections currently use a mix of redacted placeholders, full-card opacity, blur, inline explicit loading states, and pending text. Risk, fire, and atmosphere sections use placeholder redaction plus `summaryResolving`; Local Alerts uses explicit content states and an opacity transition; Outlook uses card-level placeholder and pending copy. The result is visually coherent enough to function, but not coherent enough to feel intentionally designed.
+
+## Why now
+A shared visual treatment would make resolve-forward updates feel like the app is refining the local picture instead of several components independently reloading.
+
+## Scope
+Likely files/components:
+- `Sources/Features/Summary/SummaryResolving.swift`
+- `Sources/Utilities/Core/SkyAwareMotion.swift`
+- `Sources/Utilities/Extensions/ext+View.swift`
+- `Sources/Features/Summary/SummaryView.swift`
+- `Sources/Features/Badges/StormRiskBadgeView.swift`
+- `Sources/Features/Badges/SevereWeatherBadgeView.swift`
+- `Sources/Features/Badges/FireWeatherRailView.swift`
+- `Sources/Features/Badges/AtmosphereRailView.swift`
+- `Sources/Features/Summary/ActiveAlertSummaryView.swift`
+- `Sources/Features/Summary/OutlookSummaryCard.swift`
+
+## Non-goals
+- Do not change data flow.
+- Do not change provider behavior.
+- Do not change refresh timing.
+- Do not change business logic.
+- Do not redesign the whole Summary screen.
+- Do not replace the cached-first model with a blocking loading state.
+
+## Proposed approach
+Create or refine a small shared resolve-forward visual vocabulary for Summary sections. Prefer stable containers with inner-content crossfade, subtle opacity lift, and optional blur-to-clear where it adds clarity. Avoid whole-card dimming when a child already has a clear resolving state. Keep Reduce Motion support explicit.
+
+The implementation should be conservative: centralize constants and modifiers only where it removes real inconsistency. Do not introduce a large UI framework.
+
+## Acceptance criteria
+- Summary sections use a consistent resolving language: stable container, calm inner transition, and no spinner-first behavior.
+- Resolve-forward transitions respect Reduce Motion.
+- Placeholder/resolving visuals reserve enough space to prevent obvious layout jumps.
+- Existing section order and interactions remain unchanged.
+- No section appears disabled unless it is intentionally unavailable.
+- The visual style works in light and dark mode.
+
+## Validation
+- Build `SkyAware` for an iOS Simulator target.
+- Inspect Summary previews for loaded, partially loaded, offline, and Dynamic Type states.
+- Manually record or observe cached launch and manual refresh on the Today tab.
+- Verify no new animation jank when multiple sections resolve together.
+- Inspect iPhone 17 or iPhone 17 Pro simulator if available.
+
+## Risks / edge cases
+- A shared modifier can accidentally flatten important section-specific semantics.
+- Too much blur can read as disabled or stale.
+- Crossfades can hide real alert appearance if overused.
+- Fixed placeholder heights can break at accessibility text sizes.
+
+## Issue 3
+
+Title: `[UI Polish] Polish risk badge resolve-forward transitions`
+
+## Recommended model
+Codex 5.3
+
+## Recommended reasoning
+Medium
+
+## Problem
+Storm Risk and Severe Risk are the primary severe-weather signals, but their resolving states are currently represented by rendering a fallback value and applying placeholder/redaction and section resolving effects from the parent. Icon, label, summary, color, and opacity can all change at once when data resolves. That can make the most important area feel jumpy instead of confidently updating.
+
+## Why now
+Risk badges define the first impression of the Summary screen. Their updates should feel deliberate, stable, and trustworthy.
+
+## Scope
+Likely files/components:
+- `Sources/Features/Summary/SummaryView.swift`
+- `Sources/Features/Badges/StormRiskBadgeView.swift`
+- `Sources/Features/Badges/SevereWeatherBadgeView.swift`
+- `Sources/Utilities/Extensions/ext+View.swift`
+- `Sources/Utilities/Core/SkyAwareMotion.swift`
+- Existing badge previews in the same files
+
+## Non-goals
+- Do not change risk scoring.
+- Do not change map layer selection.
+- Do not change provider behavior.
+- Do not change refresh timing.
+- Do not redesign the whole Summary screen.
+- Do not add new risk categories or alter color semantics.
+
+## Proposed approach
+Keep the existing badge layout and semantic color system, but make placeholder, resolving, stale/offline-adjacent, and resolved states visually aligned. Consider moving the resolving representation closer to the badge content instead of relying only on parent-level redaction and blur. Use subtle crossfades or content transitions for label/icon/value changes. Keep badge dimensions stable.
+
+Use the recent widget direction as inspiration for semantic glow and full-surface polish, but do not copy widget layouts into the app.
+
+## Acceptance criteria
+- Storm Risk and Severe Risk maintain stable dimensions while resolving.
+- Icon, label, summary, and color changes feel intentional and calm.
+- Placeholder/resolving states do not look like false `All Clear` risk.
+- Offline styling remains distinct from resolving.
+- The two badges transition consistently with each other.
+- Risk colors remain semantic and are not reused as generic decoration.
+
+## Validation
+- Build `SkyAware` for an iOS Simulator target.
+- Inspect badge previews across storm and severe risk levels.
+- Manually inspect Today during cached launch and manual refresh.
+- Check light mode, dark mode, Reduce Motion, and accessibility Dynamic Type where badges stack.
+- Capture before/after screenshots for the Summary hero area.
+
+## Risks / edge cases
+- A placeholder that resembles `All Clear` can create false calm.
+- Strong glow or animation can make severe-weather UI feel theatrical.
+- Text can truncate when risk summaries include probabilities.
+- Stacked Dynamic Type layout may expose height mismatches.
+
+## Issue 4
+
+Title: `[UI Polish] Stabilize Local Alerts resolving and empty states`
+
+## Recommended model
+Codex 5.3
+
+## Recommended reasoning
+Medium
+
+## Problem
+Local Alerts has the right conceptual states, but it remains one of the most sensitive resolve-forward surfaces. It needs to clearly distinguish checking latest alerts, no active alerts, active alerts, unavailable location, and offline. The current implementation already uses an internal content state and crossfade, but the visual language still risks reading as either false calm or a partially loaded card during startup and refresh.
+
+## Why now
+Alerts are high-trust content. The UI must avoid both noisy alert drama and premature reassurance while alerts are unresolved.
+
+## Scope
+Likely files/components:
+- `Sources/Features/Summary/ActiveAlertSummaryView.swift`
+- `Sources/Features/Summary/SummaryView.swift`
+- `Sources/Features/Summary/SummaryResolving.swift`
+- `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+- `docs/LifecycleInvestigationNotes.md` as prior audit context
+
+## Non-goals
+- Do not change alert ingestion.
+- Do not split Arcus/SPC/NWS refresh orchestration.
+- Do not change alert sorting or filtering.
+- Do not change refresh timing.
+- Do not change notification behavior.
+- Do not redesign the full Alerts tab.
+
+## Proposed approach
+Refine only the visual representation of the existing Local Alerts states. Keep the card container stable and transition inner content only. Ensure the checking state does not look like a final no-alert state, and the no-alert state does not appear until existing state says it should. Review the current label/copy for polish, including obvious user-facing typos, but keep wording calm and concise.
+
+Do not change whether cached alerts appear offline unless product explicitly approves that behavior separately.
+
+## Acceptance criteria
+- Checking/updating alerts is visually distinct from `No Active Alerts`.
+- Active alert rows enter without resizing or jolting the card more than necessary.
+- No-alert state does not imply alerts are fresh while alert resolving is active.
+- Offline and location-unavailable states remain visually distinct.
+- Alert Center affordance appears only where it makes visual and semantic sense.
+- VoiceOver reads loading, empty, offline, and populated states cleanly.
+
+## Validation
+- Build `SkyAware` for an iOS Simulator target.
+- Manually inspect Today with no alerts, watches only, mesos only, both watches and mesos, offline, and location unavailable.
+- Run focused Summary loading/local alert state tests if any helpers change.
+- Inspect Reduce Motion and large Dynamic Type.
+- Capture screenshots of checking, no-alert, active-alert, and offline states.
+
+## Risks / edge cases
+- False calm if `No Active Alerts` appears while checks are still resolving.
+- Overly dramatic styling can make normal watch/meso states feel like warnings.
+- Inner transitions can still cause height jumps if rows are not reserved carefully.
+- Offline messaging can hide useful cached alert context, but changing that is a behavior decision and out of scope.
+
+## Issue 5
+
+Title: `[UI Polish] Smooth Current Conditions resolve-forward updates`
+
+## Recommended model
+Codex 5.3
+
+## Recommended reasoning
+Medium
+
+## Problem
+Current Conditions combines location, temperature, condition icon, condition text, offline token, and resolving status. Temperature and icon changes use opacity transitions, while the settled condition line disappears during active refresh. Location and status text can swap based on readiness and placemark availability. The area can feel more like a status console than a stable weather-aware header.
+
+## Why now
+Current Conditions is the user's anchor for the Summary screen. It should show cached/local context immediately and then refine in place without looking like the entire header is being rebuilt.
+
+## Scope
+Likely files/components:
+- `Sources/Features/Summary/SummaryStatus.swift`
+- `Sources/Features/Summary/SummaryView.swift`
+- `Sources/Models/SummaryWeather.swift`
+- Existing Summary previews
+
+## Non-goals
+- Do not change WeatherKit fetching.
+- Do not change location resolution.
+- Do not change refresh timing.
+- Do not add new provider calls.
+- Do not redesign the whole Summary screen.
+
+## Proposed approach
+Keep the existing data inputs and layout, but refine the visual state transitions for temperature, icon, condition text, and location/status copy. Prefer layout-stable placeholders and subtle content transitions. If freshness/as-of language is shown, use existing timestamps only and keep it neutral, such as `As of 3:42 PM`, rather than broad `Updated` language that implies every section refreshed.
+
+## Acceptance criteria
+- Temperature, condition icon, and condition text update without visible layout jump.
+- The header remains anchored on location when cached content exists.
+- Resolving status does not cause the condition line to flicker or collapse.
+- Offline token remains compact and clear.
+- Long placemark names and large Dynamic Type do not overlap the weather value.
+
+## Validation
+- Build `SkyAware` for an iOS Simulator target.
+- Inspect Summary previews for ready, loading, offline, and location unavailable.
+- Manually inspect Today during cached launch, cold start, and manual refresh.
+- Check light mode, dark mode, Reduce Motion, and accessibility Dynamic Type.
+
+## Risks / edge cases
+- `Updated` copy can imply all sections are fresh when only conditions changed.
+- Too much persistent freshness text can add clutter.
+- Location names can crowd temperature on compact widths.
+- Hiding condition text during refresh can read as missing data.
+
+## Issue 6
+
+Title: `[UI Polish] Normalize secondary Summary resolving states`
+
+## Recommended model
+Codex 5.3
+
+## Recommended reasoning
+Medium
+
+## Problem
+Secondary sections such as Fire Risk, Atmospheric Conditions, and Outlook Summary are visually quieter than the hero area, which is correct, but their resolving and pending language is inconsistent. Atmospheric Conditions currently has generic loading phrasing, Outlook uses sync-oriented pending language, and section-level placeholders differ from Local Alerts and risk badges.
+
+## Why now
+Secondary sections should support the severe-weather picture without competing with it. Consistent quiet resolving states would reduce noise and make the Summary screen feel more coherent.
+
+## Scope
+Likely files/components:
+- `Sources/Features/Badges/FireWeatherRailView.swift`
+- `Sources/Features/Badges/AtmosphereRailView.swift`
+- `Sources/Features/Summary/OutlookSummaryCard.swift`
+- `Sources/Features/Summary/SummaryView.swift`
+- Relevant previews in those files
+
+## Non-goals
+- Do not change fire risk logic.
+- Do not change WeatherKit fetching.
+- Do not change outlook sync behavior.
+- Do not change refresh timing.
+- Do not redesign the full Outlooks tab.
+- Do not introduce new data dependencies.
+
+## Proposed approach
+Align secondary resolving states with the shared Summary transition style from the earlier primitive work. Replace generic or system-ish visual language with calm user-facing states in the issue implementation. Keep secondary sections visually subordinate to the risk badges and Local Alerts. Use stable rail/card heights where practical without breaking Dynamic Type.
+
+## Acceptance criteria
+- Fire, atmosphere, and outlook sections use a consistent calm resolving treatment.
+- Atmospheric loading state avoids generic `Loading` phrasing in user-facing text.
+- Outlook pending/resolving language does not expose sync mechanics.
+- Secondary sections do not compete visually with Storm Risk, Severe Risk, or active Local Alerts.
+- Placeholders reserve reasonable space and avoid abrupt height changes.
+
+## Validation
+- Build `SkyAware` for an iOS Simulator target.
+- Inspect Fire, Atmosphere, and Outlook previews.
+- Manually inspect Today with missing weather, missing outlook, offline, and fully resolved content.
+- Check light mode, dark mode, Reduce Motion, and large Dynamic Type.
+
+## Risks / edge cases
+- Quiet states can become too subtle and look broken.
+- Fixed heights can truncate explanatory text.
+- Outlook copy can accidentally imply no outlook exists when it simply has not resolved locally.
+- Fire risk colors must remain semantically distinct from storm/severe risk colors.
+
+## Issue 7
+
+Title: `[UI Polish] Align cold-start resolving screen with SkyAware visual direction`
+
+## Recommended model
+Codex 5.3
+
+## Recommended reasoning
+Medium
+
+## Problem
+The cold-start `LoadingView` is already limited to no meaningful cached content, which matches the resolve-forward model. Visually, it uses a ghost Summary stack, accent glows, and a weather icon. It should be reviewed against the newer polished blue/dark SkyAware direction so the no-cache startup state feels like the same product as the Summary and recent widget work.
+
+## Why now
+The full-screen resolving state is the first impression when the app has no useful cache. It should feel calm, severe-weather-aware, and consistent without encouraging a return to blocking loading for cached starts.
+
+## Scope
+Likely files/components:
+- `Sources/Features/Loading/LoadingView.swift`
+- `Sources/Utilities/Core/SkyAwareMotion.swift`
+- `docs/SkyAware Branding and Design Guide.md`
+- `docs/SkyAware North Star Spec.md`
+- Widget rendering files only as visual inspiration:
+  - `WidgetsExtension/WidgetRenderingComponents.swift`
+  - `WidgetsExtension/WidgetRenderingStyle.swift`
+
+## Non-goals
+- Do not change when `LoadingView` appears.
+- Do not add a blocking splash for cached content.
+- Do not change refresh orchestration.
+- Do not change loading timing.
+- Do not redesign the Summary screen.
+- Do not copy widget layouts directly into the app.
+
+## Proposed approach
+Keep the existing no-cache-only behavior. Refine the visual treatment toward a full-surface atmospheric blue base, subtle semantic glow, typography-led hierarchy, and calm motion. Keep the ghost Summary hint if it helps continuity, but ensure it does not look like real partially loaded content. Preserve Reduce Motion support.
+
+## Acceptance criteria
+- Cold-start resolving feels visually aligned with the current SkyAware design direction.
+- The screen still clearly communicates that SkyAware is getting local conditions ready.
+- Motion remains calm and respects Reduce Motion.
+- The ghost content reads as atmospheric context, not fake data.
+- Cached launch still bypasses this full-screen resolving state when meaningful content exists.
+
+## Validation
+- Build `SkyAware` for an iOS Simulator target.
+- Inspect `LoadingView` preview in light and dark mode.
+- Manually test a true no-cache startup if practical.
+- Verify cached startup still shows Summary content immediately.
+- Capture screenshots for light/dark and Reduce Motion review.
+
+## Risks / edge cases
+- Making the screen too beautiful can incentivize overuse; behavior must remain unchanged.
+- Ghost placeholders can be mistaken for real content.
+- Strong glow can feel flashy rather than trustworthy.
+- Cold-start copy must avoid generic loading or provider language.

--- a/docs/plans/resolve-forward-ui-polish-playbook.md
+++ b/docs/plans/resolve-forward-ui-polish-playbook.md
@@ -1,0 +1,166 @@
+# Resolve-Forward UI Polish Playbook
+
+Use this playbook when implementing GitHub issues #195 through #201.
+
+The work is visual polish for the existing cached-first, resolve-forward Summary experience. It is not a loading architecture project. Do not change what loads, when it loads, how providers refresh, how data is persisted, or how alerts/risk/weather are resolved.
+
+## Issue Set
+
+| Order | Issue | Title | Dependency |
+|---|---:|---|---|
+| 1 | [#195](https://github.com/justinrooks/project-arcus/issues/195) | [UI Polish] Standardize Summary resolving header language | None |
+| 2 | [#196](https://github.com/justinrooks/project-arcus/issues/196) | [UI Polish] Add consistent Summary resolve-forward transition primitives | Should precede #197, #198, #200 |
+| 3 | [#197](https://github.com/justinrooks/project-arcus/issues/197) | [UI Polish] Polish risk badge resolve-forward transitions | Prefer after #196 |
+| 4 | [#198](https://github.com/justinrooks/project-arcus/issues/198) | [UI Polish] Stabilize Local Alerts resolving and empty states | Prefer after #196 |
+| 5 | [#199](https://github.com/justinrooks/project-arcus/issues/199) | [UI Polish] Smooth Current Conditions resolve-forward updates | Best after #195 |
+| 6 | [#200](https://github.com/justinrooks/project-arcus/issues/200) | [UI Polish] Normalize secondary Summary resolving states | Prefer after #196 |
+| 7 | [#201](https://github.com/justinrooks/project-arcus/issues/201) | [UI Polish] Align cold-start resolving screen with SkyAware visual direction | Independent, last |
+
+## Required Read Order
+
+Before touching code for any issue, read:
+
+1. `AGENTS.md`
+2. `Sources/AGENTS.md`
+3. `tasks/lessons.md`
+4. The current GitHub issue body
+5. `docs/plans/resolve-forward-ui-polish-progress.md`
+6. `docs/SkyAware North Star Spec.md`
+7. `docs/SkyAware Branding and Design Guide.md`
+8. The relevant Summary/loading files for the issue
+
+For Local Alerts work, also read:
+
+- `docs/LifecycleInvestigationNotes.md`
+
+For cold-start resolving work, also read widget rendering files only as visual reference:
+
+- `WidgetsExtension/WidgetRenderingComponents.swift`
+- `WidgetsExtension/WidgetRenderingStyle.swift`
+
+## Non-Negotiables
+
+- Do not change provider behavior.
+- Do not change refresh orchestration.
+- Do not change refresh timing.
+- Do not change loading timing.
+- Do not change what loads when.
+- Do not change persistence.
+- Do not change alert/risk/weather business logic.
+- Do not introduce new data dependencies.
+- Do not add a blocking splash when cached Summary content exists.
+- Do not alter widget code unless an issue explicitly asks for a widget implementation change.
+- Do not use provider names, system jargon, or debug language in user-facing copy.
+
+This is polish work. If the implementation starts needing architecture, stop and re-plan. Architecture changes for a visual issue are usually a smell wearing a tie.
+
+## Design North Star
+
+SkyAware is a severe-weather awareness app, not a generic weather app.
+
+The Summary resolve-forward experience should feel:
+
+- calm
+- clear
+- professional
+- coherent
+- trustworthy
+- increasingly accurate as data resolves
+
+Prefer:
+
+- stable containers
+- typography-led hierarchy
+- subtle opacity lift
+- restrained blur-to-clear
+- crossfades where they clarify state
+- neutral freshness language
+- semantic color only
+
+Avoid:
+
+- spinners as the default answer
+- shimmer or flashy loading ornament
+- noisy state labels
+- provider/system language
+- fake `All Clear` placeholders
+- whole-card dimming when inner content can resolve cleanly
+- layout jumps that make content feel rebuilt
+
+## Current Implementation Map
+
+Primary Summary surfaces:
+
+- `Sources/App/HomeView.swift`
+- `Sources/App/HomeRefreshPipeline.swift`
+- `Sources/App/HomeRefreshV2/HomeSnapshot.swift`
+- `Sources/App/HomeRefreshV2/HomeSnapshotStore.swift`
+- `Sources/Features/Summary/SummaryView.swift`
+- `Sources/Features/Summary/SummaryStatus.swift`
+- `Sources/Features/Summary/SummaryResolving.swift`
+- `Sources/Features/Loading/LoadingView.swift`
+
+Section components:
+
+- `Sources/Features/Badges/StormRiskBadgeView.swift`
+- `Sources/Features/Badges/SevereWeatherBadgeView.swift`
+- `Sources/Features/Badges/FireWeatherRailView.swift`
+- `Sources/Features/Badges/AtmosphereRailView.swift`
+- `Sources/Features/Summary/ActiveAlertSummaryView.swift`
+- `Sources/Features/Summary/OutlookSummaryCard.swift`
+
+Motion and surfaces:
+
+- `Sources/Utilities/Core/SkyAwareMotion.swift`
+- `Sources/Utilities/Extensions/ext+View.swift`
+
+Relevant tests:
+
+- `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+
+## Per-Issue Workflow
+
+1. Read the required docs and the current progress file.
+2. Inspect the exact files listed in the issue scope.
+3. Write down the smallest implementation plan in the progress file before editing if the issue touches more than one component.
+4. Keep changes scoped to the issue.
+5. Prefer existing modifiers, colors, radius, motion, and component patterns.
+6. Add or adjust focused tests only where state helpers or deterministic presentation logic changes.
+7. Run the smallest relevant validation before finishing.
+8. Update `docs/plans/resolve-forward-ui-polish-progress.md` before final response.
+
+## Validation Expectations
+
+At minimum:
+
+- Build the app target when production Swift changes are made.
+- Run focused tests when helper logic changes.
+- Inspect relevant previews when the issue changes SwiftUI layout or copy.
+- Manually inspect the affected Summary states in Simulator when practical.
+
+Use this build command unless a newer repo-local command supersedes it:
+
+```sh
+xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build
+```
+
+For issue-specific validation, follow the GitHub issue body. Do not claim tests, builds, screenshots, or simulator validation unless they actually ran.
+
+## Progress Handoff Requirement
+
+Before finishing any issue, update:
+
+- `docs/plans/resolve-forward-ui-polish-progress.md`
+
+Record:
+
+- issue status
+- files changed
+- behavior intentionally preserved
+- validation run
+- screenshots or previews inspected, if any
+- deferred work
+- risk notes for the next issue
+
+The next agent should be able to resume without reading your mind. We are good, but not telepathic. Yet.
+

--- a/docs/plans/resolve-forward-ui-polish-progress.md
+++ b/docs/plans/resolve-forward-ui-polish-progress.md
@@ -418,6 +418,42 @@ Date: 2026-05-27
   - cached refresh behavior
   - light/dark, Reduce Motion, larger Dynamic Type
 
+## Review Fix - [P1] Missing risk data after completed local-data attempt appears indefinitely resolving
+
+Status: Complete
+Date: 2026-05-27
+
+### Finding Fixed
+
+- Resolved the risk-placeholder gating bug where `stormRisk`, `severeRisk`, or `fireRisk` being `nil` always showed resolving copy, even after local-data completion and Summary readiness.
+
+### Files Changed
+
+- `Sources/Features/Summary/SummaryView.swift`
+- `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+
+### Behavior Preserved
+
+- Risk scoring unchanged.
+- Risk mapping unchanged.
+- Provider behavior unchanged.
+- Refresh orchestration/timing unchanged.
+- Loading timing unchanged.
+- What loads when unchanged.
+- Persistence unchanged.
+- Business logic unchanged.
+- Offline behavior preserved.
+- Map tap behavior preserved.
+
+### Validation Run
+
+- Ran: `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build`
+- Ran: `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5" -only-testing:SkyAwareTests/SummaryViewRiskPlaceholderPresentationTests test`
+
+### Remaining Risks
+
+- Visual nuance for ready-with-missing-risk fallback relies on existing safe fallback values (`.allClear` / `.clear`) without an explicit "data unavailable" affordance; this preserves current product semantics but should be reviewed in UI QA for trust/readability.
+
 ### Handoff Notes
 
 - For #201 cold-start resolving:

--- a/docs/plans/resolve-forward-ui-polish-progress.md
+++ b/docs/plans/resolve-forward-ui-polish-progress.md
@@ -14,7 +14,7 @@ Update this file after each issue is implemented. Keep entries factual: what cha
 | 4 | [#198](https://github.com/justinrooks/project-arcus/issues/198) | Stabilize Local Alerts resolving and empty states | Complete | Local Alerts keeps a stable container with inner-state crossfade, clearer copy, and cleaner offline VoiceOver grouping. |
 | 5 | [#199](https://github.com/justinrooks/project-arcus/issues/199) | Smooth Current Conditions resolve-forward updates | Complete | Current Conditions now keeps cached weather identity stable while resolve-forward updates settle in place. |
 | 6 | [#200](https://github.com/justinrooks/project-arcus/issues/200) | Normalize secondary Summary resolving states | Complete | Fire/Atmosphere/Outlook now use calmer shared resolve-forward language and stable unresolved placeholders. |
-| 7 | [#201](https://github.com/justinrooks/project-arcus/issues/201) | Align cold-start resolving screen with SkyAware visual direction | Not started | Independent and intentionally last. |
+| 7 | [#201](https://github.com/justinrooks/project-arcus/issues/201) | Align cold-start resolving screen with SkyAware visual direction | Complete | Cold-start `LoadingView` now uses full-surface atmospheric treatment, calmer hierarchy, and abstract ghost structure without behavior changes. |
 
 ## Global Constraints
 
@@ -424,9 +424,63 @@ Date: 2026-05-27
   - Reuse this issue’s calm secondary language conventions (resolve-forward, user-facing, no sync/system phrasing).
   - Preserve stable titles/surfaces during resolving where possible so the cold-start view feels like the same visual system, not a separate loading mode.
 
-## Next Recommended Issue
+## Issue #201 - Align cold-start resolving screen with SkyAware visual direction
 
-Start with [#200](https://github.com/justinrooks/project-arcus/issues/200), then [#201](https://github.com/justinrooks/project-arcus/issues/201).
+Status: Complete
+Date: 2026-05-27
+
+### Scope Completed
+
+- Reworked cold-start `LoadingView` visual treatment to a full-surface atmospheric blue base that matches the newer Summary/widget-era SkyAware visual direction.
+- Shifted loading hierarchy to typography-first messaging with calm, user-facing resolve-forward copy and no generic loading/system language.
+- Replaced the old icon-centric ghost stack with a more abstract structural ghost composition so unresolved context reads as atmospheric structure, not fake loaded data.
+- Kept motion low-frequency and atmospheric (subtle glow drift + pulse) with explicit Reduce Motion static fallback.
+- Added focused `LoadingView` previews for dark mode and Reduce Motion inspection.
+
+### Files Changed
+
+- `Sources/Features/Loading/LoadingView.swift`
+- `docs/plans/resolve-forward-ui-polish-progress.md`
+
+### Behavior Preserved
+
+- `LoadingView` appearance gating unchanged (still true empty/no-cache startup only).
+- Cached-first Summary bypass behavior unchanged.
+- Data flow unchanged.
+- Provider behavior unchanged.
+- Refresh orchestration unchanged.
+- Refresh timing unchanged.
+- Loading timing unchanged.
+- What loads when unchanged.
+- Persistence unchanged.
+- Business logic unchanged.
+- Widget code unchanged.
+
+### Validation
+
+- Ran: `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build`
+- Result: Success (`** BUILD SUCCEEDED **`).
+- Previews updated/available for:
+  - light mode
+  - dark mode
+  - Reduce Motion
+
+### Validation Not Run
+
+- Manual true no-cache and cached-launch simulator walkthrough was not run in this pass.
+- Manual transition walkthrough from cold-start resolving into Summary was not run in this pass.
+- Manual larger Dynamic Type simulator pass was not run in this pass.
+
+### Remaining Visual Risks / Final Polish Notes
+
+- The atmospheric ghost abstraction is intentionally less data-like; final tuning may still benefit from screenshot review on-device to ensure the blur level is neither too soft in dark mode nor too bright in light mode.
+- If future polish wants further consistency with Summary surfaces, adjust only visual constants inside `LoadingView`; do not expand full-screen loading to cached starts.
+
+### Final Handoff Summary (#195-#201)
+
+- The complete #195-#201 sequence is now implemented as scoped visual polish while preserving cached-first, resolve-forward architecture and behavior.
+- Summary resolving language, transition primitives, hero badges, local alerts, current conditions, secondary sections, and cold-start empty-state visuals now present a calmer, more coherent, typography-led system.
+- No issue in this sequence changed providers, orchestration, timing, persistence, or business logic.
 
 ## Handoff Template
 

--- a/docs/plans/resolve-forward-ui-polish-progress.md
+++ b/docs/plans/resolve-forward-ui-polish-progress.md
@@ -10,7 +10,7 @@ Update this file after each issue is implemented. Keep entries factual: what cha
 |---|---:|---|---|---|
 | 1 | [#195](https://github.com/justinrooks/project-arcus/issues/195) | Standardize Summary resolving header language | Complete | Secondary status line stabilized to one calm global message with reduced churn. |
 | 2 | [#196](https://github.com/justinrooks/project-arcus/issues/196) | Add consistent Summary resolve-forward transition primitives | Complete | Added small shared resolve-forward style primitive and normalized Summary section resolve transitions. |
-| 3 | [#197](https://github.com/justinrooks/project-arcus/issues/197) | Polish risk badge resolve-forward transitions | Not started | Prefer after #196. |
+| 3 | [#197](https://github.com/justinrooks/project-arcus/issues/197) | Polish risk badge resolve-forward transitions | Complete | Added badge-local resolve placeholders and calm content crossfades while keeping risk semantics unchanged. |
 | 4 | [#198](https://github.com/justinrooks/project-arcus/issues/198) | Stabilize Local Alerts resolving and empty states | Not started | Prefer after #196. Read `docs/LifecycleInvestigationNotes.md`. |
 | 5 | [#199](https://github.com/justinrooks/project-arcus/issues/199) | Smooth Current Conditions resolve-forward updates | Not started | Best after #195. |
 | 6 | [#200](https://github.com/justinrooks/project-arcus/issues/200) | Normalize secondary Summary resolving states | Not started | Prefer after #196. |
@@ -166,6 +166,81 @@ Date: 2026-05-27
 - For #200 (secondary Summary states):
   - Default secondary sections to `style: .subtle` unless a section has clear readability justification for `blurLift`.
   - Reuse animated placeholders where skeleton text is already present to minimize layout jumps.
+
+## Issue #197 - Polish risk badge resolve-forward transitions
+
+Status: Complete
+Date: 2026-05-27
+
+### Scope Completed
+
+- Replaced risk-badge unresolved placeholder redaction with explicit in-badge resolve-forward placeholder content so unresolved state no longer reads like confirmed `All Clear`.
+- Kept Storm Risk and Severe Risk structurally parallel with the same state model:
+  - `offline` (existing offline card, unchanged),
+  - `resolving placeholder` (neutral badge surface + resolving copy),
+  - `resolved` (semantic risk colors + normal risk copy).
+- Added calm, non-dramatic content crossfades for icon/message/summary updates in both badges to smooth cached → freshly resolved changes.
+- Updated Summary risk badge host behavior to:
+  - pass explicit resolving/placeholder flags into both badges,
+  - use `.summaryResolving(..., style: .subtle)` for already-resolved badge refreshes,
+  - avoid extra whole-badge dim/blur during unresolved placeholder phase.
+- Added preview rows in both badge files to exercise resolving placeholder and resolving-with-data states.
+
+### Files Changed
+
+- `Sources/Features/Summary/SummaryView.swift`
+- `Sources/Features/Badges/StormRiskBadgeView.swift`
+- `Sources/Features/Badges/SevereWeatherBadgeView.swift`
+
+### How Badge Resolving Works Now
+
+- Missing risk data while online shows a neutral, stable badge with resolving language (`Resolving/Refining ...`) instead of fallback semantic risk values.
+- Once data is present, badges transition into semantic risk content with gentle content opacity transitions.
+- While fresh data continues to resolve on already-populated badges, Summary applies the #196 resolve-forward primitive in `.subtle` mode so badges feel active, not disabled.
+
+### Behavior Preserved
+
+- Risk scoring unchanged.
+- Risk mapping unchanged.
+- Map layer selection unchanged.
+- Provider behavior unchanged.
+- Refresh orchestration unchanged.
+- Refresh timing unchanged.
+- Loading timing unchanged.
+- What loads when unchanged.
+- Persistence unchanged.
+- Business logic unchanged.
+- Existing badge tap behavior and accessibility hints unchanged.
+- Semantic risk colors unchanged for resolved states.
+- Offline badge state remains distinct from resolving state.
+
+### Validation
+
+- Ran: `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build`
+- Result: Success (`** BUILD SUCCEEDED **`).
+- Previews updated for resolving paths in both badge components.
+
+### Validation Not Run
+
+- Focused tests not run because no scoring, mapping, provider, orchestration, or deterministic helper logic changed.
+- Manual simulator visual matrix not run in this pass:
+  - unresolved → resolved
+  - cached → refreshed
+  - offline cards
+  - light/dark
+  - Reduce Motion
+  - larger Dynamic Type stacked hero tiles
+
+### Deferred Work
+
+- Manual before/after screenshot capture for Summary hero area across the full visual matrix listed above.
+
+### Handoff Notes
+
+- For #198 and #200:
+  - Keep using `SummaryResolveForwardStyle.subtle` as the default when content is already present and refining.
+  - Prefer section-local resolving placeholders over fallback semantic content + heavy redaction when unresolved state could imply a false calm.
+  - If additional resolve-forward placeholders are added elsewhere, match this badge pattern: neutral surface, stable dimensions, concise progressive language, and restrained transitions.
 
 ## Next Recommended Issue
 

--- a/docs/plans/resolve-forward-ui-polish-progress.md
+++ b/docs/plans/resolve-forward-ui-polish-progress.md
@@ -13,7 +13,7 @@ Update this file after each issue is implemented. Keep entries factual: what cha
 | 3 | [#197](https://github.com/justinrooks/project-arcus/issues/197) | Polish risk badge resolve-forward transitions | Complete | Added badge-local resolve placeholders and calm content crossfades while keeping risk semantics unchanged. |
 | 4 | [#198](https://github.com/justinrooks/project-arcus/issues/198) | Stabilize Local Alerts resolving and empty states | Complete | Local Alerts keeps a stable container with inner-state crossfade, clearer copy, and cleaner offline VoiceOver grouping. |
 | 5 | [#199](https://github.com/justinrooks/project-arcus/issues/199) | Smooth Current Conditions resolve-forward updates | Complete | Current Conditions now keeps cached weather identity stable while resolve-forward updates settle in place. |
-| 6 | [#200](https://github.com/justinrooks/project-arcus/issues/200) | Normalize secondary Summary resolving states | Not started | Prefer after #196. |
+| 6 | [#200](https://github.com/justinrooks/project-arcus/issues/200) | Normalize secondary Summary resolving states | Complete | Fire/Atmosphere/Outlook now use calmer shared resolve-forward language and stable unresolved placeholders. |
 | 7 | [#201](https://github.com/justinrooks/project-arcus/issues/201) | Align cold-start resolving screen with SkyAware visual direction | Not started | Independent and intentionally last. |
 
 ## Global Constraints
@@ -349,6 +349,80 @@ Date: 2026-05-27
 
 - #200 can reuse the same approach used here for secondary/status surfaces: keep stable container geometry, avoid hiding settled text just because background resolve is active, and prefer gentle de-emphasis over collapse.
 - If secondary sections need freshness copy later, keep it neutral and scoped (for example using existing per-section timestamps only) rather than broad cross-section `Updated` language.
+
+## Issue #200 - Normalize secondary Summary resolving states
+
+Status: Complete
+Date: 2026-05-27
+
+### Scope Completed
+
+- Normalized Fire Risk unresolved behavior to use an explicit, calm resolve-forward placeholder rail instead of redacting a semantic `No Fire Risk` fallback.
+- Kept Fire Risk offline treatment distinct and preserved fire semantic colors for resolved states.
+- Updated Atmospheric Conditions unresolved copy to calm resolve-forward language and removed generic loading phrasing.
+- Updated Outlook Summary unresolved/pending language to user-facing resolve-forward phrasing and removed sync-mechanic wording.
+- Kept Outlook header stable as `Outlook Summary` across pending/resolved states to reduce visual churn.
+- Added focused Outlook and Fire previews for unresolved states to support visual verification paths.
+- Aligned secondary section transitions with existing #196 pattern by keeping Fire resolve-forward host treatment subtle when data already exists.
+
+### Files Changed
+
+- `Sources/Features/Summary/SummaryView.swift`
+- `Sources/Features/Badges/FireWeatherRailView.swift`
+- `Sources/Features/Badges/AtmosphereRailView.swift`
+- `Sources/Features/Summary/OutlookSummaryCard.swift`
+
+### How Secondary Resolving States Work Now
+
+- Fire Risk:
+  - offline: existing offline card remains unchanged and distinct;
+  - unresolved online: neutral resolving rail with stable height/copy;
+  - resolved: existing semantic fire-risk rail.
+- Atmospheric Conditions:
+  - unresolved online: same rail layout and metric footprint with calm resolve-forward copy;
+  - offline: existing offline card unchanged and distinct.
+- Outlook Summary:
+  - unresolved initial/pending states now describe local resolve-forward progress without provider/sync language;
+  - title remains stable while body text resolves into live summary when available.
+
+### Behavior Preserved
+
+- Fire risk logic unchanged.
+- WeatherKit fetching unchanged.
+- Outlook sync behavior unchanged.
+- Provider behavior unchanged.
+- Refresh orchestration unchanged.
+- Refresh timing unchanged.
+- Loading timing unchanged.
+- What loads when unchanged.
+- Persistence unchanged.
+- Business logic unchanged.
+- Existing tap/navigation behavior unchanged.
+
+### Validation
+
+- Ran: `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build`
+- Result: Success (`** BUILD SUCCEEDED **`).
+
+### Validation Not Run
+
+- Focused tests were not run because no deterministic helper/business logic changed.
+- Manual Simulator/previews matrix across light/dark, Reduce Motion, and larger Dynamic Type states was not run in this pass.
+
+### Deferred Work
+
+- Manual visual QA for the full requested matrix:
+  - Fire unresolved/resolved/offline
+  - Atmosphere unresolved/resolved/offline
+  - Outlook missing/loading/pending/resolved
+  - cached refresh behavior
+  - light/dark, Reduce Motion, larger Dynamic Type
+
+### Handoff Notes
+
+- For #201 cold-start resolving:
+  - Reuse this issue’s calm secondary language conventions (resolve-forward, user-facing, no sync/system phrasing).
+  - Preserve stable titles/surfaces during resolving where possible so the cold-start view feels like the same visual system, not a separate loading mode.
 
 ## Next Recommended Issue
 

--- a/docs/plans/resolve-forward-ui-polish-progress.md
+++ b/docs/plans/resolve-forward-ui-polish-progress.md
@@ -638,3 +638,53 @@ Date: YYYY-MM-DD
 
 - ...
 ```
+
+## Final Taste-Polish Handoff - Resolve-Forward Summary + Cold Start
+
+Status: Complete
+Date: 2026-05-27
+
+### Notes Addressed
+
+- Reduced cold-start `LoadingView` visual mass by lowering the fixed minimum height (`560` -> `500`) while preserving full-surface presentation and existing appearance gating.
+- Removed the cold-start material mini-card treatment and shifted to typography-led integrated messaging over the atmospheric surface to avoid card-on-card feel.
+- Updated remaining user-facing resolve-forward copy on Summary/risk/secondary surfaces to the canonical family:
+  - `Getting storm risk…`
+  - `Getting severe risk…`
+  - `Getting fire risk…`
+  - `Getting outlook details…`
+  - `Getting atmospheric details…`
+- Replaced user-facing `server is offline` strings on Summary-adjacent surfaces with connection-return language centered on saved local data.
+- Tuned unresolved risk placeholder backgrounds (Storm/Severe/Fire) from neutral gray-white into restrained atmospheric blue/slate gradients to feel integrated without implying resolved risk semantics.
+- Restored limited specificity for recent completion status (`Updated conditions`, `Got storm risk`, `Checked local alerts`) while preserving prior churn controls and timing window.
+- Kept the hidden `00°` weather-width placeholder and explicitly marked both hidden placeholder elements as `accessibilityHidden(true)` to prevent leakage.
+- Renamed the `LoadingView` Reduce Motion preview to avoid claiming behavior that cannot be forced via a writable environment key in this toolchain (`Reduce Motion (Name Only)`).
+
+### Notes Intentionally Left Unchanged
+
+- `LoadingView` still uses a minimum height floor (now lower) instead of fully dynamic geometry math to keep launch layout stable and avoid introducing additional complexity/risk in this polish-only pass.
+
+### Files Changed
+
+- `Sources/Features/Loading/LoadingView.swift`
+- `Sources/Features/Summary/SummaryStatus.swift`
+- `Sources/Features/Summary/SummaryResolving.swift`
+- `Sources/Features/Summary/OutlookSummaryCard.swift`
+- `Sources/Features/Summary/ActiveAlertSummaryView.swift`
+- `Sources/Features/Badges/StormRiskBadgeView.swift`
+- `Sources/Features/Badges/SevereWeatherBadgeView.swift`
+- `Sources/Features/Badges/FireWeatherRailView.swift`
+- `Sources/Features/Badges/AtmosphereRailView.swift`
+- `docs/plans/resolve-forward-ui-polish-progress.md`
+
+### Validation Run
+
+- Ran string-level inspection for targeted copy regressions:
+  - no remaining user-facing `server is offline` strings in Summary/loading/risk/secondary surfaces
+  - no remaining user-facing `Resolving`/`Refining` language in those surfaces
+- Ran: `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build`
+- Result: Success (`** BUILD SUCCEEDED **`).
+
+### Remaining Risks
+
+- Visual tone and spacing for the lighter-weight cold-start message region still needs final simulator eyes-on across smallest iPhone heights, dark mode, and large Dynamic Type to confirm perceived balance after lowering minimum height.

--- a/docs/plans/resolve-forward-ui-polish-progress.md
+++ b/docs/plans/resolve-forward-ui-polish-progress.md
@@ -9,7 +9,7 @@ Update this file after each issue is implemented. Keep entries factual: what cha
 | Order | Issue | Title | Status | Notes |
 |---|---:|---|---|---|
 | 1 | [#195](https://github.com/justinrooks/project-arcus/issues/195) | Standardize Summary resolving header language | Complete | Secondary status line stabilized to one calm global message with reduced churn. |
-| 2 | [#196](https://github.com/justinrooks/project-arcus/issues/196) | Add consistent Summary resolve-forward transition primitives | Not started | Should precede #197, #198, and #200. |
+| 2 | [#196](https://github.com/justinrooks/project-arcus/issues/196) | Add consistent Summary resolve-forward transition primitives | Complete | Added small shared resolve-forward style primitive and normalized Summary section resolve transitions. |
 | 3 | [#197](https://github.com/justinrooks/project-arcus/issues/197) | Polish risk badge resolve-forward transitions | Not started | Prefer after #196. |
 | 4 | [#198](https://github.com/justinrooks/project-arcus/issues/198) | Stabilize Local Alerts resolving and empty states | Not started | Prefer after #196. Read `docs/LifecycleInvestigationNotes.md`. |
 | 5 | [#199](https://github.com/justinrooks/project-arcus/issues/199) | Smooth Current Conditions resolve-forward updates | Not started | Best after #195. |
@@ -83,9 +83,93 @@ Date: 2026-05-27
 - #196 should build transition primitives on top of this calmer single-message behavior; avoid reintroducing multi-message rotation in the header.
 - `primaryActiveMessage` is now the intended entry point when a single resolving message is needed.
 
+## Issue #196 - Add consistent Summary resolve-forward transition primitives
+
+Status: Complete
+Date: 2026-05-27
+
+### Scope Completed
+
+- Refined shared motion constants for resolve-forward polish to reduce heavy dim/blur that could read as disabled.
+- Added a narrow Summary-specific resolve-forward style primitive:
+  - `SummaryResolveForwardStyle.subtle` for stable-card, inner-content lift with no blur.
+  - `SummaryResolveForwardStyle.blurLift` for sections where restrained blur-to-clear still improves clarity.
+- Updated `summaryResolving` to use the new style primitive while preserving explicit Reduce Motion handling.
+- Applied animated placeholder settling to Summary risk/rail/outlook loading paths to reserve space and reduce abrupt transitions.
+- Updated Summary section usage to align with consistent resolve-forward language:
+  - Risk badges + Fire rail keep `blurLift`.
+  - Atmosphere rail, Local Alerts, and Outlook use `subtle`.
+
+### Files Changed
+
+- `Sources/Utilities/Core/SkyAwareMotion.swift`
+- `Sources/Features/Summary/SummaryResolving.swift`
+- `Sources/Features/Summary/SummaryView.swift`
+- `Sources/Features/Summary/OutlookSummaryCard.swift`
+
+### New/Refined Transition Primitives
+
+- `SummaryResolveForwardStyle` enum in `SummaryResolving.swift`.
+- Refined shared constants in `SkyAwareMotion`:
+  - `resolvingBlur` lowered to `1.8`
+  - `resolvingOpacity` lifted to `0.90`
+  - added `resolvingSubtleOpacity = 0.94`
+  - `placeholderOpacity` lifted to `0.90`
+
+### Sections Updated To Use Primitive
+
+- `SummaryView` risk snapshot:
+  - Storm Risk badge (`blurLift`)
+  - Severe Risk badge (`blurLift`)
+  - Fire Risk rail (`blurLift`)
+  - Atmospheric rail (`subtle`)
+- `ActiveAlertSummaryView` host transition in `SummaryView` (`subtle` while alerts resolve)
+- `OutlookSummaryCard` host transition in `SummaryView` (`subtle`)
+- `OutlookSummaryCard` placeholder settling set to animated
+
+### Behavior Preserved
+
+- Data flow unchanged.
+- Provider behavior unchanged.
+- Refresh orchestration unchanged.
+- Refresh timing unchanged.
+- Loading timing unchanged.
+- What loads when unchanged.
+- Persistence unchanged.
+- Business logic unchanged.
+- Section order and interactions unchanged.
+
+### Validation
+
+- Ran: `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build`
+- Result: Success (`** BUILD SUCCEEDED **`).
+- Screenshots/previews inspected: Not run in this pass.
+
+### Validation Not Run
+
+- Focused unit tests were not run because no deterministic state/business logic changed.
+- Manual simulator state matrix (loaded/partial/cached refresh/offline/Reduce Motion/large Dynamic Type) not run in this pass.
+
+### Deferred Work
+
+- Manual visual QA pass across Summary states and dynamic type sizes to confirm no edge-case layout shift under mixed resolving.
+- Optional follow-up adjustment for alert section inner transition intensity if #198 reveals state-specific roughness.
+
+### Handoff Notes
+
+- For #197 (risk badges):
+  - Reuse `summaryResolving(..., style: .blurLift)` for badge-level resolve-forward by default; only move to `.subtle` if a specific badge treatment adds too much blur in dark mode.
+  - Keep placeholder reservation behavior and avoid introducing spinner-first badge states.
+- For #198 (Local Alerts):
+  - Treat `style: .subtle` as baseline for resolve-forward while loading/empty/alerts branches swap.
+  - Keep container stable and favor content crossfades inside the card; do not shift back to whole-card dimming semantics.
+- For #200 (secondary Summary states):
+  - Default secondary sections to `style: .subtle` unless a section has clear readability justification for `blurLift`.
+  - Reuse animated placeholders where skeleton text is already present to minimize layout jumps.
+
 ## Next Recommended Issue
 
-Start with [#195](https://github.com/justinrooks/project-arcus/issues/195), then [#196](https://github.com/justinrooks/project-arcus/issues/196).
+Start with [#197](https://github.com/justinrooks/project-arcus/issues/197), then [#198](https://github.com/justinrooks/project-arcus/issues/198), then [#200](https://github.com/justinrooks/project-arcus/issues/200).
 
 ## Handoff Template
 

--- a/docs/plans/resolve-forward-ui-polish-progress.md
+++ b/docs/plans/resolve-forward-ui-polish-progress.md
@@ -482,6 +482,45 @@ Date: 2026-05-27
 - Summary resolving language, transition primitives, hero badges, local alerts, current conditions, secondary sections, and cold-start empty-state visuals now present a calmer, more coherent, typography-led system.
 - No issue in this sequence changed providers, orchestration, timing, persistence, or business logic.
 
+## Review Fix - P1 stale cross-location weather during resolve-forward
+
+Status: Complete
+Date: 2026-05-27
+
+### Finding Fixed
+
+- Prevented stale cached weather from being shown when Summary location context changes while weather is temporarily unresolved during an active refresh.
+
+### Files Changed
+
+- `Sources/Features/Summary/SummaryStatus.swift`
+- `Sources/Features/Summary/SummaryView.swift`
+- `Tests/UnitTests/SummaryStatusWeatherRetentionTests.swift`
+- `docs/plans/resolve-forward-ui-polish-progress.md`
+
+### Behavior Preserved
+
+- Same-location resolve-forward smoothing remains: cached Current Conditions can remain visible while fresh weather resolves.
+- WeatherKit fetching unchanged.
+- Location resolution unchanged.
+- Provider behavior unchanged.
+- Refresh orchestration unchanged.
+- Refresh timing unchanged.
+- Loading timing unchanged.
+- What loads when unchanged.
+- Persistence unchanged.
+- Business logic unchanged.
+
+### Validation
+
+- Ran focused tests for the new deterministic retention helper.
+- Ran required build:
+  - `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build`
+
+### Remaining Risks
+
+- Identity uses quantized coordinates + placemark summary from `LocationSnapshot`; if future requirements decouple displayed placemark from snapshot identity, this guard may need to align with a different canonical context key.
+
 ## Handoff Template
 
 Copy this section when completing an issue.

--- a/docs/plans/resolve-forward-ui-polish-progress.md
+++ b/docs/plans/resolve-forward-ui-polish-progress.md
@@ -12,7 +12,7 @@ Update this file after each issue is implemented. Keep entries factual: what cha
 | 2 | [#196](https://github.com/justinrooks/project-arcus/issues/196) | Add consistent Summary resolve-forward transition primitives | Complete | Added small shared resolve-forward style primitive and normalized Summary section resolve transitions. |
 | 3 | [#197](https://github.com/justinrooks/project-arcus/issues/197) | Polish risk badge resolve-forward transitions | Complete | Added badge-local resolve placeholders and calm content crossfades while keeping risk semantics unchanged. |
 | 4 | [#198](https://github.com/justinrooks/project-arcus/issues/198) | Stabilize Local Alerts resolving and empty states | Complete | Local Alerts keeps a stable container with inner-state crossfade, clearer copy, and cleaner offline VoiceOver grouping. |
-| 5 | [#199](https://github.com/justinrooks/project-arcus/issues/199) | Smooth Current Conditions resolve-forward updates | Not started | Best after #195. |
+| 5 | [#199](https://github.com/justinrooks/project-arcus/issues/199) | Smooth Current Conditions resolve-forward updates | Complete | Current Conditions now keeps cached weather identity stable while resolve-forward updates settle in place. |
 | 6 | [#200](https://github.com/justinrooks/project-arcus/issues/200) | Normalize secondary Summary resolving states | Not started | Prefer after #196. |
 | 7 | [#201](https://github.com/justinrooks/project-arcus/issues/201) | Align cold-start resolving screen with SkyAware visual direction | Not started | Independent and intentionally last. |
 
@@ -299,9 +299,60 @@ Date: 2026-05-27
   - transition only inner state content;
   - avoid additional whole-card dimming when a section already has an explicit resolving state.
 
+## Issue #199 - Smooth Current Conditions resolve-forward updates
+
+Status: Complete
+Date: 2026-05-27
+
+### Scope Completed
+
+- Kept Current Conditions anchored on location while weather refines by caching the last resolved weather payload for visual continuity during active resolve-forward refreshes.
+- Stabilized temperature/icon rendering when weather is temporarily missing by reserving a constant footprint and using calm value/icon transitions instead of abrupt disappear/reappear behavior.
+- Prevented settled condition-line flicker/collapse during active refresh by continuing to display the last known condition text with subtle de-emphasis while resolving.
+- Tightened long placemark behavior in compact/condensed layouts by forcing one-line truncation for non-stacked hero layout and preserving two-line support only in stacked Dynamic Type layouts.
+- Preserved existing offline token UI, popover behavior, and header condense motion.
+
+### Files Changed
+
+- `Sources/Features/Summary/SummaryStatus.swift`
+- `docs/plans/resolve-forward-ui-polish-progress.md`
+
+### Behavior Preserved
+
+- WeatherKit fetching unchanged.
+- Location resolution unchanged.
+- Provider behavior unchanged.
+- Refresh orchestration unchanged.
+- Refresh timing unchanged.
+- Loading timing unchanged.
+- What loads when unchanged.
+- Persistence unchanged.
+- Business logic unchanged.
+- Offline token interaction and copy unchanged.
+- Condensing header behavior unchanged.
+
+### Validation
+
+- Ran: `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build`
+- Result: Success (`** BUILD SUCCEEDED **`).
+
+### Validation Not Run
+
+- Focused tests not run because no deterministic helper/business logic changed.
+- Manual Simulator/previews matrix not run in this pass (ready, missing weather -> resolved, cached refresh, offline token, location unavailable, long placemark, light/dark, Reduce Motion, larger Dynamic Type).
+
+### Deferred Work
+
+- Manual visual QA pass across the full Current Conditions state matrix, especially compact-width long placemark + offline token and large Dynamic Type stacked layouts.
+
+### Handoff Notes
+
+- #200 can reuse the same approach used here for secondary/status surfaces: keep stable container geometry, avoid hiding settled text just because background resolve is active, and prefer gentle de-emphasis over collapse.
+- If secondary sections need freshness copy later, keep it neutral and scoped (for example using existing per-section timestamps only) rather than broad cross-section `Updated` language.
+
 ## Next Recommended Issue
 
-Start with [#197](https://github.com/justinrooks/project-arcus/issues/197), then [#198](https://github.com/justinrooks/project-arcus/issues/198), then [#200](https://github.com/justinrooks/project-arcus/issues/200).
+Start with [#200](https://github.com/justinrooks/project-arcus/issues/200), then [#201](https://github.com/justinrooks/project-arcus/issues/201).
 
 ## Handoff Template
 

--- a/docs/plans/resolve-forward-ui-polish-progress.md
+++ b/docs/plans/resolve-forward-ui-polish-progress.md
@@ -299,6 +299,47 @@ Date: 2026-05-27
   - transition only inner state content;
   - avoid additional whole-card dimming when a section already has an explicit resolving state.
 
+## Review Fix - [P2] Local Alerts collapses before fade completes
+
+Status: Complete
+Date: 2026-05-27
+
+### Finding Fixed
+
+- Fixed Local Alerts content-height snapping when transitioning away from populated alerts so outgoing rows can complete the intended fade without abrupt clipping/cropping.
+
+### Files Changed
+
+- `Sources/Features/Summary/ActiveAlertSummaryView.swift`
+- `docs/plans/resolve-forward-ui-polish-progress.md`
+
+### Behavior Preserved
+
+- Alert ingestion unchanged.
+- Arcus/SPC/NWS orchestration unchanged.
+- Alert sorting/filtering unchanged.
+- Refresh/loading timing unchanged.
+- What loads when unchanged.
+- Notification behavior unchanged.
+- Persistence unchanged.
+- Business logic unchanged.
+- Existing loading/empty/alerts/offline state semantics unchanged.
+- Alert Center button behavior unchanged.
+- VoiceOver grouping unchanged.
+
+### Validation
+
+- Ran: `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build`
+- Result: Success (`** BUILD SUCCEEDED **`).
+
+### Visual Validation
+
+- Manual simulator visual validation: Not run in this pass.
+
+### Remaining Risks
+
+- The transition-height hold duration tracks the current Local Alerts layer-change timing (`0.32s`, `0.01s` with Reduce Motion). If motion timing changes later, this duration should be updated to stay aligned.
+
 ## Issue #199 - Smooth Current Conditions resolve-forward updates
 
 Status: Complete

--- a/docs/plans/resolve-forward-ui-polish-progress.md
+++ b/docs/plans/resolve-forward-ui-polish-progress.md
@@ -1,0 +1,129 @@
+# Resolve-Forward UI Polish Progress
+
+This is the durable handoff ledger for GitHub issues #195 through #201.
+
+Update this file after each issue is implemented. Keep entries factual: what changed, what was validated, what was deliberately left alone, and what the next session should know.
+
+## Current Status
+
+| Order | Issue | Title | Status | Notes |
+|---|---:|---|---|---|
+| 1 | [#195](https://github.com/justinrooks/project-arcus/issues/195) | Standardize Summary resolving header language | Complete | Secondary status line stabilized to one calm global message with reduced churn. |
+| 2 | [#196](https://github.com/justinrooks/project-arcus/issues/196) | Add consistent Summary resolve-forward transition primitives | Not started | Should precede #197, #198, and #200. |
+| 3 | [#197](https://github.com/justinrooks/project-arcus/issues/197) | Polish risk badge resolve-forward transitions | Not started | Prefer after #196. |
+| 4 | [#198](https://github.com/justinrooks/project-arcus/issues/198) | Stabilize Local Alerts resolving and empty states | Not started | Prefer after #196. Read `docs/LifecycleInvestigationNotes.md`. |
+| 5 | [#199](https://github.com/justinrooks/project-arcus/issues/199) | Smooth Current Conditions resolve-forward updates | Not started | Best after #195. |
+| 6 | [#200](https://github.com/justinrooks/project-arcus/issues/200) | Normalize secondary Summary resolving states | Not started | Prefer after #196. |
+| 7 | [#201](https://github.com/justinrooks/project-arcus/issues/201) | Align cold-start resolving screen with SkyAware visual direction | Not started | Independent and intentionally last. |
+
+## Global Constraints
+
+- Visual representation only.
+- Preserve cached-first, resolve-forward behavior.
+- Preserve full-screen resolving only for true empty/no-cache startup.
+- Do not change data flow, provider behavior, refresh orchestration, refresh timing, persistence, notification behavior, or business logic.
+- Do not alter widget code unless a future issue explicitly changes the scope.
+
+## Baseline Audit Artifacts
+
+- Audit drafts: `docs/audits/resolve-forward-ui-polish-issues.md`
+- Agent playbook: `docs/plans/resolve-forward-ui-polish-playbook.md`
+- Design spec: `docs/SkyAware North Star Spec.md`
+- Full design guide: `docs/SkyAware Branding and Design Guide.md`
+- Local Alerts prior investigation: `docs/LifecycleInvestigationNotes.md`
+
+## Implementation Log
+
+## Issue #195 - Standardize Summary resolving header language
+
+Status: Complete
+Date: 2026-05-27
+
+### Scope Completed
+
+- Updated Summary resolving copy to the preferred calm language family and removed generic "everything ready" phrasing.
+- Stabilized the Summary header secondary status line to a single primary active message instead of rotating among concurrent tasks.
+- Kept recent-completion messaging subtle and non-repetitive by suppressing completion echo for `.finalizing`.
+- Ensured settled condition text reappears as soon as active resolving ends so the header reads as becoming more accurate, not reloading.
+- Updated focused unit tests for `SummaryResolutionState` status-message behavior.
+
+### Files Changed
+
+- `Sources/Features/Summary/SummaryResolving.swift`
+- `Sources/Features/Summary/SummaryStatus.swift`
+- `Sources/Features/Summary/SummaryView.swift`
+- `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+
+### Behavior Preserved
+
+- Data flow unchanged.
+- Provider behavior unchanged.
+- Refresh orchestration unchanged.
+- Refresh timing unchanged.
+- Loading timing unchanged.
+- What loads when unchanged.
+- Persistence unchanged.
+- Business logic unchanged.
+
+### Validation
+
+- Ran: `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build`
+- Result: Success (`** BUILD SUCCEEDED **`).
+- Ran: `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5" -only-testing:SkyAwareTests/HomeViewLoadingOverlayStateTests test`
+- Result: Success (`** TEST SUCCEEDED **`).
+- xcresult: `/Users/justin/Library/Developer/Xcode/DerivedData/SkyAware-agjazkpfcnuppmaofanownrwirhh/Logs/Test/Test-SkyAware-2026.05.27_11-10-42--0600.xcresult`
+- Screenshots/previews inspected: Not run in this pass.
+
+### Deferred Work
+
+- Manual visual pass in Summary previews and Simulator states (ready/loading/cached refresh/offline/location unavailable/Reduce Motion/larger Dynamic Type) remains for follow-up polish verification.
+
+### Handoff Notes
+
+- #196 should build transition primitives on top of this calmer single-message behavior; avoid reintroducing multi-message rotation in the header.
+- `primaryActiveMessage` is now the intended entry point when a single resolving message is needed.
+
+## Next Recommended Issue
+
+Start with [#195](https://github.com/justinrooks/project-arcus/issues/195), then [#196](https://github.com/justinrooks/project-arcus/issues/196).
+
+## Handoff Template
+
+Copy this section when completing an issue.
+
+```md
+## Issue #NNN - Title
+
+Status: Complete / Partial / Blocked
+Date: YYYY-MM-DD
+
+### Scope Completed
+
+- ...
+
+### Files Changed
+
+- `path/to/file.swift`
+
+### Behavior Preserved
+
+- Data flow unchanged.
+- Provider behavior unchanged.
+- Refresh timing unchanged.
+- Business logic unchanged.
+
+### Validation
+
+- Ran: `...`
+- Result: ...
+- Screenshots/previews inspected: ...
+- Not run: ... because ...
+
+### Deferred Work
+
+- ...
+
+### Handoff Notes
+
+- ...
+```

--- a/docs/plans/resolve-forward-ui-polish-progress.md
+++ b/docs/plans/resolve-forward-ui-polish-progress.md
@@ -712,3 +712,46 @@ Date: 2026-05-27
 ### Remaining Risks
 
 - Visual tone and spacing for the lighter-weight cold-start message region still needs final simulator eyes-on across smallest iPhone heights, dark mode, and large Dynamic Type to confirm perceived balance after lowering minimum height.
+
+## Follow-up - Issue #198 Local Alerts first-render collapse fix
+
+Status: Complete
+Date: 2026-05-27
+
+### Scope Completed
+
+- Reworked `ActiveAlertSummaryView` Local Alerts height-hold logic to remove timing fragility from `onChange`-only activation.
+- Added previous-state-based transition tracking with private state:
+  - `lastStableContentState`
+  - `isLeavingAlertsHeightHoldActive`
+- Kept the existing Task-based hold expiry window, cancellation on superseding transitions, and cancellation on disappear.
+- Added a focused helper used by min-height logic:
+  - `usesFlexibleAlertHeight(currentState:isLeavingAlerts:)`
+
+### Why This Closes The First-Render Hole
+
+- The first render after `.alerts -> .loading/.empty/.offline` now still sees `lastStableContentState == .alerts`, so the container stays flexible immediately.
+- This means the card does not briefly fall back to the compact 72pt minimum before the fade finishes.
+
+### Behavior Preserved
+
+- Alert data flow unchanged.
+- Alert provider behavior unchanged.
+- Refresh orchestration unchanged.
+- Loading timing unchanged.
+- Alert state selection/order unchanged.
+- Navigation and sheet behavior unchanged.
+- Row sorting, limits, and expansion behavior unchanged.
+
+### Validation
+
+- Ran: `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2" -only-testing:SkyAwareTests test`
+- Result: Success (`** TEST SUCCEEDED **`).
+- xcresult inspected via: `xcrun xcresulttool get object --legacy --format json --path ...`
+- Non-zero test count confirmed: `testsCount = 462`.
+- xcresult path:
+  - `/Users/justin/Library/Developer/Xcode/DerivedData/SkyAware-agjazkpfcnuppmaofanownrwirhh/Logs/Test/Test-SkyAware-2026.05.27_14-34-54--0600.xcresult`
+
+### Manual Visual Inspection
+
+- Not run in this pass.

--- a/docs/plans/resolve-forward-ui-polish-progress.md
+++ b/docs/plans/resolve-forward-ui-polish-progress.md
@@ -598,6 +598,30 @@ Date: 2026-05-27
 
 - Identity uses quantized coordinates + placemark summary from `LocationSnapshot`; if future requirements decouple displayed placemark from snapshot identity, this guard may need to align with a different canonical context key.
 
+### Follow-up - one-render stale pairing hole
+
+Status: Complete
+Date: 2026-05-27
+
+- What changed:
+  - `SummaryStatus` now computes one body-visible weather value (`visibleWeather`) through `SummaryStatus.resolveDisplayedWeather(...)` instead of `weather ?? displayedWeather`.
+  - All rendered weather surfaces (temperature text, symbol, condition line, and weather-linked animations/transitions) now use that identity-gated value.
+  - Expanded `SummaryStatusWeatherRetentionTests` in `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift` to cover:
+    - same identity + refreshing + live nil => retained weather
+    - different identity + refreshing + live nil => nil
+    - same identity + not refreshing + live nil => nil
+    - live weather present => live weather + current identity
+    - regression assertion for immediate clear on identity change during refresh
+- Why this closes the hole:
+  - The render path is now identity-gated during body evaluation, so SwiftUI cannot render old-location retained weather for the interim pass before `.task` retention state updates.
+- Tests run:
+  - `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2" -only-testing:SkyAwareTests test`
+  - xcresult summary checked with `xcrun xcresulttool get test-results summary ...` and `totalTestCount` is non-zero.
+- xcresult path:
+  - `/Users/justin/Library/Developer/Xcode/DerivedData/SkyAware-agjazkpfcnuppmaofanownrwirhh/Logs/Test/Test-SkyAware-2026.05.27_14-31-30--0600.xcresult`
+- Remaining visual/manual validation not performed:
+  - Manual simulator visual pass for the specific location-switch transition state was not run in this pass.
+
 ## Handoff Template
 
 Copy this section when completing an issue.

--- a/docs/plans/resolve-forward-ui-polish-progress.md
+++ b/docs/plans/resolve-forward-ui-polish-progress.md
@@ -720,17 +720,20 @@ Date: 2026-05-27
 
 ### Scope Completed
 
-- Reworked `ActiveAlertSummaryView` Local Alerts height-hold logic to remove timing fragility from `onChange`-only activation.
-- Added previous-state-based transition tracking with private state:
-  - `lastStableContentState`
-  - `isLeavingAlertsHeightHoldActive`
+- Reworked `ActiveAlertSummaryView` Local Alerts height-hold logic around an explicit private `HeightPhase` model:
+  - `.uninitialized`
+  - `.stable(ContentState)`
+  - `.leavingAlerts`
+- Removed the separate hold flag that made the first leaving-alerts render depend on `.onChange` running first.
 - Kept the existing Task-based hold expiry window, cancellation on superseding transitions, and cancellation on disappear.
 - Added a focused helper used by min-height logic:
   - `usesFlexibleAlertHeight(currentState:isLeavingAlerts:)`
 
 ### Why This Closes The First-Render Hole
 
-- The first render after `.alerts -> .loading/.empty/.offline` now still sees `lastStableContentState == .alerts`, so the container stays flexible immediately.
+- The first render after `.alerts -> .loading/.empty/.offline` now still sees `heightPhase == .stable(.alerts)`, so `isLeavingAlertsTransition` is true before `.onChange` runs.
+- After `.onChange` runs, `heightPhase` becomes `.leavingAlerts` and stays flexible until the Task-based hold expires.
+- When the hold expires, `heightPhase` advances to `.stable(contentState)`, allowing compact states to settle back to the 72pt minimum.
 - This means the card does not briefly fall back to the compact 72pt minimum before the fade finishes.
 
 ### Behavior Preserved
@@ -747,10 +750,10 @@ Date: 2026-05-27
 
 - Ran: `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2" -only-testing:SkyAwareTests test`
 - Result: Success (`** TEST SUCCEEDED **`).
-- xcresult inspected via: `xcrun xcresulttool get object --legacy --format json --path ...`
-- Non-zero test count confirmed: `testsCount = 462`.
+- xcresult inspected via: `xcrun xcresulttool get test-results summary --path ...`
+- Non-zero test count confirmed: `totalTestCount = 462`.
 - xcresult path:
-  - `/Users/justin/Library/Developer/Xcode/DerivedData/SkyAware-agjazkpfcnuppmaofanownrwirhh/Logs/Test/Test-SkyAware-2026.05.27_14-34-54--0600.xcresult`
+  - `/Users/justin/Library/Developer/Xcode/DerivedData/SkyAware-agjazkpfcnuppmaofanownrwirhh/Logs/Test/Test-SkyAware-2026.05.27_14-45-51--0600.xcresult`
 
 ### Manual Visual Inspection
 

--- a/docs/plans/resolve-forward-ui-polish-progress.md
+++ b/docs/plans/resolve-forward-ui-polish-progress.md
@@ -11,7 +11,7 @@ Update this file after each issue is implemented. Keep entries factual: what cha
 | 1 | [#195](https://github.com/justinrooks/project-arcus/issues/195) | Standardize Summary resolving header language | Complete | Secondary status line stabilized to one calm global message with reduced churn. |
 | 2 | [#196](https://github.com/justinrooks/project-arcus/issues/196) | Add consistent Summary resolve-forward transition primitives | Complete | Added small shared resolve-forward style primitive and normalized Summary section resolve transitions. |
 | 3 | [#197](https://github.com/justinrooks/project-arcus/issues/197) | Polish risk badge resolve-forward transitions | Complete | Added badge-local resolve placeholders and calm content crossfades while keeping risk semantics unchanged. |
-| 4 | [#198](https://github.com/justinrooks/project-arcus/issues/198) | Stabilize Local Alerts resolving and empty states | Not started | Prefer after #196. Read `docs/LifecycleInvestigationNotes.md`. |
+| 4 | [#198](https://github.com/justinrooks/project-arcus/issues/198) | Stabilize Local Alerts resolving and empty states | Complete | Local Alerts keeps a stable container with inner-state crossfade, clearer copy, and cleaner offline VoiceOver grouping. |
 | 5 | [#199](https://github.com/justinrooks/project-arcus/issues/199) | Smooth Current Conditions resolve-forward updates | Not started | Best after #195. |
 | 6 | [#200](https://github.com/justinrooks/project-arcus/issues/200) | Normalize secondary Summary resolving states | Not started | Prefer after #196. |
 | 7 | [#201](https://github.com/justinrooks/project-arcus/issues/201) | Align cold-start resolving screen with SkyAware visual direction | Not started | Independent and intentionally last. |
@@ -241,6 +241,63 @@ Date: 2026-05-27
   - Keep using `SummaryResolveForwardStyle.subtle` as the default when content is already present and refining.
   - Prefer section-local resolving placeholders over fallback semantic content + heavy redaction when unresolved state could imply a false calm.
   - If additional resolve-forward placeholders are added elsewhere, match this badge pattern: neutral surface, stable dimensions, concise progressive language, and restrained transitions.
+
+## Issue #198 - Stabilize Local Alerts resolving and empty states
+
+Status: Complete
+Date: 2026-05-27
+
+### Scope Completed
+
+- Kept `ActiveAlertSummaryView` as the single Local Alerts presentation container and preserved its existing explicit content states (`loading`, `empty`, `alerts`, `offline`).
+- Stabilized inner-state transition rendering by routing state swaps through a dedicated `contentStateContainer` `ZStack` so only the content region crossfades while the card container stays visually stable.
+- Preserved and clarified resolve-forward tone with distinct checking vs no-alert states:
+  - checking: `Checking local alerts` + `Bringing in local alerts…`
+  - empty: `No Active Alerts` + calm explanatory copy
+- Fixed user-facing copy defect in alert section label: `Watches & Warningso` -> `Watches & Warnings`.
+- Improved VoiceOver grouping for offline state by combining label + message into a single accessibility element, matching the loading/empty treatment.
+
+### Files Changed
+
+- `Sources/Features/Summary/ActiveAlertSummaryView.swift`
+- `docs/plans/resolve-forward-ui-polish-progress.md`
+
+### Behavior Preserved
+
+- Alert ingestion unchanged.
+- Arcus/SPC/NWS orchestration unchanged.
+- Alert sorting/filtering unchanged.
+- Refresh timing unchanged.
+- Loading timing unchanged.
+- What loads when unchanged.
+- Notification behavior unchanged.
+- Persistence unchanged.
+- Business logic unchanged.
+- Existing alert row interactions, detail sheets, and Alert Center navigation behavior unchanged.
+- Offline-vs-cached alert behavior unchanged.
+
+### Validation
+
+- Ran: `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build`
+- Result: Success (`** BUILD SUCCEEDED **`).
+- Ran: `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5" -only-testing:SkyAwareTests/HomeViewLoadingOverlayStateTests test`
+- Result: Success (`** TEST SUCCEEDED **`).
+- xcresult: `/Users/justin/Library/Developer/Xcode/DerivedData/SkyAware-agjazkpfcnuppmaofanownrwirhh/Logs/Test/Test-SkyAware-2026.05.27_11-33-05--0600.xcresult`
+
+### Validation Not Run
+
+- Manual simulator visual matrix for all requested Local Alerts states (checking, no-alert, watches-only, mesos-only, mixed, offline, location unavailable, cached refresh), Reduce Motion, larger Dynamic Type, and VoiceOver playback was not run in this pass.
+
+### Deferred Work
+
+- Perform a manual visual QA pass across the Local Alerts state matrix to confirm transition feel under real runtime state changes (especially empty -> populated with multiple rows and dynamic type edge sizes).
+
+### Handoff Notes
+
+- For #200, reuse the same section pattern used here:
+  - keep a stable outer card/container;
+  - transition only inner state content;
+  - avoid additional whole-card dimming when a section already has an explicit resolving state.
 
 ## Next Recommended Issue
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -10,3 +10,7 @@
 
 - During final reviews, distinguish written brief language from later accepted platform/product decisions in the implementation and progress log before labeling behavior as a blocker.
 - For FB-017 widgets, preserve the intentional choices that watches outrank mesoscale discussions, small widgets omit visible freshness to stay single-signal, and freshness copy avoids `Updated` language.
+
+## 2026-05-27
+
+- For SwiftUI transition-state fixes, do not gate the first render of a new input state on state that is only set from `onChange`; derive first-frame behavior from the previous stable phase already held in `@State`, then let `onChange` advance the phase for the remainder of the transition.


### PR DESCRIPTION
# Summary
This branch refines resolve-forward behavior across Summary and Local Alerts so loading, stale, empty, and recovered states transition consistently and avoid first-render/layout regressions. It also updates related docs and unit-test coverage for loading overlay behavior.

# What Changed
- Standardized Summary resolving header language and transition primitives to normalize state progression.
- Updated Summary status and loading UI paths to reduce stale/resolving mismatches and align cold-start behavior with product direction.
- Stabilized Local Alerts resolving, empty, and first-render layout behavior, including height retention timing issues.
- Polished weather risk and severe/fire/atmosphere badge transitions during resolve-forward updates.
- Added and expanded unit test coverage in HomeView loading overlay state tests.
- Added/updated resolve-forward audit and planning docs plus lessons notes tied to this work.

# User Impact
Users should see more stable and coherent loading/resolving behavior in Summary and Local Alerts, with fewer confusing intermediate states and fewer visual jumps during data refresh and first render.

# Testing
- No test execution evidence was found in this branch history.
- Unit test files were updated: `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`.

# Notes
- PR scope is based on committed branch changes from merge-base to `HEAD`.
- Local uncommitted audit-doc changes in the working tree were intentionally excluded from this PR scope.