### PR TITLE
Fix Today refresh invalidation and stale alert focus

### DIFF
--- a/Sources/App/HomeView.swift
+++ b/Sources/App/HomeView.swift
@@ -243,6 +243,9 @@ struct HomeView: View {
                                     showsLoading: true,
                                     environment: refreshEnvironment
                                 )
+                            },
+                            onFocusedAlertRequestHandled: { requestID in
+                                remoteAlertPresentationState.clearFocusRequest(id: requestID)
                             }
                         )
                         .background(.skyAwareBackground)

--- a/Sources/App/HomeView.swift
+++ b/Sources/App/HomeView.swift
@@ -29,7 +29,6 @@ struct HomeView: View {
     @State private var refreshPipeline: HomeRefreshPipeline
     @State private var selectedTab: HomeTab = .today
     @State private var selectedMapLayer: MapLayer = .categorical
-    @State private var todayHeaderCondenseProgress: CGFloat = 0
     @State private var showsLocationReliabilityRail: Bool = false
     @State private var locationReliabilityRailQualifyingDay: String?
     @State private var locationReliabilityRailLastEligibilityReason: LocationReliabilitySummaryRailEligibilityReason?
@@ -202,29 +201,33 @@ struct HomeView: View {
 
             TabView(selection: $selectedTab) {
                 Tab("Today", systemImage: "clock.arrow.trianglehead.clockwise.rotate.90.path.dotted", value: .today) {
-                    NavigationStack {
-                        ScrollView {
-                            summaryContentView
-                            .toolbar(.hidden, for: .navigationBar)
-                            .background(.skyAwareBackground)
-                        }
-                        .onScrollGeometryChange(for: CGFloat.self) { geometry in
-                            geometry.contentOffset.y + geometry.contentInsets.top
-                        } action: { _, newValue in
-                            let normalizedProgress = min(max((newValue - 6) / 68, 0), 1)
-                            if abs(todayHeaderCondenseProgress - normalizedProgress) > 0.001 {
-                                todayHeaderCondenseProgress = normalizedProgress
-                            }
-                        }
-                        .background(Color(.skyAwareBackground).ignoresSafeArea())
-                        .refreshable {
-                            await refreshPipeline.forceRefreshCurrentContext(
-                                showsLoading: true,
-                                environment: refreshEnvironment
+                    TodayTabView(
+                        snap: displayedLocationSnapshot,
+                        stormRisk: displayedStormRisk,
+                        severeRisk: displayedSevereRisk,
+                        fireRisk: displayedFireRisk,
+                        mesos: displayedMesos,
+                        alerts: displayedAlerts,
+                        outlook: displayedOutlook,
+                        weather: displayedWeather,
+                        readinessState: readinessState,
+                        resolutionState: refreshPipeline.resolutionState,
+                        showsOfflineToken: runtimeConnectivityState.isOffline,
+                        locationReliabilityRailState: showsLocationReliabilityRail
+                            ? SummaryView.LocationReliabilityRailState(
+                                onOpen: openLocationReliabilityRail,
+                                onDismiss: dismissLocationReliabilityRailForToday
                             )
-                        }
+                            : nil,
+                        onOpenMapLayer: openMap,
+                        onOpenAlerts: openAlertsTab,
+                        onOpenOutlooks: openOutlooksTab
+                    ) {
+                        await refreshPipeline.forceRefreshCurrentContext(
+                            showsLoading: true,
+                            environment: refreshEnvironment
+                        )
                     }
-                    .background(Color(.skyAwareBackground).ignoresSafeArea())
                 }
 
                 Tab("Alerts", systemImage: "exclamationmark.triangle", value: .alerts) {
@@ -360,47 +363,6 @@ struct HomeView: View {
 }
 
 extension HomeView {
-    @ViewBuilder
-    private var summaryContentView: some View {
-        let snap = displayedLocationSnapshot
-        let stormRisk = displayedStormRisk
-        let severeRisk = displayedSevereRisk
-        let fireRisk = displayedFireRisk
-        let mesos = displayedMesos
-        let alerts = displayedAlerts
-        let outlook = displayedOutlook
-        let weather = displayedWeather
-        let readiness = readinessState
-        let resolution = refreshPipeline.resolutionState
-        let isOffline = runtimeConnectivityState.isOffline
-        let condenseProgress = todayHeaderCondenseProgress
-        let railState = showsLocationReliabilityRail
-            ? SummaryView.LocationReliabilityRailState(
-                onOpen: openLocationReliabilityRail,
-                onDismiss: dismissLocationReliabilityRailForToday
-            )
-            : nil
-
-        SummaryView(
-            snap: snap,
-            stormRisk: stormRisk,
-            severeRisk: severeRisk,
-            fireRisk: fireRisk,
-            mesos: mesos,
-            alerts: alerts,
-            outlook: outlook,
-            weather: weather,
-            readinessState: readiness,
-            resolutionState: resolution,
-            showsOfflineToken: isOffline,
-            headerCondenseProgress: condenseProgress,
-            locationReliabilityRailState: railState,
-            onOpenMapLayer: openMap,
-            onOpenAlerts: openAlertsTab,
-            onOpenOutlooks: openOutlooksTab
-        )
-    }
-
     private func openMap(_ layer: MapLayer) {
         selectedMapLayer = layer
         selectedTab = .map
@@ -615,6 +577,67 @@ extension HomeView {
         LocationReliabilityAskLedger.live().recordSameDaySuppression(qualifyingDay: qualifyingDay)
     }
 
+}
+
+private struct TodayTabView: View {
+    @State private var headerCondenseProgress: CGFloat = 0
+
+    let snap: LocationSnapshot?
+    let stormRisk: StormRiskLevel?
+    let severeRisk: SevereWeatherThreat?
+    let fireRisk: FireRiskLevel?
+    let mesos: [MdDTO]
+    let alerts: [AlertDTO]
+    let outlook: ConvectiveOutlookDTO?
+    let weather: SummaryWeather?
+    let readinessState: SummaryReadinessState
+    let resolutionState: SummaryResolutionState
+    let showsOfflineToken: Bool
+    let locationReliabilityRailState: SummaryView.LocationReliabilityRailState?
+    let onOpenMapLayer: (MapLayer) -> Void
+    let onOpenAlerts: () -> Void
+    let onOpenOutlooks: () -> Void
+    let refreshAction: () async -> Void
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                SummaryView(
+                    snap: snap,
+                    stormRisk: stormRisk,
+                    severeRisk: severeRisk,
+                    fireRisk: fireRisk,
+                    mesos: mesos,
+                    alerts: alerts,
+                    outlook: outlook,
+                    weather: weather,
+                    readinessState: readinessState,
+                    resolutionState: resolutionState,
+                    showsOfflineToken: showsOfflineToken,
+                    headerCondenseProgress: headerCondenseProgress,
+                    locationReliabilityRailState: locationReliabilityRailState,
+                    onOpenMapLayer: onOpenMapLayer,
+                    onOpenAlerts: onOpenAlerts,
+                    onOpenOutlooks: onOpenOutlooks
+                )
+                    .toolbar(.hidden, for: .navigationBar)
+                    .background(.skyAwareBackground)
+            }
+            .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                geometry.contentOffset.y + geometry.contentInsets.top
+            } action: { _, newValue in
+                let normalizedProgress = min(max((newValue - 6) / 68, 0), 1)
+                if abs(headerCondenseProgress - normalizedProgress) > 0.001 {
+                    headerCondenseProgress = normalizedProgress
+                }
+            }
+            .background(Color(.skyAwareBackground).ignoresSafeArea())
+            .refreshable {
+                await refreshAction()
+            }
+        }
+        .background(Color(.skyAwareBackground).ignoresSafeArea())
+    }
 }
 
 #Preview("Home") {

--- a/Sources/App/RemoteHotAlertHandler.swift
+++ b/Sources/App/RemoteHotAlertHandler.swift
@@ -25,6 +25,11 @@ final class RemoteAlertPresentationState {
     func present(alertID: String, alert: AlertDTO?) {
         focusRequest = RemoteAlertFocusRequest(alertID: alertID, alert: alert)
     }
+
+    func clearFocusRequest(id: RemoteAlertFocusRequest.ID?) {
+        guard let id, focusRequest?.id == id else { return }
+        focusRequest = nil
+    }
 }
 
 actor RemoteHotAlertHandler {

--- a/Sources/App/SkyAwareApp.swift
+++ b/Sources/App/SkyAwareApp.swift
@@ -299,6 +299,7 @@ private extension SkyAwareApp {
 
     static var uiTestSeedWatches: [AlertDTO] {
         let issued = Date().addingTimeInterval(-1_800)
+        let olderIssued = Date().addingTimeInterval(-2_400)
         let ends = Date().addingTimeInterval(7_200)
         return [
             AlertDTO(
@@ -324,6 +325,35 @@ private extension SkyAwareApp {
                 tornadoDamageThreat: "Possible",
                 maxWindGust: "70",
                 maxHailSize: "1.00",
+                windThreat: nil,
+                hailThreat: nil,
+                thunderstormDamageThreat: nil,
+                flashFloodDetection: nil,
+                flashFloodDamageThreat: nil
+            ),
+            AlertDTO(
+                id: "ui-test-watch-002",
+                messageId: "ui-test-watch-message-002",
+                currentRevisionSent: olderIssued,
+                title: "UI Test Fire Weather Watch",
+                headline: "UI Test Fire Weather Watch Headline",
+                issued: olderIssued,
+                expires: ends,
+                ends: ends,
+                messageType: "Alert",
+                sender: "NWS Test Office",
+                severity: "Moderate",
+                urgency: "Expected",
+                certainty: "Likely",
+                description: "Second UI test watch description for alert center navigation validation.",
+                instruction: "Avoid activities that could start fires.",
+                response: "Monitor",
+                areaSummary: "UI Test Fire Zone",
+                geometryData: nil,
+                tornadoDetection: nil,
+                tornadoDamageThreat: nil,
+                maxWindGust: nil,
+                maxHailSize: nil,
                 windThreat: nil,
                 hailThreat: nil,
                 thunderstormDamageThreat: nil,

--- a/Sources/Features/Alert/AlertView.swift
+++ b/Sources/Features/Alert/AlertView.swift
@@ -14,6 +14,7 @@ struct AlertView: View {
     let alerts: [AlertDTO]
     let focusedAlertRequest: RemoteAlertFocusRequest?
     let onRefresh: (() async -> Void)?
+    let onFocusedAlertRequestHandled: ((RemoteAlertFocusRequest.ID) -> Void)?
     
     @State private var selectedAlert: AlertDTO?
     
@@ -59,12 +60,14 @@ struct AlertView: View {
         mesos: [MdDTO],
         alerts: [AlertDTO],
         focusedAlertRequest: RemoteAlertFocusRequest? = nil,
-        onRefresh: (() async -> Void)? = nil
+        onRefresh: (() async -> Void)? = nil,
+        onFocusedAlertRequestHandled: ((RemoteAlertFocusRequest.ID) -> Void)? = nil
     ) {
         self.mesos = mesos
         self.alerts = alerts
         self.focusedAlertRequest = focusedAlertRequest
         self.onRefresh = onRefresh
+        self.onFocusedAlertRequestHandled = onFocusedAlertRequestHandled
     }
     
     var body: some View {
@@ -132,8 +135,9 @@ struct AlertView: View {
             await onRefresh()
         }
         .task(id: focusedAlertRequest?.id) {
-            guard let focusedAlert = focusedAlertRequest?.alert else { return }
+            guard let focusedAlertRequest, let focusedAlert = focusedAlertRequest.alert else { return }
             selectedAlert = focusedAlert
+            onFocusedAlertRequestHandled?(focusedAlertRequest.id)
         }
         .scrollIndicators(.hidden)
         .background(Color(.skyAwareBackground).ignoresSafeArea())

--- a/Sources/Features/Alert/AlertView.swift
+++ b/Sources/Features/Alert/AlertView.swift
@@ -15,7 +15,6 @@ struct AlertView: View {
     let focusedAlertRequest: RemoteAlertFocusRequest?
     let onRefresh: (() async -> Void)?
     
-    @State private var selectedMeso: MdDTO?
     @State private var selectedAlert: AlertDTO?
     
     private var hasNoAlerts: Bool {
@@ -80,8 +79,8 @@ struct AlertView: View {
                         symbol: "exclamationmark.triangle.fill"
                     ) {
                         ForEach(sortedAlerts) { alert in
-                            Button {
-                                selectedAlert = alert
+                            NavigationLink {
+                                alertDetail(for: alert)
                             } label: {
                                 AlertRowView(alert: alert)
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -106,8 +105,8 @@ struct AlertView: View {
                         symbol: "waveform.path.ecg"
                     ) {
                         ForEach(sortedMesos) { meso in
-                            Button {
-                                selectedMeso = meso
+                            NavigationLink {
+                                mesoDetail(for: meso)
                             } label: {
                                 AlertRowView(alert: meso)
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -139,30 +138,35 @@ struct AlertView: View {
         .scrollIndicators(.hidden)
         .background(Color(.skyAwareBackground).ignoresSafeArea())
         .navigationDestination(item: $selectedAlert) { alert in
-            ScrollView {
-                AlertDetailView(alert: alert, layout: .full)
-                    .padding(.top, 8)
-                    .padding(.bottom, 24)
-            }
-            .accessibilityIdentifier("alert-center-watch-detail-view")
-            .scrollContentBackground(.hidden)
-            .background(.skyAwareBackground)
-            .navigationTitle("Weather Alert")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbarBackground(.skyAwareBackground, for: .navigationBar)
+            alertDetail(for: alert)
         }
-        .navigationDestination(item: $selectedMeso) { meso in
-            ScrollView {
-                MesoscaleDiscussionCard(meso: meso, layout: .full)
-                    .padding(.top, 8)
-                    .padding(.bottom, 24)
-            }
-            .scrollContentBackground(.hidden)
-            .background(.skyAwareBackground)
-            .navigationTitle("Mesoscale Discussion")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbarBackground(.skyAwareBackground, for: .navigationBar)
+    }
+
+    private func alertDetail(for alert: AlertDTO) -> some View {
+        ScrollView {
+            AlertDetailView(alert: alert, layout: .full)
+                .padding(.top, 8)
+                .padding(.bottom, 24)
         }
+        .accessibilityIdentifier("alert-center-watch-detail-view")
+        .scrollContentBackground(.hidden)
+        .background(.skyAwareBackground)
+        .navigationTitle("Weather Alert")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.skyAwareBackground, for: .navigationBar)
+    }
+
+    private func mesoDetail(for meso: MdDTO) -> some View {
+        ScrollView {
+            MesoscaleDiscussionCard(meso: meso, layout: .full)
+                .padding(.top, 8)
+                .padding(.bottom, 24)
+        }
+        .scrollContentBackground(.hidden)
+        .background(.skyAwareBackground)
+        .navigationTitle("Mesoscale Discussion")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.skyAwareBackground, for: .navigationBar)
     }
     
     private var overviewCard: some View {

--- a/Tests/UITests/SkyAwareUITests.swift
+++ b/Tests/UITests/SkyAwareUITests.swift
@@ -205,6 +205,38 @@ final class SkyAwareUITests: XCTestCase {
     }
 
     @MainActor
+    func testAlertCenterSecondAlertTapPushesExpectedDetailAndBackReturnsToList() throws {
+        let app = XCUIApplication()
+        app.launchEnvironment["UI_TESTS_FORCE_ONBOARDING_COMPLETE"] = "1"
+        app.launchEnvironment["UI_TESTS_LOCATION_AUTH_MODE"] = "authorized"
+        app.launchEnvironment["UI_TESTS_SUPPRESS_LOCATION_RESTRICTED_SHEET"] = "1"
+        app.launchEnvironment["UI_TESTS_STATIC_HOME"] = "1"
+        app.launch()
+
+        let alertsTab = app.tabBars.buttons["Alerts"]
+        XCTAssertTrue(alertsTab.waitForExistence(timeout: 10), "Expected Alerts tab to exist.")
+        alertsTab.tap()
+
+        let secondAlertRow = app.buttons["alert-center-watch-row-ui-test-watch-002"]
+        XCTAssertTrue(secondAlertRow.waitForExistence(timeout: 10), "Expected second seeded alert row to appear.")
+        secondAlertRow.tap()
+
+        XCTAssertTrue(app.navigationBars["Weather Alert"].waitForExistence(timeout: 10), "Expected second alert tap to push detail.")
+        XCTAssertTrue(
+            app.staticTexts["UI Test Fire Weather Watch"].waitForExistence(timeout: 10),
+            "Expected detail to show the second alert, not a stale first alert selection."
+        )
+
+        let backButton = app.navigationBars["Weather Alert"].buttons["Active Alerts"]
+        XCTAssertTrue(backButton.waitForExistence(timeout: 10), "Expected back button to return to the alert list.")
+        backButton.tap()
+
+        XCTAssertTrue(app.navigationBars["Active Alerts"].waitForExistence(timeout: 10), "Expected Back to return to the alert list.")
+        XCTAssertTrue(secondAlertRow.waitForExistence(timeout: 10), "Expected second alert row to remain available after returning.")
+        XCTAssertFalse(app.navigationBars["Weather Alert"].exists, "Back should not reveal a queued stale alert detail.")
+    }
+
+    @MainActor
     func testSummaryReliabilityRailOpensExplanationSheetAndNotNowDismisses() throws {
         let app = XCUIApplication()
         app.launchEnvironment["UI_TESTS_FORCE_ONBOARDING_COMPLETE"] = "1"

--- a/Tests/UnitTests/RemoteHotAlertHandlerTests.swift
+++ b/Tests/UnitTests/RemoteHotAlertHandlerTests.swift
@@ -67,6 +67,26 @@ struct RemoteHotAlertHandlerTests {
         #expect(context?.revisionSent == Date(timeIntervalSinceReferenceDate: 802_204_200))
     }
 
+    @Test("numeric APNs revision date decodes from standard epoch seconds")
+    func numericAPNsRevisionDateDecodesFromStandardEpochSeconds() {
+        let userInfo: [AnyHashable: Any] = [
+            "aps": [
+                "alert": [
+                    "title": "Tornado Warning",
+                    "subtitle": "Includes your location",
+                    "body": "Tornado danger in your area."
+                ]
+            ],
+            "arcusAlertId": "99999999-8888-7777-6666-555555555555",
+            "revisionSent": NSNumber(value: 1_711_282_900)
+        ]
+
+        let context = HomeRemoteAlertContext(userInfo: userInfo)
+
+        #expect(context?.alertID == "99999999-8888-7777-6666-555555555555")
+        #expect(context?.revisionSent == Date(timeIntervalSince1970: 1_711_282_900))
+    }
+
     @Test("background receipt maps to newData when the targeted alert becomes locally available")
     func backgroundReceipt_returnsNewData() async throws {
         let revisionSent = Date(timeIntervalSince1970: 1_776_438_000)

--- a/Tests/UnitTests/RemoteHotAlertHandlerTests.swift
+++ b/Tests/UnitTests/RemoteHotAlertHandlerTests.swift
@@ -184,6 +184,35 @@ struct RemoteHotAlertHandlerTests {
         #expect(await widgetDriver.refreshCallCount() == 1)
     }
 
+    @Test("presentation state clears the matching focus request after it is consumed")
+    @MainActor
+    func presentationStateClearsMatchingFocusRequest() {
+        let state = RemoteAlertPresentationState()
+        let alert = makeAlert(id: "alert-open", revisionSent: Date(timeIntervalSince1970: 1_776_438_000))
+        state.present(alertID: "alert-open", alert: alert)
+        let requestID = state.focusRequest?.id
+
+        state.clearFocusRequest(id: requestID)
+
+        #expect(state.focusRequest == nil)
+    }
+
+    @Test("presentation state keeps newer focus request when an older request is consumed")
+    @MainActor
+    func presentationStateKeepsNewerFocusRequest() throws {
+        let state = RemoteAlertPresentationState()
+        let firstAlert = makeAlert(id: "first-alert", revisionSent: Date(timeIntervalSince1970: 1_776_438_000))
+        let secondAlert = makeAlert(id: "second-alert", revisionSent: Date(timeIntervalSince1970: 1_776_438_100))
+        state.present(alertID: "first-alert", alert: firstAlert)
+        let firstRequestID = try #require(state.focusRequest?.id)
+        state.present(alertID: "second-alert", alert: secondAlert)
+
+        state.clearFocusRequest(id: firstRequestID)
+
+        #expect(state.focusRequest?.alertID == "second-alert")
+        #expect(state.focusRequest?.alert == secondAlert)
+    }
+
     @Test("remote notification returns newData when widget snapshot refresh fails")
     func backgroundReceipt_refreshFailureDoesNotChangeApnsResult() async {
         let revisionSent = Date(timeIntervalSince1970: 1_776_438_000)

--- a/docs/audits/weekly-contract-drift-audit.md
+++ b/docs/audits/weekly-contract-drift-audit.md
@@ -33,3 +33,26 @@
 - Recommended fix: Update `arcus-signal/docs/api-endpoints.md` `source` enum documentation to include expanded values (`foregroundPrime`, `foregroundActivate`, `foregroundLocationChange`, `manualRefresh`, `backgroundLocationChange`, `onboarding`, `settingsPreference`) and note backward compatibility with legacy values
 - Watchlist items: Device preference sync response date decoding still relies on ISO-8601 assumptions across Vapor/client; add explicit contract test if this endpoint is consumed beyond best-effort decode
 - Implementation recommended: Yes (documentation contract correction)
+
+## 2026-06-08
+- Audit mode: Cross-repo orchestration mode
+- Repos scanned: SkyAware (`/Users/justin/Code/project-arcus`), arcus-signal (`/Users/justin/Code/arcus-signal`), ArcusCore (`/Users/justin/Code/ArcusCore`)
+- Commit window:
+  - SkyAware `36ce30a..4bea901` (`384fcb0`, `47e074c`, `ab86f7e`, `4bea901`)
+  - arcus-signal `9d1caca..12a69c1` (`49ece86` through `12a69c1`)
+  - ArcusCore `ebd690e..HEAD` (no commits; current shared contracts inspected as reference)
+- Contract surfaces inspected: APNs hot-alert payload keys/date encoding, targeted alert lookup query contract, location snapshot source enum/documentation, device presence persistence and source constraints, new Storm Setup route/response DTOs, alert payload builders, Meso DTO legacy decode compatibility
+- Files inspected:
+  - SkyAware: `Sources/App/RemoteHotAlertHandler.swift`, `Tests/UnitTests/RemoteHotAlertHandlerTests.swift`, `Sources/Clients/ArcusClient.swift`, `Sources/Models/Meso/MdDTO.swift`, `Tests/UnitTests/MdDTOCodableCompatibilityTests.swift`, `Sources/Infrastructure/Location/LocationSnapshotPusher.swift`, `Sources/Infrastructure/Location/HTTPLocationSnapshotUploader.swift`, `Sources/Infrastructure/Location/HTTPDevicePreferenceSyncUploader.swift`
+  - arcus-signal: `Sources/App/configure.swift`, `Sources/App/Jobs/NotificationSendJob.swift`, `Sources/App/Clients/APNsClient.swift`, `Sources/App/Controllers/DeviceController.swift`, `Sources/App/Controllers/StormSetupController.swift`, `Sources/App/StormSetup/StormSetupModels.swift`, `Sources/App/Models/Device/DevicePresenceModel.swift`, `Sources/App/Migrations/UpdateDevicePresenceSourceConstraintForExpandedLocationUploadSources.swift`, `Sources/App/Controllers/AlertsController.swift`, `Sources/App/Models/API/AlertSeriesRow.swift`, `Sources/App/Models/NWS/ArcusSeriesModel.swift`, `docs/api-endpoints.md`
+  - ArcusCore: `Sources/ArcusCore/HotAlertAPNsPayload.swift`, `Sources/ArcusCore/DeviceAlertPayload.swift`, `Sources/ArcusCore/LocationSnapshotPushPayload.swift`, `Sources/ArcusCore/LocationUploadSource.swift`, `Sources/ArcusCore/DevicePreferenceSyncPayload.swift`, `Tests/ArcusCoreTests/ArcusCoreTests.swift`
+- Top finding: APNs `HotAlertAPNsPayload.revisionSent` still has server encoder drift. New SkyAware evidence in `384fcb0` added numeric APNs date fallback tests (`Tests/UnitTests/RemoteHotAlertHandlerTests.swift`) while ArcusCore still defines ISO-8601 shared contract tests and arcus-signal still registers APNs containers with plain `JSONEncoder()` in `Sources/App/configure.swift`.
+- Recommended fix: In arcus-signal, use an APNs request encoder configured with `dateEncodingStrategy = .iso8601` for both sandbox and production containers, then add an APNs payload encoding contract test around `HotAlertAPNsPayload`.
+- Watchlist items:
+  - New `GET /api/v1/storm-setup/current?h3=` returns `TornadoIngredientSnapshot`, but no SkyAware or ArcusCore consumer/shared contract was found. Promote only after client/shared model evidence exists or endpoint docs/specs declare a stable public contract.
+  - `arcus-signal/docs/api-endpoints.md` still lists stale location snapshot `source` values; this is the unresolved 2026-06-01 documentation contract finding, not a new finding.
+- Implementation recommended: Yes, for the APNs encoder contract fix.
+- Resolution notes:
+  - `arcus-signal` now uses a dedicated APNs request encoder with `dateEncodingStrategy = .iso8601` for both sandbox and production containers.
+  - Added a focused App test that encodes `HotAlertAPNsPayload` through the shared APNs request encoder and verifies `revisionSent` emits ISO-8601.
+  - This keeps `HotAlertAPNsPayload` aligned with the ArcusCore shared decode contract and removes the server-side date encoding drift.

--- a/docs/audits/weekly-performance-audit.md
+++ b/docs/audits/weekly-performance-audit.md
@@ -19,3 +19,20 @@
 - implementation notes:
   - Replaced `nil -> context` reset pattern with `applyResolvedContext(_:)` in `LocationSession`.
   - Added refresh-key guard to skip `currentContext` reassignment when location scope identity is unchanged.
+
+## 2026-06-07
+- workflow reviewed: Foreground Refresh and UI State Propagation
+- files inspected:
+  - Sources/App/HomeView.swift
+  - Sources/App/HomeRefreshPipeline.swift
+  - Sources/Features/Summary/SummaryView.swift
+  - Sources/Features/Summary/SummaryStatus.swift
+  - Sources/Features/Summary/ActiveAlertSummaryView.swift
+- top finding: `HomeView` stores Today tab scroll-condense progress at the shell root, so every scroll tick invalidates the entire five-tab container and recomputes unrelated derived state such as cached outlook DTO mapping and projection selection.
+- best next fix: move `todayHeaderCondenseProgress` into the Today-tab subtree, or into `SummaryView`, so scroll-driven updates only invalidate the visible summary header instead of the whole `TabView`.
+- measurement gap: profile `HomeView` and `SummaryView` body recomputation counts while scrolling the Today tab to quantify fan-out and confirm whether the root-shell invalidation is visible in Instruments.
+- implementation recommended: yes
+- implementation status: completed on 2026-06-07
+- implementation notes:
+  - Moved Today scroll-condense state into a dedicated `TodayTabView` subtree in `HomeView`.
+  - Kept the visible behavior intact while preventing scroll progress from invalidating the full five-tab shell.

--- a/docs/audits/weekly-test-gap-audit.md
+++ b/docs/audits/weekly-test-gap-audit.md
@@ -18,3 +18,14 @@
 - Watchlist items:
   - `arcus-signal` source-constraint migration now allows expanded upload sources, but current coverage only smoke-tests `foregroundPrime`; the rest are not directly exercised through `POST /api/v1/devices/location-snapshots`.
 - Implementation recommended: Completed (regression test added in `Tests/UnitTests/LocationProviderTests.swift`)
+
+## 2026-06-09
+- Repository reviewed: project-arcus (`/Users/justin/Code/project-arcus`)
+- Commit window inspected: since `2026-06-02T15:07:36.770Z` through `2026-06-09`; commits inspected included `384fcb0ab4ac7b123786d50cecdb7dd8e5ce80d3` through `21a670b3cfd88452985604fd7dd296d9fac47386`
+- High-risk areas inspected: remote alert context date parsing, APNs hot-alert handling, `MdDTO` compatibility decoding, persisted location upload queue decoding, diagnostics handling
+- Files inspected: `Sources/App/RemoteHotAlertHandler.swift`, `Sources/Models/Meso/MdDTO.swift`, `Sources/Infrastructure/Location/LocationSnapshotPusher.swift`, `Tests/UnitTests/RemoteHotAlertHandlerTests.swift`, `Tests/UnitTests/MdDTOCodableCompatibilityTests.swift`, `Tests/UnitTests/LocationProviderTests.swift`
+- Existing relevant tests found: `Tests/UnitTests/RemoteHotAlertHandlerTests.swift`, `Tests/UnitTests/MdDTOCodableCompatibilityTests.swift`, `Tests/UnitTests/LocationProviderTests.swift`
+- Top recommended test: `RemoteHotAlertHandlerTests.numericAPNsRevisionDateDecodesFromStandardEpochSeconds` to lock the non-reference-date branch in `HomeRemoteAlertContext.normalizedDate(from:)`
+- Watchlist items: none
+- Implementation recommended: No
+- Out-of-scope repositories intentionally not scanned: none

--- a/docs/audits/weekly-test-gap-audit.md
+++ b/docs/audits/weekly-test-gap-audit.md
@@ -25,7 +25,8 @@
 - High-risk areas inspected: remote alert context date parsing, APNs hot-alert handling, `MdDTO` compatibility decoding, persisted location upload queue decoding, diagnostics handling
 - Files inspected: `Sources/App/RemoteHotAlertHandler.swift`, `Sources/Models/Meso/MdDTO.swift`, `Sources/Infrastructure/Location/LocationSnapshotPusher.swift`, `Tests/UnitTests/RemoteHotAlertHandlerTests.swift`, `Tests/UnitTests/MdDTOCodableCompatibilityTests.swift`, `Tests/UnitTests/LocationProviderTests.swift`
 - Existing relevant tests found: `Tests/UnitTests/RemoteHotAlertHandlerTests.swift`, `Tests/UnitTests/MdDTOCodableCompatibilityTests.swift`, `Tests/UnitTests/LocationProviderTests.swift`
-- Top recommended test: `RemoteHotAlertHandlerTests.numericAPNsRevisionDateDecodesFromStandardEpochSeconds` to lock the non-reference-date branch in `HomeRemoteAlertContext.normalizedDate(from:)`
+- Top recommended test: `RemoteHotAlertHandlerTests.numericAPNsRevisionDateDecodesFromStandardEpochSeconds` to lock the non-reference-date branch in `HomeRemoteAlertContext.normalizedDate(from:)` (implemented in `Tests/UnitTests/RemoteHotAlertHandlerTests.swift`)
 - Watchlist items: none
-- Implementation recommended: No
+- Validation note: `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2" -only-testing:SkyAwareTests/RemoteHotAlertHandlerTests test` passed on 2026-06-09.
+- Implementation recommended: Completed
 - Out-of-scope repositories intentionally not scanned: none


### PR DESCRIPTION
# Summary
This branch isolates Today tab scroll-driven state so the root tab shell stops doing extra work on every scroll tick, and it fixes stale alert focus handling so refresh and back-navigation flows land on the intended alert detail. It also adds regression coverage around remote alert parsing and alert-center navigation, plus the audit notes that tracked the work.

# What Changed
- Moved Today tab scroll-condense progress into a dedicated `TodayTabView` subtree instead of keeping it at the root `HomeView` level.
- Kept the Today summary behavior the same while reducing invalidation fan-out from scroll updates.
- Added `clearFocusRequest(id:)` to `RemoteAlertPresentationState` and clear consumed focus requests after the alert detail consumes them.
- Reworked alert and mesoscale rows to use navigation destinations backed by shared detail builders.
- Seeded a second UI-test watch and added a UI regression test for returning from alert detail without surfacing stale selection state.
- Added unit coverage for numeric APNs revision-date decoding and focus-request clearing behavior.
- Updated the weekly performance, contract-drift, and test-gap audit docs that motivated the branch.

# User Impact
Users should see the same Today and Alert screens, but with less unnecessary internal work while scrolling the Today tab. More importantly, alert refresh and back-navigation flows should now open the correct alert detail instead of reusing stale focus state. The other changes are internal or test-harness updates.

# Testing
- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:SkyAwareTests/RemoteHotAlertHandlerTests test` passed.

# Notes
- The branch includes a small internal refactor (`TodayTabView`) to keep scroll state local to the Today tab.
- The UI regression coverage was added in `Tests/UITests/SkyAwareUITests.swift`, but that suite was not run in this session.