### PR TITLE
Stabilize Today cache roll-forward and Local Alerts state flow

### DIFF
--- a/Sources/App/HomeRefreshPipeline.swift
+++ b/Sources/App/HomeRefreshPipeline.swift
@@ -86,6 +86,9 @@ final class HomeRefreshPipeline {
     var alerts: [AlertDTO] { alertSnapshot.alerts }
     var outlooks: [ConvectiveOutlookDTO] { outlookSnapshot.outlooks }
     var outlook: ConvectiveOutlookDTO? { outlookSnapshot.outlook }
+    var isRefreshInFlight: Bool {
+        activeRefreshCount > 0 || followUpRefreshCount > 0
+    }
 
     init(
         initialSnap: LocationSnapshot? = nil,
@@ -185,7 +188,7 @@ final class HomeRefreshPipeline {
         updateEnvironment(environment)
         guard scenePhase == .active, let newKey else { return }
 
-        if isForegroundRefreshInFlight {
+        if isRefreshInFlight {
             environment.logger.debug(
                 "Deferring foreground refresh trigger=\(HomeRefreshTrigger.foregroundLocationChange.logName, privacy: .public) while activeRefreshCount=\(self.activeRefreshCount, privacy: .public) followUpRefreshCount=\(self.followUpRefreshCount, privacy: .public)"
             )
@@ -325,10 +328,6 @@ final class HomeRefreshPipeline {
         guard activeRefreshCount > 0 else { return }
         activeRefreshCount -= 1
         finalizeForegroundRefreshIfNeeded()
-    }
-
-    private var isForegroundRefreshInFlight: Bool {
-        activeRefreshCount > 0 || followUpRefreshCount > 0
     }
 
     private func handleIngestionProgress(_ event: HomeIngestionProgressEvent) async {

--- a/Sources/App/HomeView.swift
+++ b/Sources/App/HomeView.swift
@@ -138,6 +138,17 @@ struct HomeView: View {
         )
     }
 
+    private var localAlertsDisplayState: LocalAlertsDisplayState {
+        LocalAlertsDisplayState.from(
+            todayContentState: todayContentState,
+            hasCachedProjection: displayedProjection != nil,
+            isCurrentContextResolvedInPipeline: isCurrentContextResolvedInPipeline,
+            lastHotAlertsLoadAt: displayedProjection?.lastHotAlertsLoadAt,
+            hasActiveAlerts: !displayedMesos.isEmpty || !displayedAlerts.isEmpty,
+            isLocationUnavailable: readinessState == .locationUnavailable
+        )
+    }
+
     private var todayContentState: TodayContentState {
         TodayContentState.from(
             readinessState: readinessState,
@@ -217,6 +228,7 @@ struct HomeView: View {
                         outlook: displayedOutlook,
                         weather: displayedWeather,
                         todayContentState: todayContentState,
+                        localAlertsDisplayState: localAlertsDisplayState,
                         readinessState: readinessState,
                         resolutionState: refreshPipeline.resolutionState,
                         isRefreshInFlight: refreshPipeline.isRefreshInFlight,
@@ -618,6 +630,7 @@ private struct TodayTabView: View {
     let outlook: ConvectiveOutlookDTO?
     let weather: SummaryWeather?
     let todayContentState: TodayContentState
+    let localAlertsDisplayState: LocalAlertsDisplayState
     let readinessState: SummaryReadinessState
     let resolutionState: SummaryResolutionState
     let isRefreshInFlight: Bool
@@ -663,6 +676,7 @@ private struct TodayTabView: View {
                     outlook: outlook,
                     weather: visibleWeather,
                     todayContentState: todayContentState,
+                    localAlertsDisplayState: localAlertsDisplayState,
                     readinessState: readinessState,
                     resolutionState: resolutionState,
                     showsOfflineToken: showsOfflineToken,

--- a/Sources/App/HomeView.swift
+++ b/Sources/App/HomeView.swift
@@ -124,14 +124,18 @@ struct HomeView: View {
     }
 
     private var displayedOutlook: ConvectiveOutlookDTO? {
-        refreshPipeline.outlooks.first ?? cachedOutlooks.first?.dto ?? refreshPipeline.outlook
+        Self.preferredOutlook(
+            cachedOutlook: cachedOutlooks.first?.dto,
+            liveOutlooks: refreshPipeline.outlooks,
+            liveOutlook: refreshPipeline.outlook
+        )
     }
 
     private var displayedOutlooks: [ConvectiveOutlookDTO] {
-        if refreshPipeline.outlooks.isEmpty == false {
-            return refreshPipeline.outlooks
-        }
-        return cachedOutlookDTOs
+        Self.preferredOutlooks(
+            cachedOutlooks: cachedOutlookDTOs,
+            liveOutlooks: refreshPipeline.outlooks
+        )
     }
 
     private var todayContentState: TodayContentState {
@@ -139,7 +143,7 @@ struct HomeView: View {
             readinessState: readinessState,
             hasCachedContent: displayedProjection != nil,
             hasLiveContent: usesPipelineSummaryFallback,
-            isRefreshing: refreshPipeline.resolutionState.isRefreshing,
+            isRefreshing: refreshPipeline.isRefreshInFlight,
             isOffline: runtimeConnectivityState.isOffline
         )
     }
@@ -215,6 +219,7 @@ struct HomeView: View {
                         todayContentState: todayContentState,
                         readinessState: readinessState,
                         resolutionState: refreshPipeline.resolutionState,
+                        isRefreshInFlight: refreshPipeline.isRefreshInFlight,
                         showsOfflineToken: runtimeConnectivityState.isOffline,
                         locationReliabilityRailState: showsLocationReliabilityRail
                             ? SummaryView.LocationReliabilityRailState(
@@ -427,12 +432,12 @@ extension HomeView {
 
     static func showsBootstrapLoading(
         readinessState: SummaryReadinessState,
-        resolutionState: SummaryResolutionState,
+        isRefreshInFlight: Bool,
         hasProjection: Bool
     ) -> Bool {
         readinessState != .locationUnavailable &&
         hasProjection == false &&
-        (resolutionState.isRefreshing || readinessState != .ready)
+        (isRefreshInFlight || readinessState != .ready)
     }
 
     static func preferredSummaryValue<T>(
@@ -444,6 +449,21 @@ extension HomeView {
             return pipelineValue ?? projectionValue
         }
         return projectionValue ?? pipelineValue
+    }
+
+    static func preferredOutlooks(
+        cachedOutlooks: [ConvectiveOutlookDTO],
+        liveOutlooks: [ConvectiveOutlookDTO]
+    ) -> [ConvectiveOutlookDTO] {
+        liveOutlooks.isEmpty ? cachedOutlooks : liveOutlooks
+    }
+
+    static func preferredOutlook(
+        cachedOutlook: ConvectiveOutlookDTO?,
+        liveOutlooks: [ConvectiveOutlookDTO],
+        liveOutlook: ConvectiveOutlookDTO?
+    ) -> ConvectiveOutlookDTO? {
+        liveOutlooks.first ?? cachedOutlook ?? liveOutlook
     }
 
     struct LocationReliabilityRailState: Equatable {
@@ -600,6 +620,7 @@ private struct TodayTabView: View {
     let todayContentState: TodayContentState
     let readinessState: SummaryReadinessState
     let resolutionState: SummaryResolutionState
+    let isRefreshInFlight: Bool
     let showsOfflineToken: Bool
     let locationReliabilityRailState: SummaryView.LocationReliabilityRailState?
     let onOpenMapLayer: (MapLayer) -> Void
@@ -615,7 +636,7 @@ private struct TodayTabView: View {
         TodayVisibleWeatherState.resolve(
             liveWeather: weather,
             displayedWeather: visibleWeatherState.weather,
-            isRefreshing: resolutionState.isRefreshing,
+            isRefreshing: isRefreshInFlight,
             displayedWeatherLocationIdentity: visibleWeatherState.locationIdentity,
             weatherLocationIdentity: weatherLocationIdentity
         ).weather
@@ -624,7 +645,7 @@ private struct TodayTabView: View {
     private var visibleWeatherTaskState: TodayVisibleWeatherStateTaskState {
         TodayVisibleWeatherStateTaskState(
             liveWeather: weather,
-            isRefreshing: resolutionState.isRefreshing,
+            isRefreshing: isRefreshInFlight,
             weatherLocationIdentity: weatherLocationIdentity
         )
     }
@@ -672,7 +693,7 @@ private struct TodayTabView: View {
             visibleWeatherState = TodayVisibleWeatherState.resolve(
                 liveWeather: weather,
                 displayedWeather: visibleWeatherState.weather,
-                isRefreshing: resolutionState.isRefreshing,
+                isRefreshing: isRefreshInFlight,
                 displayedWeatherLocationIdentity: visibleWeatherState.locationIdentity,
                 weatherLocationIdentity: weatherLocationIdentity
             )

--- a/Sources/App/HomeView.swift
+++ b/Sources/App/HomeView.swift
@@ -153,7 +153,9 @@ struct HomeView: View {
         TodayContentState.from(
             readinessState: readinessState,
             hasCachedContent: displayedProjection != nil,
-            hasLiveContent: usesPipelineSummaryFallback,
+            hasLiveContent: usesPipelineSummaryFallback || (
+                isUITestStaticMode && (!refreshPipeline.mesos.isEmpty || !refreshPipeline.alerts.isEmpty)
+            ),
             isRefreshing: refreshPipeline.isRefreshInFlight,
             isOffline: runtimeConnectivityState.isOffline
         )

--- a/Sources/App/HomeView.swift
+++ b/Sources/App/HomeView.swift
@@ -588,6 +588,7 @@ extension HomeView {
 
 private struct TodayTabView: View {
     @State private var headerCondenseProgress: CGFloat = 0
+    @State private var visibleWeatherState = TodayVisibleWeatherState()
 
     let snap: LocationSnapshot?
     let stormRisk: StormRiskLevel?
@@ -607,6 +608,28 @@ private struct TodayTabView: View {
     let onOpenOutlooks: () -> Void
     let refreshAction: () async -> Void
 
+    private var weatherLocationIdentity: SummaryWeatherLocationIdentity? {
+        SummaryWeatherLocationIdentity(snapshot: snap)
+    }
+
+    private var visibleWeather: SummaryWeather? {
+        TodayVisibleWeatherState.resolve(
+            liveWeather: weather,
+            displayedWeather: visibleWeatherState.weather,
+            isRefreshing: resolutionState.isRefreshing,
+            displayedWeatherLocationIdentity: visibleWeatherState.locationIdentity,
+            weatherLocationIdentity: weatherLocationIdentity
+        ).weather
+    }
+
+    private var visibleWeatherTaskState: TodayVisibleWeatherStateTaskState {
+        TodayVisibleWeatherStateTaskState(
+            liveWeather: weather,
+            isRefreshing: resolutionState.isRefreshing,
+            weatherLocationIdentity: weatherLocationIdentity
+        )
+    }
+
     var body: some View {
         NavigationStack {
             ScrollView {
@@ -618,7 +641,7 @@ private struct TodayTabView: View {
                     mesos: mesos,
                     alerts: alerts,
                     outlook: outlook,
-                    weather: weather,
+                    weather: visibleWeather,
                     todayContentState: todayContentState,
                     readinessState: readinessState,
                     resolutionState: resolutionState,
@@ -646,7 +669,22 @@ private struct TodayTabView: View {
             }
         }
         .background(Color(.skyAwareBackground).ignoresSafeArea())
+        .task(id: visibleWeatherTaskState) {
+            visibleWeatherState = TodayVisibleWeatherState.resolve(
+                liveWeather: weather,
+                displayedWeather: visibleWeatherState.weather,
+                isRefreshing: resolutionState.isRefreshing,
+                displayedWeatherLocationIdentity: visibleWeatherState.locationIdentity,
+                weatherLocationIdentity: weatherLocationIdentity
+            )
+        }
     }
+}
+
+private struct TodayVisibleWeatherStateTaskState: Equatable {
+    let liveWeather: SummaryWeather?
+    let isRefreshing: Bool
+    let weatherLocationIdentity: SummaryWeatherLocationIdentity?
 }
 
 #Preview("Home") {

--- a/Sources/App/HomeView.swift
+++ b/Sources/App/HomeView.swift
@@ -312,7 +312,6 @@ struct HomeView: View {
                     .transition(.opacity)
             }
         }
-        .transition(.opacity)
         .tint(.skyAwareAccent)
         .task {
             if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" { return }

--- a/Sources/App/HomeView.swift
+++ b/Sources/App/HomeView.swift
@@ -134,6 +134,16 @@ struct HomeView: View {
         return cachedOutlookDTOs
     }
 
+    private var todayContentState: TodayContentState {
+        TodayContentState.from(
+            readinessState: readinessState,
+            hasCachedContent: displayedProjection != nil,
+            hasLiveContent: usesPipelineSummaryFallback,
+            isRefreshing: refreshPipeline.resolutionState.isRefreshing,
+            isOffline: runtimeConnectivityState.isOffline
+        )
+    }
+
     private var readinessState: SummaryReadinessState {
         if locationSession.authorizationStatus == .denied || locationSession.authorizationStatus == .restricted {
             return .locationUnavailable
@@ -149,16 +159,8 @@ struct HomeView: View {
         )
     }
 
-    private var hasMeaningfulSummaryContent: Bool {
-        displayedProjection != nil || usesPipelineSummaryFallback
-    }
-
     private var isEmptyResolvingSummary: Bool {
-        Self.showsBootstrapLoading(
-            readinessState: readinessState,
-            resolutionState: refreshPipeline.resolutionState,
-            hasProjection: hasMeaningfulSummaryContent
-        )
+        todayContentState.showsResolvingSurface
     }
 
     init(
@@ -210,6 +212,7 @@ struct HomeView: View {
                         alerts: displayedAlerts,
                         outlook: displayedOutlook,
                         weather: displayedWeather,
+                        todayContentState: todayContentState,
                         readinessState: readinessState,
                         resolutionState: refreshPipeline.resolutionState,
                         showsOfflineToken: runtimeConnectivityState.isOffline,
@@ -594,6 +597,7 @@ private struct TodayTabView: View {
     let alerts: [AlertDTO]
     let outlook: ConvectiveOutlookDTO?
     let weather: SummaryWeather?
+    let todayContentState: TodayContentState
     let readinessState: SummaryReadinessState
     let resolutionState: SummaryResolutionState
     let showsOfflineToken: Bool
@@ -615,6 +619,7 @@ private struct TodayTabView: View {
                     alerts: alerts,
                     outlook: outlook,
                     weather: weather,
+                    todayContentState: todayContentState,
                     readinessState: readinessState,
                     resolutionState: resolutionState,
                     showsOfflineToken: showsOfflineToken,

--- a/Sources/Features/Badges/AtmosphereRailView.swift
+++ b/Sources/Features/Badges/AtmosphereRailView.swift
@@ -421,7 +421,7 @@ private struct AtmosphericMetricRow: View {
     AtmosphericConditionsCard(weather: AtmosphericConditionsPreviewData.veryMoist)
 }
 
-#Preview("Atmospheric Conditions - Missing Values") {
+#Preview("Atmospheric Conditions - Unavailable Weather") {
     AtmosphericConditionsCard(weather: nil)
 }
 

--- a/Sources/Features/Summary/ActiveAlertSummaryView.swift
+++ b/Sources/Features/Summary/ActiveAlertSummaryView.swift
@@ -541,12 +541,157 @@ private struct WatchRowView: View {
 
 #Preview {
     NavigationStack {
-        ActiveAlertSummaryView(
+        ActiveAlertPreviewContainer(
             mesos: MD.sampleDiscussionDTOs,
-            alerts: Watch.sampleWatchRows
+            alerts: Watch.sampleWatchRows,
+            localAlertsDisplayState: .current(content: .populated, source: .cached),
+            todayContentState: .current
         )
-            .toolbar(.hidden, for: .navigationBar)
-            .background(.skyAwareBackground)
-            .environment(\.dependencies, Dependencies.unconfigured)
+        .toolbar(.hidden, for: .navigationBar)
+        .background(.skyAwareBackground)
+        .environment(\.dependencies, Dependencies.unconfigured)
+    }
+}
+
+#Preview("Local Alerts - Populated Alerts") {
+    ActiveAlertPreviewContainer(
+        alerts: Watch.sampleWatchRows,
+        localAlertsDisplayState: .current(content: .populated, source: .cached)
+    )
+}
+
+#Preview("Local Alerts - Populated Mesos") {
+    ActiveAlertPreviewContainer(
+        mesos: MD.sampleDiscussionDTOs,
+        localAlertsDisplayState: .current(content: .populated, source: .cached)
+    )
+}
+
+#Preview("Local Alerts - Mixed Alert and Meso") {
+    ActiveAlertPreviewContainer(
+        mesos: [MD.sampleDiscussionDTOs[0]],
+        alerts: [Watch.sampleWatchRows[0]],
+        localAlertsDisplayState: .current(content: .populated, source: .cached)
+    )
+}
+
+#Preview("Local Alerts - Known Empty") {
+    ActiveAlertPreviewContainer(
+        mesos: [],
+        alerts: [],
+        localAlertsDisplayState: .current(content: .empty, source: .cached)
+    )
+}
+
+#Preview("Local Alerts - No Cache Resolving") {
+    ActiveAlertPreviewContainer(
+        mesos: [],
+        alerts: [],
+        localAlertsDisplayState: .noCacheResolving,
+        todayContentState: .noCacheResolving
+    )
+}
+
+#Preview("Local Alerts - Cached Refreshing Populated") {
+    ActiveAlertPreviewContainer(
+        mesos: MD.sampleDiscussionDTOs,
+        alerts: Watch.sampleWatchRows,
+        localAlertsDisplayState: .cachedRefreshing(content: .populated),
+        todayContentState: .cachedRefreshing
+    )
+}
+
+#Preview("Local Alerts - Cached Refreshing Empty") {
+    ActiveAlertPreviewContainer(
+        mesos: [],
+        alerts: [],
+        localAlertsDisplayState: .cachedRefreshing(content: .empty),
+        todayContentState: .cachedRefreshing
+    )
+}
+
+#Preview("Local Alerts - Offline Cached Populated") {
+    ActiveAlertPreviewContainer(
+        mesos: MD.sampleDiscussionDTOs,
+        alerts: Watch.sampleWatchRows,
+        localAlertsDisplayState: .staleOrDegraded(content: .populated),
+        todayContentState: .staleRefreshing,
+        isOffline: true
+    )
+    .environment(\.colorScheme, .dark)
+}
+
+#Preview("Local Alerts - Offline Cached Empty") {
+    ActiveAlertPreviewContainer(
+        mesos: [],
+        alerts: [],
+        localAlertsDisplayState: .staleOrDegraded(content: .empty),
+        todayContentState: .staleRefreshing,
+        isOffline: true
+    )
+    .environment(\.colorScheme, .light)
+}
+
+#Preview("Local Alerts - Degraded Cached Populated") {
+    ActiveAlertPreviewContainer(
+        mesos: MD.sampleDiscussionDTOs,
+        alerts: Watch.sampleWatchRows,
+        localAlertsDisplayState: .staleOrDegraded(content: .populated),
+        todayContentState: .degraded,
+        isOffline: true
+    )
+}
+
+#Preview("Local Alerts - Degraded Cached Empty") {
+    ActiveAlertPreviewContainer(
+        mesos: [],
+        alerts: [],
+        localAlertsDisplayState: .staleOrDegraded(content: .empty),
+        todayContentState: .degraded,
+        isOffline: true
+    )
+}
+
+#Preview("Local Alerts - AX Large Type") {
+    ActiveAlertPreviewContainer(
+        mesos: MD.sampleDiscussionDTOs,
+        alerts: Watch.sampleWatchRows,
+        localAlertsDisplayState: .cachedRefreshing(content: .populated),
+        todayContentState: .cachedRefreshing
+    )
+    .environment(\.dynamicTypeSize, .accessibility3)
+}
+
+private struct ActiveAlertPreviewContainer: View {
+    let mesos: [MdDTO]
+    let alerts: [AlertDTO]
+    let localAlertsDisplayState: LocalAlertsDisplayState
+    let todayContentState: TodayContentState
+    let isOffline: Bool
+
+    init(
+        mesos: [MdDTO] = [],
+        alerts: [AlertDTO] = [],
+        localAlertsDisplayState: LocalAlertsDisplayState,
+        todayContentState: TodayContentState = .current,
+        isOffline: Bool = false
+    ) {
+        self.mesos = mesos
+        self.alerts = alerts
+        self.localAlertsDisplayState = localAlertsDisplayState
+        self.todayContentState = todayContentState
+        self.isOffline = isOffline
+    }
+
+    var body: some View {
+        ActiveAlertSummaryView(
+            mesos: mesos,
+            alerts: alerts,
+            localAlertsDisplayState: localAlertsDisplayState,
+            todayContentState: todayContentState,
+            isOffline: isOffline
+        )
+        .padding()
+        .background(.skyAwareBackground)
     }
 }

--- a/Sources/Features/Summary/ActiveAlertSummaryView.swift
+++ b/Sources/Features/Summary/ActiveAlertSummaryView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct ActiveAlertSummaryView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    private enum ContentState: Equatable {
+    enum ContentState: Equatable {
         case loading
         case empty
         case alerts
@@ -24,7 +24,7 @@ struct ActiveAlertSummaryView: View {
 
     let mesos: [MdDTO]
     let alerts: [AlertDTO]
-    let isLoading: Bool
+    let localAlertsDisplayState: LocalAlertsDisplayState
     let todayContentState: TodayContentState
     let isOffline: Bool
     let onOpenAlertCenter: (() -> Void)?
@@ -40,14 +40,14 @@ struct ActiveAlertSummaryView: View {
     init(
         mesos: [MdDTO],
         alerts: [AlertDTO],
-        isLoading: Bool = false,
+        localAlertsDisplayState: LocalAlertsDisplayState = .current(content: .populated, source: .cached),
         todayContentState: TodayContentState = .current,
         isOffline: Bool = false,
         onOpenAlertCenter: (() -> Void)? = nil
     ) {
         self.mesos = mesos
         self.alerts = alerts
-        self.isLoading = isLoading
+        self.localAlertsDisplayState = localAlertsDisplayState
         self.todayContentState = todayContentState
         self.isOffline = isOffline
         self.onOpenAlertCenter = onOpenAlertCenter
@@ -60,13 +60,10 @@ struct ActiveAlertSummaryView: View {
     }
 
     private var contentState: ContentState {
-        if isLoading {
-            return .loading
-        }
-        if hasRenderableAlerts {
-            return .alerts
-        }
-        return .empty
+        return Self.contentState(
+            for: localAlertsDisplayState,
+            hasRenderableAlerts: hasRenderableAlerts
+        )
     }
 
     private var isLeavingAlertsTransition: Bool {
@@ -80,6 +77,33 @@ struct ActiveAlertSummaryView: View {
 
     private var usesFlexibleAlertHeight: Bool {
         Self.usesFlexibleAlertHeight(currentState: contentState, isLeavingAlerts: isLeavingAlertsTransition)
+    }
+
+    private var contentStateAnimation: Animation? {
+        guard let previousState = previousStableContentState else {
+            return nil
+        }
+
+        guard Self.shouldAnimateContentStateTransition(
+            from: previousState,
+            to: contentState,
+            suppressesRoutineRefreshMotion: todayContentState.suppressesRoutineRefreshMotion
+        ) else {
+            return nil
+        }
+
+        return SkyAwareMotion.layerChange(reduceMotion)
+    }
+
+    private var previousStableContentState: ContentState? {
+        switch heightPhase {
+        case .stable(let state):
+            return state
+        case .leavingAlerts:
+            return .alerts
+        case .uninitialized:
+            return nil
+        }
     }
 
     private var transitionHoldDurationNanoseconds: UInt64 {
@@ -125,7 +149,7 @@ struct ActiveAlertSummaryView: View {
 
                 Spacer(minLength: 12)
 
-                if let onOpenAlertCenter, isLoading == false, (hasRenderableAlerts || isOffline) {
+                if let onOpenAlertCenter, contentState != .loading, (hasRenderableAlerts || isOffline) {
                     Button {
                         onOpenAlertCenter()
                     } label: {
@@ -211,10 +235,7 @@ struct ActiveAlertSummaryView: View {
         ZStack(alignment: .topLeading) {
             contentStateView
         }
-        .animation(
-            todayContentState.suppressesRoutineRefreshMotion ? nil : SkyAwareMotion.layerChange(reduceMotion),
-            value: contentState
-        )
+        .animation(contentStateAnimation, value: contentState)
         .frame(
             maxWidth: .infinity,
             minHeight: usesFlexibleAlertHeight ? nil : 72,
@@ -226,11 +247,7 @@ struct ActiveAlertSummaryView: View {
     private var contentStateView: some View {
         switch contentState {
         case .loading:
-            if todayContentState.showsResolvingSurface {
-                loadingContent
-            } else {
-                emptyContent
-            }
+            loadingContent
         case .alerts:
             alertsContent
         case .empty:
@@ -317,8 +334,41 @@ struct ActiveAlertSummaryView: View {
         }
     }
 
-    private static func usesFlexibleAlertHeight(currentState: ContentState, isLeavingAlerts: Bool) -> Bool {
+    static func usesFlexibleAlertHeight(currentState: ContentState, isLeavingAlerts: Bool) -> Bool {
         currentState == .alerts || isLeavingAlerts
+    }
+
+    static func shouldAnimateContentStateTransition(
+        from oldState: ContentState,
+        to newState: ContentState,
+        suppressesRoutineRefreshMotion: Bool
+    ) -> Bool {
+        guard suppressesRoutineRefreshMotion == false else {
+            return false
+        }
+
+        guard oldState != .loading, newState != .loading else {
+            return false
+        }
+
+        return oldState != newState
+    }
+
+    // Keep visible alerts ahead of transient loading/empty bookkeeping so cached refreshes stay calm.
+    static func contentState(
+        for displayState: LocalAlertsDisplayState,
+        hasRenderableAlerts: Bool
+    ) -> ContentState {
+        if hasRenderableAlerts {
+            return .alerts
+        }
+
+        switch displayState.presentationState {
+        case .loading:
+            return .loading
+        case .alerts, .empty, .unavailable:
+            return .empty
+        }
     }
 }
 
@@ -491,7 +541,10 @@ private struct WatchRowView: View {
 
 #Preview {
     NavigationStack {
-        ActiveAlertSummaryView(mesos: MD.sampleDiscussionDTOs, alerts: Watch.sampleWatchRows)
+        ActiveAlertSummaryView(
+            mesos: MD.sampleDiscussionDTOs,
+            alerts: Watch.sampleWatchRows
+        )
             .toolbar(.hidden, for: .navigationBar)
             .background(.skyAwareBackground)
             .environment(\.dependencies, Dependencies.unconfigured)

--- a/Sources/Features/Summary/ActiveAlertSummaryView.swift
+++ b/Sources/Features/Summary/ActiveAlertSummaryView.swift
@@ -159,7 +159,6 @@ struct ActiveAlertSummaryView: View {
             }
 
             innerContent
-                .animation(SkyAwareMotion.layerChange(reduceMotion), value: contentState)
         }
         .padding(18)
         .cardBackground(
@@ -211,9 +210,11 @@ struct ActiveAlertSummaryView: View {
     private var contentStateContainer: some View {
         ZStack(alignment: .topLeading) {
             contentStateView
-                .id(contentState)
-                .transition(.opacity)
         }
+        .animation(
+            todayContentState.suppressesRoutineRefreshMotion ? nil : SkyAwareMotion.layerChange(reduceMotion),
+            value: contentState
+        )
         .frame(
             maxWidth: .infinity,
             minHeight: usesFlexibleAlertHeight ? nil : 72,

--- a/Sources/Features/Summary/ActiveAlertSummaryView.swift
+++ b/Sources/Features/Summary/ActiveAlertSummaryView.swift
@@ -25,6 +25,7 @@ struct ActiveAlertSummaryView: View {
     let mesos: [MdDTO]
     let alerts: [AlertDTO]
     let isLoading: Bool
+    let todayContentState: TodayContentState
     let isOffline: Bool
     let onOpenAlertCenter: (() -> Void)?
     private let sortedMesos: [MdDTO]
@@ -40,12 +41,14 @@ struct ActiveAlertSummaryView: View {
         mesos: [MdDTO],
         alerts: [AlertDTO],
         isLoading: Bool = false,
+        todayContentState: TodayContentState = .current,
         isOffline: Bool = false,
         onOpenAlertCenter: (() -> Void)? = nil
     ) {
         self.mesos = mesos
         self.alerts = alerts
         self.isLoading = isLoading
+        self.todayContentState = todayContentState
         self.isOffline = isOffline
         self.onOpenAlertCenter = onOpenAlertCenter
         self.sortedMesos = AlertPresentationOrdering.ordered(mesos, endDate: \.validEnd)
@@ -222,7 +225,11 @@ struct ActiveAlertSummaryView: View {
     private var contentStateView: some View {
         switch contentState {
         case .loading:
-            loadingContent
+            if todayContentState.showsResolvingSurface {
+                loadingContent
+            } else {
+                emptyContent
+            }
         case .alerts:
             alertsContent
         case .empty:

--- a/Sources/Features/Summary/LocalAlertsDisplayState.swift
+++ b/Sources/Features/Summary/LocalAlertsDisplayState.swift
@@ -1,0 +1,103 @@
+//
+//  LocalAlertsDisplayState.swift
+//  SkyAware
+//
+//  Created by OpenAI Codex.
+//
+
+import Foundation
+
+enum LocalAlertsPresentationState: Sendable, Equatable {
+    case unavailable
+    case loading
+    case alerts
+    case empty
+}
+
+enum LocalAlertsDisplayState: Sendable, Equatable {
+    enum Content: Sendable, Equatable {
+        case empty
+        case populated
+    }
+
+    enum Source: Sendable, Equatable {
+        case live
+        case cached
+    }
+
+    enum UnavailableReason: Sendable, Equatable {
+        case locationUnavailable
+        case noUsefulAlertState
+    }
+
+    case noCacheResolving
+    case current(content: Content, source: Source)
+    case cachedRefreshing(content: Content)
+    case staleOrDegraded(content: Content)
+    case unavailable(reason: UnavailableReason)
+
+    static func from(
+        todayContentState: TodayContentState,
+        hasCachedProjection: Bool,
+        isCurrentContextResolvedInPipeline: Bool,
+        lastHotAlertsLoadAt: Date?,
+        hasActiveAlerts: Bool,
+        isLocationUnavailable: Bool
+    ) -> LocalAlertsDisplayState {
+        if isLocationUnavailable {
+            return .unavailable(reason: .locationUnavailable)
+        }
+
+        let content: Content = hasActiveAlerts ? .populated : .empty
+
+        if isCurrentContextResolvedInPipeline {
+            return .current(content: content, source: .live)
+        }
+
+        switch todayContentState {
+        case .noCacheResolving:
+            return .noCacheResolving
+
+        case .cachedRefreshing:
+            if hasCachedProjection {
+                guard lastHotAlertsLoadAt != nil || hasActiveAlerts else {
+                    return .unavailable(reason: .noUsefulAlertState)
+                }
+                return .cachedRefreshing(content: content)
+            }
+            return .noCacheResolving
+
+        case .staleRefreshing, .degraded:
+            if hasCachedProjection {
+                guard lastHotAlertsLoadAt != nil || hasActiveAlerts else {
+                    return .unavailable(reason: .noUsefulAlertState)
+                }
+                return .staleOrDegraded(content: content)
+            }
+            return .current(content: content, source: .live)
+
+        case .current:
+            if hasCachedProjection {
+                guard lastHotAlertsLoadAt != nil || hasActiveAlerts else {
+                    return .unavailable(reason: .noUsefulAlertState)
+                }
+                return .current(content: content, source: .cached)
+            }
+            return .current(content: content, source: .live)
+
+        case .unavailable:
+            return .unavailable(reason: .noUsefulAlertState)
+        }
+    }
+
+    var presentationState: LocalAlertsPresentationState {
+        switch self {
+        case .noCacheResolving:
+            .loading
+        case .current(let content, _), .cachedRefreshing(let content), .staleOrDegraded(let content):
+            content == .populated ? .alerts : .empty
+        case .unavailable:
+            .unavailable
+        }
+    }
+}

--- a/Sources/Features/Summary/LocalAlertsDisplayState.swift
+++ b/Sources/Features/Summary/LocalAlertsDisplayState.swift
@@ -100,4 +100,25 @@ enum LocalAlertsDisplayState: Sendable, Equatable {
             .unavailable
         }
     }
+
+    var showsLoadingCopy: Bool {
+        self == .noCacheResolving
+    }
+
+    var showsOfflineStatusCopy: Bool {
+        switch self {
+        case .staleOrDegraded(content: .populated):
+            true
+        case .noCacheResolving,
+            .current,
+            .cachedRefreshing,
+            .staleOrDegraded(content: .empty),
+            .unavailable:
+            false
+        }
+    }
+
+    var usesSummaryResolvingTreatment: Bool {
+        false
+    }
 }

--- a/Sources/Features/Summary/OutlookSummaryCard.swift
+++ b/Sources/Features/Summary/OutlookSummaryCard.swift
@@ -13,6 +13,7 @@ struct OutlookSummaryCard: View {
     let outlook: ConvectiveOutlookDTO?
     let isLoading: Bool
     let isPending: Bool
+    let todayContentState: TodayContentState
     let onBrowseAllOutlooks: (() -> Void)?
     
     @State private var navigateToFull = false
@@ -21,11 +22,13 @@ struct OutlookSummaryCard: View {
         outlook: ConvectiveOutlookDTO?,
         isLoading: Bool = false,
         isPending: Bool = false,
+        todayContentState: TodayContentState = .current,
         onBrowseAllOutlooks: (() -> Void)? = nil
     ) {
         self.outlook = outlook
         self.isLoading = isLoading
         self.isPending = isPending
+        self.todayContentState = todayContentState
         self.onBrowseAllOutlooks = onBrowseAllOutlooks
     }
 
@@ -34,13 +37,24 @@ struct OutlookSummaryCard: View {
     }
 
     private var summaryText: String {
-        if let summary = outlook?.summary {
-            return summary
+        Self.outlookSummaryText(
+            outlook: outlook,
+            todayContentState: todayContentState,
+            isLoading: isLoading,
+            isPending: isPending
+        )
+    }
+
+    private var headerSymbolName: String {
+        if outlook != nil {
+            return "sun.max.fill"
         }
-        if isPending {
-            return "Getting outlook details…"
+
+        if todayContentState.showsResolvingSurface {
+            return "sun.horizon.fill"
         }
-        return "Getting outlook details…"
+
+        return "sun.max.fill"
     }
 
     private var adaptiveLayout: SkyAwareAdaptiveLayout {
@@ -74,7 +88,7 @@ struct OutlookSummaryCard: View {
         }
         .padding(18)
         .cardBackground(cornerRadius: SkyAwareRadius.card, shadowOpacity: 0.08, shadowRadius: 8, shadowY: 3)
-        .placeholder(isLoading, animated: true)
+        .placeholder(isLoading && todayContentState.showsResolvingSurface, animated: true)
         .navigationDestination(isPresented: $navigateToFull) {
             if let outlook {
                 ConvectiveOutlookDetailView(outlook: outlook)
@@ -84,7 +98,7 @@ struct OutlookSummaryCard: View {
 
     private var headerRow: some View {
         HStack(alignment: .center, spacing: 12) {
-            Label(titleText, systemImage: isPending ? "sun.horizon.fill" : "sun.max.fill")
+            Label(titleText, systemImage: headerSymbolName)
                 .sectionLabel()
 
             Spacer(minLength: 12)
@@ -116,6 +130,23 @@ struct OutlookSummaryCard: View {
             }
         }
     }
+
+    static func outlookSummaryText(
+        outlook: ConvectiveOutlookDTO?,
+        todayContentState: TodayContentState,
+        isLoading: Bool,
+        isPending: Bool
+    ) -> String {
+        if let summary = outlook?.summary {
+            return summary
+        }
+
+        if isLoading && todayContentState.showsResolvingSurface {
+            return "Getting outlook details…"
+        }
+
+        return "Outlook details will appear here when available."
+    }
 }
 
 #Preview {
@@ -145,7 +176,7 @@ struct OutlookSummaryCard: View {
 
 #Preview("Outlook Summary - Initial Resolve") {
     NavigationStack {
-        OutlookSummaryCard(outlook: nil, isLoading: true)
+        OutlookSummaryCard(outlook: nil, isLoading: true, todayContentState: .noCacheResolving)
             .padding()
     }
 }

--- a/Sources/Features/Summary/PrimaryAwarenessPanel.swift
+++ b/Sources/Features/Summary/PrimaryAwarenessPanel.swift
@@ -44,11 +44,11 @@ enum SummaryAwarenessPrimaryState: Equatable, Sendable {
         severeRisk: SevereWeatherThreat?,
         fireRisk: FireRiskLevel?,
         alerts: [AlertDTO],
+        todayContentState: TodayContentState,
         isStormRiskResolving: Bool,
         isSevereRiskResolving: Bool,
         isFireRiskResolving: Bool,
-        isOffline: Bool,
-        isRefreshing: Bool = false
+        isOffline: Bool
     ) -> SummaryAwarenessPrimaryState {
         if let alert = Self.activeAlert(from: alerts) {
             return .alert(title: alert.title, detail: alert.detail)
@@ -66,7 +66,7 @@ enum SummaryAwarenessPrimaryState: Equatable, Sendable {
             return .fire(fireRisk)
         }
 
-        if isOffline == false {
+        if isOffline == false, todayContentState.showsResolvingSurface {
             if isSevereRiskResolving {
                 return .loading(
                     title: "Severe Risk",
@@ -468,7 +468,7 @@ struct PrimaryAwarenessPanel: View {
     let severeRisk: SevereWeatherThreat?
     let fireRisk: FireRiskLevel?
     let alerts: [AlertDTO]
-    let readinessState: SummaryReadinessState
+    let todayContentState: TodayContentState
     let resolutionState: SummaryResolutionState
     let showsOfflineToken: Bool
     let onOpenMapLayer: (MapLayer) -> Void
@@ -480,11 +480,11 @@ struct PrimaryAwarenessPanel: View {
             severeRisk: severeRisk,
             fireRisk: fireRisk,
             alerts: alerts,
+            todayContentState: todayContentState,
             isStormRiskResolving: resolutionState.isResolving(.stormRisk),
             isSevereRiskResolving: resolutionState.isResolving(.severeRisk),
             isFireRiskResolving: resolutionState.isResolving(.fireRisk),
-            isOffline: showsOfflineToken,
-            isRefreshing: resolutionState.isRefreshing
+            isOffline: showsOfflineToken
         )
     }
 
@@ -601,30 +601,24 @@ struct PrimaryAwarenessPanel: View {
     private var stormResolving: Bool {
         SummaryView.showsRiskResolvingPlaceholder(
             hasRiskValue: stormRisk != nil,
-            readinessState: readinessState,
-            isSectionResolving: resolutionState.isResolving(.stormRisk),
-            showsOfflineToken: showsOfflineToken,
-            isRefreshing: resolutionState.isRefreshing
+            todayContentState: todayContentState,
+            showsOfflineToken: showsOfflineToken
         )
     }
 
     private var severeResolving: Bool {
         SummaryView.showsRiskResolvingPlaceholder(
             hasRiskValue: severeRisk != nil,
-            readinessState: readinessState,
-            isSectionResolving: resolutionState.isResolving(.severeRisk),
-            showsOfflineToken: showsOfflineToken,
-            isRefreshing: resolutionState.isRefreshing
+            todayContentState: todayContentState,
+            showsOfflineToken: showsOfflineToken
         )
     }
 
     private var fireResolving: Bool {
         SummaryView.showsRiskResolvingPlaceholder(
             hasRiskValue: fireRisk != nil,
-            readinessState: readinessState,
-            isSectionResolving: resolutionState.isResolving(.fireRisk),
-            showsOfflineToken: showsOfflineToken,
-            isRefreshing: resolutionState.isRefreshing
+            todayContentState: todayContentState,
+            showsOfflineToken: showsOfflineToken
         )
     }
 
@@ -1203,6 +1197,15 @@ private extension View {
             )
 
             PrimaryAwarenessPanelPreviewCard(
+                title: "Cached Refreshing Risk",
+                stormRisk: .moderate,
+                severeRisk: .allClear,
+                fireRisk: .clear,
+                todayContentState: .cachedRefreshing,
+                colorScheme: .light
+            )
+
+            PrimaryAwarenessPanelPreviewCard(
                 title: "Quiet Weather - Light",
                 stormRisk: .allClear,
                 severeRisk: .allClear,
@@ -1289,6 +1292,7 @@ private struct PrimaryAwarenessPanelPreviewCard: View {
     let severeRisk: SevereWeatherThreat
     let fireRisk: FireRiskLevel
     var alerts: [AlertDTO] = []
+    var todayContentState: TodayContentState = .current
     var colorScheme: ColorScheme? = nil
     var dynamicTypeSize: DynamicTypeSize? = nil
 
@@ -1305,7 +1309,7 @@ private struct PrimaryAwarenessPanelPreviewCard: View {
                 severeRisk: severeRisk,
                 fireRisk: fireRisk,
                 alerts: alerts,
-                readinessState: .ready,
+                todayContentState: todayContentState,
                 resolutionState: resolutionState,
                 showsOfflineToken: false,
                 onOpenMapLayer: { _ in },

--- a/Sources/Features/Summary/PrimaryAwarenessPanel.swift
+++ b/Sources/Features/Summary/PrimaryAwarenessPanel.swift
@@ -532,7 +532,7 @@ struct PrimaryAwarenessPanel: View {
                 onOpenMapLayer(.categorical)
             }
         )
-        .summaryResolving(stormResolving, style: .subtle)
+        .summaryResolving(stormResolving, todayContentState: todayContentState, style: .subtle)
         .accessibilityHint("Opens the storm risk map.")
     }
 
@@ -547,7 +547,7 @@ struct PrimaryAwarenessPanel: View {
                 onOpenMapLayer(severeMapLayer)
             }
         )
-        .summaryResolving(severeResolving, style: .subtle)
+        .summaryResolving(severeResolving, todayContentState: todayContentState, style: .subtle)
         .accessibilityHint("Opens the highlighted severe threat map.")
     }
 
@@ -563,7 +563,7 @@ struct PrimaryAwarenessPanel: View {
                 onOpenMapLayer(.fire)
             }
         )
-        .summaryResolving(fireResolving, style: .subtle)
+        .summaryResolving(fireResolving, todayContentState: todayContentState, style: .subtle)
         .accessibilityHint("Opens the fire risk map.")
     }
 

--- a/Sources/Features/Summary/SummaryResolving.swift
+++ b/Sources/Features/Summary/SummaryResolving.swift
@@ -206,21 +206,31 @@ private struct SummaryResolvingModifier: ViewModifier {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let isResolving: Bool
+    let todayContentState: TodayContentState
     let style: SummaryResolveForwardStyle
 
     func body(content: Content) -> some View {
+        let shouldApplyResolving = isResolving && todayContentState.allowsSectionResolvingTreatment
+
         content
-            .blur(radius: isResolving && reduceMotion == false ? style.blur : 0)
-            .opacity(isResolving ? style.opacity : 1)
-            .animation(SkyAwareMotion.resolve(reduceMotion), value: isResolving)
+            .blur(radius: shouldApplyResolving && reduceMotion == false ? style.blur : 0)
+            .opacity(shouldApplyResolving ? style.opacity : 1)
+            .animation(SkyAwareMotion.resolve(reduceMotion), value: shouldApplyResolving)
     }
 }
 
 extension View {
     func summaryResolving(
         _ isResolving: Bool,
+        todayContentState: TodayContentState,
         style: SummaryResolveForwardStyle = .blurLift
     ) -> some View {
-        modifier(SummaryResolvingModifier(isResolving: isResolving, style: style))
+        modifier(
+            SummaryResolvingModifier(
+                isResolving: isResolving,
+                todayContentState: todayContentState,
+                style: style
+            )
+        )
     }
 }

--- a/Sources/Features/Summary/SummaryStatus.swift
+++ b/Sources/Features/Summary/SummaryStatus.swift
@@ -34,12 +34,9 @@ struct SummaryStatus: View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var showsOfflineExplanation = false
-    @State private var displayedWeather: SummaryWeather?
-    @State private var displayedWeatherLocationIdentity: SummaryWeatherLocationIdentity?
 
     let statusText: String
     let weather: SummaryWeather?
-    let weatherLocationIdentity: SummaryWeatherLocationIdentity?
     let resolutionState: SummaryResolutionState
     let showsOfflineToken: Bool
     let isLocationUnavailable: Bool
@@ -52,13 +49,7 @@ struct SummaryStatus: View {
     }()
 
     private var visibleWeather: SummaryWeather? {
-        Self.resolveDisplayedWeather(
-            liveWeather: weather,
-            displayedWeather: displayedWeather,
-            isRefreshing: resolutionState.isRefreshing,
-            displayedWeatherLocationIdentity: displayedWeatherLocationIdentity,
-            weatherLocationIdentity: weatherLocationIdentity
-        ).weather
+        weather
     }
 
     private var formattedTemperature: String? {
@@ -132,9 +123,6 @@ struct SummaryStatus: View {
             shadowY: cardShadowY
         )
         .animation(SkyAwareMotion.settle(reduceMotion), value: clampedCondenseProgress)
-        .task(id: weatherTaskState) {
-            updateDisplayedWeather()
-        }
     }
 
     private var locationUnavailableCard: some View {
@@ -268,50 +256,8 @@ struct SummaryStatus: View {
         .animation(SkyAwareMotion.message(reduceMotion), value: visibleWeather?.conditionText)
     }
 
-    private var weatherTaskState: WeatherTaskState {
-        WeatherTaskState(
-            liveWeather: weather,
-            isRefreshing: resolutionState.isRefreshing,
-            weatherLocationIdentity: weatherLocationIdentity
-        )
-    }
-
-    private func updateDisplayedWeather() {
-        let updatedWeather = Self.resolveDisplayedWeather(
-            liveWeather: weather,
-            displayedWeather: displayedWeather,
-            isRefreshing: resolutionState.isRefreshing,
-            displayedWeatherLocationIdentity: displayedWeatherLocationIdentity,
-            weatherLocationIdentity: weatherLocationIdentity
-        )
-        displayedWeather = updatedWeather.weather
-        displayedWeatherLocationIdentity = updatedWeather.locationIdentity
-    }
-
     private func formatTemperature(_ temperature: Measurement<UnitTemperature>) -> String {
         Self.temperatureFormatter.string(from: temperature)
-    }
-}
-
-extension SummaryStatus {
-    static func resolveDisplayedWeather(
-        liveWeather: SummaryWeather?,
-        displayedWeather: SummaryWeather?,
-        isRefreshing: Bool,
-        displayedWeatherLocationIdentity: SummaryWeatherLocationIdentity?,
-        weatherLocationIdentity: SummaryWeatherLocationIdentity?
-    ) -> (weather: SummaryWeather?, locationIdentity: SummaryWeatherLocationIdentity?) {
-        if let liveWeather {
-            return (liveWeather, weatherLocationIdentity)
-        }
-
-        guard isRefreshing,
-              displayedWeather != nil,
-              displayedWeatherLocationIdentity == weatherLocationIdentity else {
-            return (nil, nil)
-        }
-
-        return (displayedWeather, displayedWeatherLocationIdentity)
     }
 }
 
@@ -486,12 +432,6 @@ private struct SummarySettledConditionLine: View {
     }
 }
 
-private struct WeatherTaskState: Equatable {
-    let liveWeather: SummaryWeather?
-    let isRefreshing: Bool
-    let weatherLocationIdentity: SummaryWeatherLocationIdentity?
-}
-
 #Preview {
     VStack {
         SummaryStatus(
@@ -514,15 +454,6 @@ private struct WeatherTaskState: Equatable {
                 windDirection: "NNW",
                 pressure: .init(value: 0.25, unit: .inchesOfMercury),
                 pressureTrend: "climbing"
-            ),
-            weatherLocationIdentity: .init(
-                snapshot: .init(
-                    coordinates: .init(latitude: 39.7392, longitude: -104.9903),
-                    timestamp: .now,
-                    accuracy: 20,
-                    placemarkSummary: "Denver, CO",
-                    h3Cell: nil
-                )
             ),
             resolutionState: SummaryResolutionState(),
             showsOfflineToken: false,
@@ -550,15 +481,6 @@ private struct WeatherTaskState: Equatable {
                 pressure: .init(value: 0.25, unit: .inchesOfMercury),
                 pressureTrend: "falling"
             ),
-            weatherLocationIdentity: .init(
-                snapshot: .init(
-                    coordinates: .init(latitude: 39.0473, longitude: -95.6752),
-                    timestamp: .now,
-                    accuracy: 20,
-                    placemarkSummary: "Topeka, KS",
-                    h3Cell: nil
-                )
-            ),
             resolutionState: SummaryResolutionState(),
             showsOfflineToken: true,
             isLocationUnavailable: false,
@@ -567,7 +489,6 @@ private struct WeatherTaskState: Equatable {
         SummaryStatus(
             statusText: "Location not available",
             weather: nil,
-            weatherLocationIdentity: nil,
             resolutionState: SummaryResolutionState(),
             showsOfflineToken: false,
             isLocationUnavailable: true,

--- a/Sources/Features/Summary/SummaryStatus.swift
+++ b/Sources/Features/Summary/SummaryStatus.swift
@@ -203,7 +203,9 @@ struct SummaryStatus: View {
                 .truncationMode(.tail)
 
             SummaryStatusSecondaryLine(
-                message: todayContentState.showsCalmUpdatingCue ? resolutionState.primaryActiveMessage : nil
+                message: todayContentState.showsCalmUpdatingCue
+                    ? resolutionState.primaryActiveMessage ?? resolutionState.recentCompletedMessage
+                    : nil
             )
         }
         .animation(SkyAwareMotion.message(reduceMotion), value: statusText)
@@ -236,7 +238,7 @@ struct SummaryStatus: View {
             Group {
                 SummarySettledConditionLine(
                     conditionText: visibleWeather?.conditionText,
-                    isRefreshing: resolutionState.isRefreshing
+                    isRefreshing: todayContentState.showsCalmUpdatingCue
                 )
             }
             .font(.footnote)

--- a/Sources/Features/Summary/SummaryStatus.swift
+++ b/Sources/Features/Summary/SummaryStatus.swift
@@ -38,6 +38,7 @@ struct SummaryStatus: View {
     let statusText: String
     let weather: SummaryWeather?
     let resolutionState: SummaryResolutionState
+    let todayContentState: TodayContentState
     let showsOfflineToken: Bool
     let isLocationUnavailable: Bool
     let condenseProgress: CGFloat
@@ -202,7 +203,7 @@ struct SummaryStatus: View {
                 .truncationMode(.tail)
 
             SummaryStatusSecondaryLine(
-                resolutionState: resolutionState
+                message: todayContentState.showsCalmUpdatingCue ? resolutionState.primaryActiveMessage : nil
             )
         }
         .animation(SkyAwareMotion.message(reduceMotion), value: statusText)
@@ -319,7 +320,7 @@ private struct SummaryOfflineToken: View {
 private struct SummaryStatusSecondaryLine: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    let resolutionState: SummaryResolutionState
+    let message: String?
     @State private var displayedMessage: String?
 
     private var messageTransition: AnyTransition {
@@ -354,44 +355,9 @@ private struct SummaryStatusSecondaryLine: View {
         .frame(minHeight: 18, alignment: .leading)
         .clipped()
         .animation(SkyAwareMotion.message(reduceMotion), value: displayedMessage)
-        .task(id: taskState) {
-            await updateDisplayedMessage()
+        .task(id: message) {
+            setDisplayedMessage(message)
         }
-    }
-
-    private var taskState: SecondaryLineTaskState {
-        SecondaryLineTaskState(
-            activeMessages: resolutionState.activeMessages,
-            recentCompletedMessage: resolutionState.recentCompletedMessage,
-            recentCompletedDeadline: resolutionState.recentCompletedDeadline
-        )
-    }
-
-    @MainActor
-    private func updateDisplayedMessage() async {
-        if let primaryActiveMessage = resolutionState.primaryActiveMessage {
-            setDisplayedMessage(primaryActiveMessage)
-            return
-        }
-
-        if let recentCompletedMessage = resolutionState.recentCompletedMessage {
-            setDisplayedMessage(recentCompletedMessage)
-
-            if let recentCompletedDeadline = resolutionState.recentCompletedDeadline {
-                let remainingMilliseconds = max(
-                    Int((recentCompletedDeadline.timeIntervalSinceNow * 1_000).rounded(.up)),
-                    0
-                )
-
-                if remainingMilliseconds > 0 {
-                    try? await Task.sleep(for: .milliseconds(remainingMilliseconds))
-                }
-            }
-
-            if Task.isCancelled { return }
-        }
-
-        setDisplayedMessage(nil)
     }
 
     @MainActor
@@ -400,12 +366,6 @@ private struct SummaryStatusSecondaryLine: View {
             displayedMessage = message
         }
     }
-}
-
-private struct SecondaryLineTaskState: Equatable {
-    let activeMessages: [String]
-    let recentCompletedMessage: String?
-    let recentCompletedDeadline: Date?
 }
 
 private struct SummarySettledConditionLine: View {
@@ -456,6 +416,7 @@ private struct SummarySettledConditionLine: View {
                 pressureTrend: "climbing"
             ),
             resolutionState: SummaryResolutionState(),
+            todayContentState: .current,
             showsOfflineToken: false,
             isLocationUnavailable: false,
             condenseProgress: 0
@@ -482,6 +443,7 @@ private struct SummarySettledConditionLine: View {
                 pressureTrend: "falling"
             ),
             resolutionState: SummaryResolutionState(),
+            todayContentState: .current,
             showsOfflineToken: true,
             isLocationUnavailable: false,
             condenseProgress: 0.75
@@ -490,6 +452,7 @@ private struct SummarySettledConditionLine: View {
             statusText: "Location not available",
             weather: nil,
             resolutionState: SummaryResolutionState(),
+            todayContentState: .noCacheResolving,
             showsOfflineToken: false,
             isLocationUnavailable: true,
             condenseProgress: 0.75

--- a/Sources/Features/Summary/SummaryStatus.swift
+++ b/Sources/Features/Summary/SummaryStatus.swift
@@ -205,6 +205,10 @@ struct SummaryStatus: View {
             SummaryStatusSecondaryLine(
                 message: todayContentState.showsCalmUpdatingCue
                     ? resolutionState.primaryActiveMessage ?? resolutionState.recentCompletedMessage
+                    : nil,
+                recentCompletedDeadline: todayContentState.showsCalmUpdatingCue
+                    && resolutionState.primaryActiveMessage == nil
+                    ? resolutionState.recentCompletedDeadline
                     : nil
             )
         }
@@ -323,7 +327,13 @@ private struct SummaryStatusSecondaryLine: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let message: String?
+    let recentCompletedDeadline: Date?
     @State private var displayedMessage: String?
+
+    private struct TaskIdentity: Equatable {
+        let message: String?
+        let recentCompletedDeadline: Date?
+    }
 
     private var messageTransition: AnyTransition {
         if reduceMotion {
@@ -357,15 +367,41 @@ private struct SummaryStatusSecondaryLine: View {
         .frame(minHeight: 18, alignment: .leading)
         .clipped()
         .animation(SkyAwareMotion.message(reduceMotion), value: displayedMessage)
-        .task(id: message) {
-            setDisplayedMessage(message)
+        .task(id: taskIdentity) {
+            await setDisplayedMessage(message)
         }
     }
 
+    private var taskIdentity: TaskIdentity {
+        TaskIdentity(message: message, recentCompletedDeadline: recentCompletedDeadline)
+    }
+
     @MainActor
-    private func setDisplayedMessage(_ message: String?) {
+    private func setDisplayedMessage(_ message: String?) async {
         withAnimation(SkyAwareMotion.message(reduceMotion)) {
             displayedMessage = message
+        }
+
+        guard message != nil, let recentCompletedDeadline else { return }
+
+        let remaining = recentCompletedDeadline.timeIntervalSinceNow
+        guard remaining > 0 else {
+            withAnimation(SkyAwareMotion.message(reduceMotion)) {
+                displayedMessage = nil
+            }
+            return
+        }
+
+        do {
+            try await Task.sleep(for: .milliseconds(Int64((remaining * 1_000).rounded(.up))))
+        } catch {
+            return
+        }
+
+        guard Task.isCancelled == false else { return }
+
+        withAnimation(SkyAwareMotion.message(reduceMotion)) {
+            displayedMessage = nil
         }
     }
 }

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -257,6 +257,7 @@ struct SummaryView: View {
         )
         .summaryResolving(
             resolutionState.isResolving(.stormRisk) && stormRiskShowsResolvingPlaceholder == false && showsOfflineToken == false,
+            todayContentState: todayContentState,
             style: .subtle
         )
         .accessibilityHint("Opens the severe risk map.")
@@ -289,6 +290,7 @@ struct SummaryView: View {
         )
         .summaryResolving(
             resolutionState.isResolving(.severeRisk) && severeRiskShowsResolvingPlaceholder == false && showsOfflineToken == false,
+            todayContentState: todayContentState,
             style: .subtle
         )
         .accessibilityHint("Opens the highlighted severe threat map.")
@@ -318,6 +320,7 @@ struct SummaryView: View {
         )
         .summaryResolving(
             resolutionState.isResolving(.fireRisk) && fireRisk != nil && showsOfflineToken == false,
+            todayContentState: todayContentState,
             style: .subtle
         )
         .accessibilityHint("Opens the fire risk map.")
@@ -346,6 +349,7 @@ struct SummaryView: View {
             statusText: statusText,
             weather: weather,
             resolutionState: resolutionState,
+            todayContentState: todayContentState,
             showsOfflineToken: showsOfflineToken,
             isLocationUnavailable: isLocationUnavailable,
             condenseProgress: headerCondenseProgress
@@ -365,6 +369,7 @@ struct SummaryView: View {
                 .placeholder(isWeatherLoading && showsOfflineToken == false, animated: true)
                 .summaryResolving(
                     resolutionState.isResolving(.atmosphere) && showsOfflineToken == false,
+                    todayContentState: todayContentState,
                     style: .subtle
                 )
         }
@@ -388,6 +393,7 @@ struct SummaryView: View {
                 mesos: mesos,
                 alerts: alerts,
                 isLoading: localAlertsPresentationState == .loading,
+                todayContentState: todayContentState,
                 isOffline: showsOfflineToken,
                 onOpenAlertCenter: onOpenAlerts
             )
@@ -397,6 +403,7 @@ struct SummaryView: View {
                     resolutionState: resolutionState,
                     showsOfflineToken: showsOfflineToken
                 ),
+                todayContentState: todayContentState,
                 style: .subtle
             )
         }
@@ -405,9 +412,14 @@ struct SummaryView: View {
             outlook: outlook,
             isLoading: outlook == nil && (readinessState == .loadingLocation || readinessState == .resolvingLocalContext),
             isPending: outlook == nil && !(readinessState == .loadingLocation || readinessState == .resolvingLocalContext),
+            todayContentState: todayContentState,
             onBrowseAllOutlooks: onOpenOutlooks
         )
-        .summaryResolving(resolutionState.isResolving(.outlook), style: .subtle)
+        .summaryResolving(
+            resolutionState.isResolving(.outlook),
+            todayContentState: todayContentState,
+            style: .subtle
+        )
 
         AttributionView()
     }
@@ -628,6 +640,38 @@ private extension AnyTransition {
             weather: SummaryPreviewData.weather,
             todayContentState: .cachedRefreshing,
             outlook: nil,
+            mesos: [],
+            alerts: []
+        )
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary – Cached Refreshing Complete") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .moderate,
+            severeRisk: .hail(probability: 0.20),
+            fireRisk: .critical,
+            weather: SummaryPreviewData.weather,
+            todayContentState: .cachedRefreshing,
+            outlook: ConvectiveOutlook.sampleOutlookDtos.first,
+            mesos: MD.sampleDiscussionDTOs,
+            alerts: Watch.sampleWatchRows
+        )
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary – Cached Refreshing Empty Alerts") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .allClear,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            weather: SummaryPreviewData.weather,
+            todayContentState: .cachedRefreshing,
+            outlook: ConvectiveOutlook.sampleOutlookDtos.first,
             mesos: [],
             alerts: []
         )

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -175,10 +175,9 @@ struct SummaryView: View {
 
     private var localAlertsPresentationState: LocalAlertsPresentationState {
         Self.localAlertsPresentationState(
-            readinessState: readinessState,
+            todayContentState: todayContentState,
             hasActiveAlerts: hasActiveAlerts,
-            isLocationUnavailable: isLocationUnavailable,
-            isAlertsResolving: resolutionState.isResolving(.alerts)
+            isLocationUnavailable: isLocationUnavailable
         )
     }
 
@@ -239,10 +238,8 @@ struct SummaryView: View {
     private var stormRiskButton: some View {
         let stormRiskShowsResolvingPlaceholder = Self.showsRiskResolvingPlaceholder(
             hasRiskValue: stormRisk != nil,
-            readinessState: readinessState,
-            isSectionResolving: resolutionState.isResolving(.stormRisk),
-            showsOfflineToken: showsOfflineToken,
-            isRefreshing: resolutionState.isRefreshing
+            todayContentState: todayContentState,
+            showsOfflineToken: showsOfflineToken
         )
 
         return Button {
@@ -273,10 +270,8 @@ struct SummaryView: View {
     private var severeRiskButton: some View {
         let severeRiskShowsResolvingPlaceholder = Self.showsRiskResolvingPlaceholder(
             hasRiskValue: severeRisk != nil,
-            readinessState: readinessState,
-            isSectionResolving: resolutionState.isResolving(.severeRisk),
-            showsOfflineToken: showsOfflineToken,
-            isRefreshing: resolutionState.isRefreshing
+            todayContentState: todayContentState,
+            showsOfflineToken: showsOfflineToken
         )
 
         return Button {
@@ -308,17 +303,15 @@ struct SummaryView: View {
         Button {
             onOpenMapLayer(.fire)
         } label: {
-            FireWeatherRailView(
-                level: fireRisk,
-                isOffline: showsOfflineToken,
-                showsResolvingPlaceholder: Self.showsRiskResolvingPlaceholder(
-                    hasRiskValue: fireRisk != nil,
-                    readinessState: readinessState,
-                    isSectionResolving: resolutionState.isResolving(.fireRisk),
-                    showsOfflineToken: showsOfflineToken,
-                    isRefreshing: resolutionState.isRefreshing
+                FireWeatherRailView(
+                    level: fireRisk,
+                    isOffline: showsOfflineToken,
+                    showsResolvingPlaceholder: Self.showsRiskResolvingPlaceholder(
+                        hasRiskValue: fireRisk != nil,
+                        todayContentState: todayContentState,
+                        showsOfflineToken: showsOfflineToken
+                    )
                 )
-            )
             .contentShape(RoundedRectangle(cornerRadius: SkyAwareRadius.large, style: .continuous))
         }
         .buttonStyle(
@@ -343,7 +336,7 @@ struct SummaryView: View {
                 severeRisk: severeRisk,
                 fireRisk: fireRisk,
                 alerts: alerts,
-                readinessState: readinessState,
+                todayContentState: todayContentState,
                 resolutionState: resolutionState,
                 showsOfflineToken: showsOfflineToken,
                 onOpenMapLayer: onOpenMapLayer,
@@ -465,10 +458,9 @@ struct SummaryView: View {
     }
 
     static func localAlertsPresentationState(
-        readinessState: SummaryReadinessState,
+        todayContentState: TodayContentState,
         hasActiveAlerts: Bool,
-        isLocationUnavailable: Bool,
-        isAlertsResolving: Bool
+        isLocationUnavailable: Bool
     ) -> LocalAlertsPresentationState {
         if isLocationUnavailable {
             return .unavailable
@@ -476,16 +468,11 @@ struct SummaryView: View {
         if hasActiveAlerts {
             return .alerts
         }
-        if isAlertsResolving {
+        if todayContentState.showsResolvingSurface {
             return .loading
         }
 
-        switch readinessState {
-        case .loadingLocation, .resolvingLocalContext:
-            return .loading
-        case .loadingLocalData, .ready, .locationUnavailable:
-            return .empty
-        }
+        return .empty
     }
 
     static func appliesLocalAlertsResolving(
@@ -519,29 +506,13 @@ struct SummaryView: View {
 
     static func showsRiskResolvingPlaceholder(
         hasRiskValue: Bool,
-        readinessState: SummaryReadinessState,
-        isSectionResolving: Bool,
-        showsOfflineToken: Bool,
-        isRefreshing: Bool = false
+        todayContentState: TodayContentState,
+        showsOfflineToken: Bool
     ) -> Bool {
         guard showsOfflineToken == false, hasRiskValue == false else {
             return false
         }
-
-        if isRefreshing {
-            return true
-        }
-
-        if isSectionResolving {
-            return true
-        }
-
-        switch readinessState {
-        case .loadingLocation, .resolvingLocalContext, .loadingLocalData:
-            return true
-        case .ready, .locationUnavailable:
-            return false
-        }
+        return todayContentState.showsResolvingSurface
     }
 }
 
@@ -647,6 +618,51 @@ private extension AnyTransition {
             readinessState: .loadingLocalData,
             showsOfflineToken: true,
             outlook: nil,
+            mesos: [],
+            alerts: []
+        )
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary – Cached Refreshing Empty Alerts") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .allClear,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            weather: SummaryPreviewData.weather,
+            todayContentState: .cachedRefreshing,
+            mesos: [],
+            alerts: []
+        )
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary – Cached Refreshing Populated Alerts") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .allClear,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            weather: SummaryPreviewData.weather,
+            todayContentState: .cachedRefreshing,
+            mesos: MD.sampleDiscussionDTOs,
+            alerts: Watch.sampleWatchRows
+        )
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary – Cached Refreshing Risk") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .high,
+            severeRisk: .tornado(probability: 0.20),
+            fireRisk: .critical,
+            weather: SummaryPreviewData.weather,
+            todayContentState: .cachedRefreshing,
             mesos: [],
             alerts: []
         )

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -168,11 +168,6 @@ struct SummaryView: View {
         readinessState == .locationUnavailable
     }
 
-    private var weatherLocationIdentity: SummaryWeatherLocationIdentity? {
-        guard let snap else { return nil }
-        return SummaryWeatherLocationIdentity(snapshot: snap)
-    }
-
     private var localAlertsPresentationState: LocalAlertsPresentationState {
         Self.localAlertsPresentationState(
             todayContentState: todayContentState,
@@ -350,7 +345,6 @@ struct SummaryView: View {
         SummaryStatus(
             statusText: statusText,
             weather: weather,
-            weatherLocationIdentity: weatherLocationIdentity,
             resolutionState: resolutionState,
             showsOfflineToken: showsOfflineToken,
             isLocationUnavailable: isLocationUnavailable,
@@ -607,7 +601,7 @@ private extension AnyTransition {
     }
 }
 
-#Preview("Summary – Loading") {
+#Preview("Summary – No Cache Resolving Weather") {
     NavigationStack {
         SummaryPreviewContent(
             stormRisk: nil,
@@ -616,7 +610,7 @@ private extension AnyTransition {
             weather: nil,
             todayContentState: .noCacheResolving,
             readinessState: .loadingLocalData,
-            showsOfflineToken: true,
+            showsOfflineToken: false,
             outlook: nil,
             mesos: [],
             alerts: []
@@ -625,7 +619,7 @@ private extension AnyTransition {
     }
 }
 
-#Preview("Summary – Cached Refreshing Empty Alerts") {
+#Preview("Summary – Cached Refreshing Weather") {
     NavigationStack {
         SummaryPreviewContent(
             stormRisk: .allClear,
@@ -633,6 +627,25 @@ private extension AnyTransition {
             fireRisk: .clear,
             weather: SummaryPreviewData.weather,
             todayContentState: .cachedRefreshing,
+            outlook: nil,
+            mesos: [],
+            alerts: []
+        )
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary – Unavailable Weather") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: nil,
+            severeRisk: nil,
+            fireRisk: nil,
+            weather: nil,
+            todayContentState: .unavailable,
+            readinessState: .ready,
+            showsOfflineToken: false,
+            outlook: nil,
             mesos: [],
             alerts: []
         )

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -382,7 +382,7 @@ struct SummaryView: View {
             ActiveAlertSummaryView(
                 mesos: mesos,
                 alerts: alerts,
-                isLoading: localAlertsDisplayState.showsLoadingCopy,
+                localAlertsDisplayState: localAlertsDisplayState,
                 todayContentState: todayContentState,
                 isOffline: localAlertsDisplayState.showsOfflineStatusCopy,
                 onOpenAlertCenter: onOpenAlerts

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -694,7 +694,223 @@ private extension AnyTransition {
     }
 }
 
+#Preview("Summary – No Cache Resolving") {
+    NavigationStack {
+        SummaryPreviewContent(
+            snap: nil,
+            stormRisk: nil,
+            severeRisk: nil,
+            fireRisk: nil,
+            weather: nil,
+            todayContentState: .noCacheResolving,
+            readinessState: .loadingLocalData,
+            outlook: nil,
+            mesos: [],
+            alerts: [],
+            hasCachedProjectionForAlerts: false,
+            lastHotAlertsLoadAt: nil
+        )
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary – Valid Cache Current") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .slight,
+            severeRisk: .tornado(probability: 0.10),
+            fireRisk: .extreme,
+            weather: SummaryPreviewData.weather,
+            todayContentState: .current,
+            outlook: ConvectiveOutlook.sampleOutlookDtos.first,
+            mesos: MD.sampleDiscussionDTOs,
+            alerts: Watch.sampleWatchRows
+        )
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary – Cached Refreshing Composite") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .moderate,
+            severeRisk: .hail(probability: 0.20),
+            fireRisk: .critical,
+            weather: SummaryPreviewData.weather,
+            todayContentState: .cachedRefreshing,
+            outlook: ConvectiveOutlook.sampleOutlookDtos.first,
+            mesos: MD.sampleDiscussionDTOs,
+            alerts: Watch.sampleWatchRows,
+            resolutionState: SummaryPreviewData.calmRefreshState()
+        )
+        .environment(\.colorScheme, .dark)
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary – Cached Refreshing Empty Local Alerts") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .allClear,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            weather: SummaryPreviewData.weather,
+            todayContentState: .cachedRefreshing,
+            outlook: ConvectiveOutlook.sampleOutlookDtos.first,
+            mesos: [],
+            alerts: [],
+            resolutionState: SummaryPreviewData.calmRefreshState(primaryTask: .alerts)
+        )
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary – Stale Cache") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .slight,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            weather: SummaryPreviewData.weather,
+            todayContentState: .degraded,
+            showsOfflineToken: true,
+            outlook: ConvectiveOutlook.sampleOutlookDtos.first,
+            mesos: MD.sampleDiscussionDTOs,
+            alerts: Watch.sampleWatchRows
+        )
+        .environment(\.colorScheme, .light)
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary – Stale Refreshing") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .moderate,
+            severeRisk: .hail(probability: 0.15),
+            fireRisk: .critical,
+            weather: SummaryPreviewData.weather,
+            todayContentState: .staleRefreshing,
+            showsOfflineToken: true,
+            outlook: ConvectiveOutlook.sampleOutlookDtos.first,
+            mesos: [],
+            alerts: [],
+            resolutionState: SummaryPreviewData.calmRefreshState(primaryTask: .weather)
+        )
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary – Degraded With Useful Cached Content") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .high,
+            severeRisk: .tornado(probability: 0.20),
+            fireRisk: .extreme,
+            weather: SummaryPreviewData.weather,
+            todayContentState: .degraded,
+            showsOfflineToken: true,
+            outlook: ConvectiveOutlook.sampleOutlookDtos.first,
+            mesos: MD.sampleDiscussionDTOs,
+            alerts: Watch.sampleWatchRows
+        )
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary – Unavailable No Useful Data") {
+    NavigationStack {
+        SummaryPreviewContent(
+            snap: nil,
+            stormRisk: nil,
+            severeRisk: nil,
+            fireRisk: nil,
+            weather: nil,
+            todayContentState: .unavailable,
+            readinessState: .ready,
+            outlook: nil,
+            mesos: [],
+            alerts: [],
+            hasCachedProjectionForAlerts: false,
+            lastHotAlertsLoadAt: nil
+        )
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary – Partial Data Available") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .moderate,
+            severeRisk: nil,
+            fireRisk: nil,
+            weather: nil,
+            todayContentState: .current,
+            outlook: ConvectiveOutlook.sampleOutlookDtos.first,
+            mesos: [MD.sampleDiscussionDTOs[0]],
+            alerts: [],
+            hasCachedProjectionForAlerts: true,
+            lastHotAlertsLoadAt: .now
+        )
+        .environment(\.dynamicTypeSize, .accessibility3)
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary – Current Weather Retained During Refresh") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .slight,
+            severeRisk: .tornado(probability: 0.10),
+            fireRisk: .critical,
+            weather: SummaryPreviewData.weather,
+            todayContentState: .cachedRefreshing,
+            outlook: ConvectiveOutlook.sampleOutlookDtos.first,
+            mesos: MD.sampleDiscussionDTOs,
+            alerts: Watch.sampleWatchRows,
+            resolutionState: SummaryPreviewData.calmRefreshState(primaryTask: .weather)
+        )
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary – Atmospheric Values Retained During Refresh") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .slight,
+            severeRisk: .tornado(probability: 0.10),
+            fireRisk: .critical,
+            weather: SummaryPreviewData.weather,
+            todayContentState: .cachedRefreshing,
+            outlook: ConvectiveOutlook.sampleOutlookDtos.first,
+            mesos: MD.sampleDiscussionDTOs,
+            alerts: Watch.sampleWatchRows,
+            resolutionState: SummaryPreviewData.calmRefreshState(primaryTask: .weather)
+        )
+        .environment(\.colorScheme, .dark)
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview("Summary – Local Alerts Update Present") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .allClear,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            weather: SummaryPreviewData.weather,
+            todayContentState: .cachedRefreshing,
+            outlook: ConvectiveOutlook.sampleOutlookDtos.first,
+            mesos: MD.sampleDiscussionDTOs,
+            alerts: Watch.sampleWatchRows,
+            resolutionState: SummaryPreviewData.calmRefreshState(primaryTask: .alerts)
+        )
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
 private struct SummaryPreviewContent: View {
+    let snap: LocationSnapshot?
     let stormRisk: StormRiskLevel?
     let severeRisk: SevereWeatherThreat?
     let fireRisk: FireRiskLevel?
@@ -705,8 +921,14 @@ private struct SummaryPreviewContent: View {
     let outlook: ConvectiveOutlookDTO?
     let mesos: [MdDTO]
     let alerts: [AlertDTO]
+    let resolutionState: SummaryResolutionState
+    let localAlertsDisplayState: LocalAlertsDisplayState?
+    let hasCachedProjectionForAlerts: Bool
+    let lastHotAlertsLoadAt: Date?
+    let isCurrentContextResolvedInPipeline: Bool
 
     init(
+        snap: LocationSnapshot? = SummaryPreviewData.snapshot,
         stormRisk: StormRiskLevel?,
         severeRisk: SevereWeatherThreat?,
         fireRisk: FireRiskLevel? = .extreme,
@@ -716,8 +938,14 @@ private struct SummaryPreviewContent: View {
         showsOfflineToken: Bool = false,
         outlook: ConvectiveOutlookDTO? = ConvectiveOutlook.sampleOutlookDtos.first,
         mesos: [MdDTO] = MD.sampleDiscussionDTOs,
-        alerts: [AlertDTO] = Watch.sampleWatchRows
+        alerts: [AlertDTO] = Watch.sampleWatchRows,
+        resolutionState: SummaryResolutionState = SummaryResolutionState(),
+        localAlertsDisplayState: LocalAlertsDisplayState? = nil,
+        hasCachedProjectionForAlerts: Bool = true,
+        lastHotAlertsLoadAt: Date? = .now,
+        isCurrentContextResolvedInPipeline: Bool = false
     ) {
+        self.snap = snap
         self.stormRisk = stormRisk
         self.severeRisk = severeRisk
         self.fireRisk = fireRisk
@@ -728,25 +956,25 @@ private struct SummaryPreviewContent: View {
         self.outlook = outlook
         self.mesos = mesos
         self.alerts = alerts
+        self.resolutionState = resolutionState
+        self.localAlertsDisplayState = localAlertsDisplayState
+        self.hasCachedProjectionForAlerts = hasCachedProjectionForAlerts
+        self.lastHotAlertsLoadAt = lastHotAlertsLoadAt
+        self.isCurrentContextResolvedInPipeline = isCurrentContextResolvedInPipeline
     }
 
     var body: some View {
-        let localAlertsDisplayState = LocalAlertsDisplayState.from(
+        let localAlertsDisplayState = localAlertsDisplayState ?? LocalAlertsDisplayState.from(
             todayContentState: todayContentState,
-            hasCachedProjection: true,
-            isCurrentContextResolvedInPipeline: false,
-            lastHotAlertsLoadAt: .now,
+            hasCachedProjection: hasCachedProjectionForAlerts,
+            isCurrentContextResolvedInPipeline: isCurrentContextResolvedInPipeline,
+            lastHotAlertsLoadAt: lastHotAlertsLoadAt,
             hasActiveAlerts: !mesos.isEmpty || !alerts.isEmpty,
             isLocationUnavailable: readinessState == .locationUnavailable
         )
 
         SummaryView(
-            snap: .init(
-                coordinates: .init(latitude: 39.75, longitude: -104.44),
-                timestamp: .now,
-                accuracy: 20,
-                placemarkSummary: "Bennett, CO"
-            ),
+            snap: snap,
             stormRisk: stormRisk,
             severeRisk: severeRisk,
             fireRisk: fireRisk,
@@ -757,7 +985,7 @@ private struct SummaryPreviewContent: View {
             todayContentState: todayContentState,
             localAlertsDisplayState: localAlertsDisplayState,
             readinessState: readinessState,
-            resolutionState: SummaryResolutionState(),
+            resolutionState: resolutionState,
             showsOfflineToken: showsOfflineToken,
             headerCondenseProgress: 0,
             locationReliabilityRailState: .init(onOpen: {}, onDismiss: {}),
@@ -769,6 +997,13 @@ private struct SummaryPreviewContent: View {
 }
 
 private enum SummaryPreviewData {
+    static let snapshot = LocationSnapshot(
+        coordinates: .init(latitude: 39.75, longitude: -104.44),
+        timestamp: .now,
+        accuracy: 20,
+        placemarkSummary: "Bennett, CO"
+    )
+
     static let weather = SummaryWeather(
         temperature: Measurement(value: 82.0, unit: .fahrenheit),
         symbolName: "sun.max.fill",
@@ -782,4 +1017,10 @@ private enum SummaryPreviewData {
         pressure: Measurement(value: 29.78, unit: .inchesOfMercury),
         pressureTrend: "falling"
     )
+
+    static func calmRefreshState(primaryTask: SummaryProviderTask = .weather) -> SummaryResolutionState {
+        var state = SummaryResolutionState()
+        state.begin(task: primaryTask, sections: [.conditions, .atmosphere, .alerts, .outlook])
+        return state
+    }
 }

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -124,13 +124,6 @@ struct SummaryView: View {
         let onDismiss: () -> Void
     }
 
-    enum LocalAlertsPresentationState: Equatable {
-        case unavailable
-        case loading
-        case alerts
-        case empty
-    }
-
     let snap: LocationSnapshot?
     let stormRisk: StormRiskLevel?
     let severeRisk: SevereWeatherThreat?
@@ -140,6 +133,7 @@ struct SummaryView: View {
     let outlook: ConvectiveOutlookDTO?
     let weather: SummaryWeather?
     let todayContentState: TodayContentState
+    let localAlertsDisplayState: LocalAlertsDisplayState
     let readinessState: SummaryReadinessState
     let resolutionState: SummaryResolutionState
     let showsOfflineToken: Bool
@@ -148,10 +142,6 @@ struct SummaryView: View {
     let onOpenMapLayer: (MapLayer) -> Void
     let onOpenAlerts: () -> Void
     let onOpenOutlooks: () -> Void
-
-    private var hasActiveAlerts: Bool {
-        !mesos.isEmpty || !alerts.isEmpty
-    }
 
     private var isWeatherLoading: Bool {
         weather == nil
@@ -168,12 +158,12 @@ struct SummaryView: View {
         readinessState == .locationUnavailable
     }
 
+    private var hasActiveAlerts: Bool {
+        !mesos.isEmpty || !alerts.isEmpty
+    }
+
     private var localAlertsPresentationState: LocalAlertsPresentationState {
-        Self.localAlertsPresentationState(
-            todayContentState: todayContentState,
-            hasActiveAlerts: hasActiveAlerts,
-            isLocationUnavailable: isLocationUnavailable
-        )
+        localAlertsDisplayState.presentationState
     }
 
     private var hasMeaningfulContent: Bool {
@@ -463,24 +453,6 @@ struct SummaryView: View {
         emptySectionCard(title: title, message: message, symbol: symbol)
     }
 
-    static func localAlertsPresentationState(
-        todayContentState: TodayContentState,
-        hasActiveAlerts: Bool,
-        isLocationUnavailable: Bool
-    ) -> LocalAlertsPresentationState {
-        if isLocationUnavailable {
-            return .unavailable
-        }
-        if hasActiveAlerts {
-            return .alerts
-        }
-        if todayContentState.showsResolvingSurface {
-            return .loading
-        }
-
-        return .empty
-    }
-
     static func appliesLocalAlertsResolving(
         presentationState: LocalAlertsPresentationState,
         resolutionState: SummaryResolutionState,
@@ -764,6 +736,15 @@ private struct SummaryPreviewContent: View {
     }
 
     var body: some View {
+        let localAlertsDisplayState = LocalAlertsDisplayState.from(
+            todayContentState: todayContentState,
+            hasCachedProjection: true,
+            isCurrentContextResolvedInPipeline: false,
+            lastHotAlertsLoadAt: .now,
+            hasActiveAlerts: !mesos.isEmpty || !alerts.isEmpty,
+            isLocationUnavailable: readinessState == .locationUnavailable
+        )
+
         SummaryView(
             snap: .init(
                 coordinates: .init(latitude: 39.75, longitude: -104.44),
@@ -779,6 +760,7 @@ private struct SummaryPreviewContent: View {
             outlook: outlook,
             weather: weather,
             todayContentState: todayContentState,
+            localAlertsDisplayState: localAlertsDisplayState,
             readinessState: readinessState,
             resolutionState: SummaryResolutionState(),
             showsOfflineToken: showsOfflineToken,

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -382,17 +382,14 @@ struct SummaryView: View {
             ActiveAlertSummaryView(
                 mesos: mesos,
                 alerts: alerts,
-                isLoading: localAlertsPresentationState == .loading,
+                isLoading: localAlertsDisplayState.showsLoadingCopy,
                 todayContentState: todayContentState,
-                isOffline: showsOfflineToken,
+                isOffline: localAlertsDisplayState.showsOfflineStatusCopy,
                 onOpenAlertCenter: onOpenAlerts
             )
             .summaryResolving(
-                Self.appliesLocalAlertsResolving(
-                    presentationState: localAlertsPresentationState,
-                    resolutionState: resolutionState,
-                    showsOfflineToken: showsOfflineToken
-                ),
+                localAlertsDisplayState.usesSummaryResolvingTreatment &&
+                resolutionState.isResolving(.alerts),
                 todayContentState: todayContentState,
                 style: .subtle
             )
@@ -451,23 +448,6 @@ struct SummaryView: View {
 
     private func unavailableCard(title: String, message: String, symbol: String) -> some View {
         emptySectionCard(title: title, message: message, symbol: symbol)
-    }
-
-    static func appliesLocalAlertsResolving(
-        presentationState: LocalAlertsPresentationState,
-        resolutionState: SummaryResolutionState,
-        showsOfflineToken: Bool
-    ) -> Bool {
-        guard showsOfflineToken == false, resolutionState.isResolving(.alerts) else {
-            return false
-        }
-
-        switch presentationState {
-        case .alerts, .empty:
-            return true
-        case .loading, .unavailable:
-            return false
-        }
     }
 
     static func showsEmptyResolving(

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -139,6 +139,7 @@ struct SummaryView: View {
     let alerts: [AlertDTO]
     let outlook: ConvectiveOutlookDTO?
     let weather: SummaryWeather?
+    let todayContentState: TodayContentState
     let readinessState: SummaryReadinessState
     let resolutionState: SummaryResolutionState
     let showsOfflineToken: Bool
@@ -154,15 +155,6 @@ struct SummaryView: View {
 
     private var isWeatherLoading: Bool {
         weather == nil
-    }
-
-    private var isSummaryLoading: Bool {
-        switch readinessState {
-        case .loadingLocation, .resolvingLocalContext, .loadingLocalData:
-            true
-        case .ready, .locationUnavailable:
-            false
-        }
     }
 
     private var statusText: String {
@@ -435,7 +427,7 @@ struct SummaryView: View {
 
     var body: some View {
         VStack(spacing: 18) {
-            if showsEmptyResolving {
+            if todayContentState.showsResolvingSurface {
                 LoadingView(message: resolutionState.primaryActiveMessage ?? readinessState.statusText)
             } else {
                 summaryContent
@@ -447,7 +439,7 @@ struct SummaryView: View {
         .padding(.horizontal, 16)
         .padding(.top, 10)
         .padding(.bottom, 20)
-        .animation(SkyAwareMotion.settle(reduceMotion), value: showsEmptyResolving)
+        .animation(SkyAwareMotion.settle(reduceMotion), value: todayContentState.showsResolvingSurface)
     }
 
     private func emptySectionCard(title: String, message: String, symbol: String) -> some View {
@@ -651,6 +643,7 @@ private extension AnyTransition {
             severeRisk: nil,
             fireRisk: nil,
             weather: nil,
+            todayContentState: .noCacheResolving,
             readinessState: .loadingLocalData,
             showsOfflineToken: true,
             outlook: nil,
@@ -666,6 +659,7 @@ private struct SummaryPreviewContent: View {
     let severeRisk: SevereWeatherThreat?
     let fireRisk: FireRiskLevel?
     let weather: SummaryWeather?
+    let todayContentState: TodayContentState
     let readinessState: SummaryReadinessState
     let showsOfflineToken: Bool
     let outlook: ConvectiveOutlookDTO?
@@ -677,6 +671,7 @@ private struct SummaryPreviewContent: View {
         severeRisk: SevereWeatherThreat?,
         fireRisk: FireRiskLevel? = .extreme,
         weather: SummaryWeather?,
+        todayContentState: TodayContentState = .current,
         readinessState: SummaryReadinessState = .ready,
         showsOfflineToken: Bool = false,
         outlook: ConvectiveOutlookDTO? = ConvectiveOutlook.sampleOutlookDtos.first,
@@ -687,6 +682,7 @@ private struct SummaryPreviewContent: View {
         self.severeRisk = severeRisk
         self.fireRisk = fireRisk
         self.weather = weather
+        self.todayContentState = todayContentState
         self.readinessState = readinessState
         self.showsOfflineToken = showsOfflineToken
         self.outlook = outlook
@@ -709,6 +705,7 @@ private struct SummaryPreviewContent: View {
             alerts: alerts,
             outlook: outlook,
             weather: weather,
+            todayContentState: todayContentState,
             readinessState: readinessState,
             resolutionState: SummaryResolutionState(),
             showsOfflineToken: showsOfflineToken,

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -679,6 +679,21 @@ private extension AnyTransition {
     }
 }
 
+#Preview("Summary – Local Alerts Location Unavailable") {
+    NavigationStack {
+        SummaryPreviewContent(
+            stormRisk: .allClear,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            weather: SummaryPreviewData.weather,
+            readinessState: .locationUnavailable,
+            mesos: [],
+            alerts: []
+        )
+        .toolbar(.hidden, for: .navigationBar)
+    }
+}
+
 private struct SummaryPreviewContent: View {
     let stormRisk: StormRiskLevel?
     let severeRisk: SevereWeatherThreat?

--- a/Sources/Features/Summary/TodayContentState.swift
+++ b/Sources/Features/Summary/TodayContentState.swift
@@ -51,4 +51,17 @@ enum TodayContentState: Sendable, Equatable {
     var showsResolvingSurface: Bool {
         self == .noCacheResolving
     }
+
+    var showsCalmUpdatingCue: Bool {
+        switch self {
+        case .cachedRefreshing, .staleRefreshing:
+            true
+        case .noCacheResolving, .current, .degraded, .unavailable:
+            false
+        }
+    }
+
+    var allowsSectionResolvingTreatment: Bool {
+        self != .cachedRefreshing
+    }
 }

--- a/Sources/Features/Summary/TodayContentState.swift
+++ b/Sources/Features/Summary/TodayContentState.swift
@@ -64,4 +64,8 @@ enum TodayContentState: Sendable, Equatable {
     var allowsSectionResolvingTreatment: Bool {
         self != .cachedRefreshing
     }
+
+    var suppressesRoutineRefreshMotion: Bool {
+        self == .cachedRefreshing
+    }
 }

--- a/Sources/Features/Summary/TodayContentState.swift
+++ b/Sources/Features/Summary/TodayContentState.swift
@@ -1,0 +1,54 @@
+//
+//  TodayContentState.swift
+//  SkyAware
+//
+//  Created by OpenAI Codex.
+//
+
+import Foundation
+
+enum TodayContentState: Sendable, Equatable {
+    case noCacheResolving
+    case cachedRefreshing
+    case current
+    case staleRefreshing
+    case degraded
+    case unavailable
+
+    static func from(
+        readinessState: SummaryReadinessState,
+        hasCachedContent: Bool,
+        hasLiveContent: Bool,
+        isRefreshing: Bool,
+        isOffline: Bool
+    ) -> TodayContentState {
+        if readinessState == .locationUnavailable {
+            return .unavailable
+        }
+
+        if hasCachedContent {
+            if isRefreshing {
+                return isOffline ? .staleRefreshing : .cachedRefreshing
+            }
+            return isOffline ? .degraded : .current
+        }
+
+        if hasLiveContent {
+            return isOffline ? .degraded : .current
+        }
+
+        if isRefreshing ||
+            readinessState == .loadingLocation ||
+            readinessState == .resolvingLocalContext ||
+            readinessState == .loadingLocalData
+        {
+            return .noCacheResolving
+        }
+
+        return .unavailable
+    }
+
+    var showsResolvingSurface: Bool {
+        self == .noCacheResolving
+    }
+}

--- a/Sources/Features/Summary/TodayVisibleWeatherState.swift
+++ b/Sources/Features/Summary/TodayVisibleWeatherState.swift
@@ -1,0 +1,44 @@
+//
+//  TodayVisibleWeatherState.swift
+//  SkyAware
+//
+//  Created by OpenAI Codex.
+//
+
+import Foundation
+
+struct TodayVisibleWeatherState: Sendable, Equatable {
+    var weather: SummaryWeather?
+    var locationIdentity: SummaryWeatherLocationIdentity?
+
+    init(
+        weather: SummaryWeather? = nil,
+        locationIdentity: SummaryWeatherLocationIdentity? = nil
+    ) {
+        self.weather = weather
+        self.locationIdentity = locationIdentity
+    }
+
+    static func resolve(
+        liveWeather: SummaryWeather?,
+        displayedWeather: SummaryWeather?,
+        isRefreshing: Bool,
+        displayedWeatherLocationIdentity: SummaryWeatherLocationIdentity?,
+        weatherLocationIdentity: SummaryWeatherLocationIdentity?
+    ) -> TodayVisibleWeatherState {
+        if let liveWeather {
+            return .init(weather: liveWeather, locationIdentity: weatherLocationIdentity)
+        }
+
+        guard isRefreshing,
+              displayedWeather != nil,
+              displayedWeatherLocationIdentity == weatherLocationIdentity else {
+            return .init()
+        }
+
+        return .init(
+            weather: displayedWeather,
+            locationIdentity: displayedWeatherLocationIdentity
+        )
+    }
+}

--- a/Tests/UnitTests/HomeRefreshPipelineTests.swift
+++ b/Tests/UnitTests/HomeRefreshPipelineTests.swift
@@ -446,10 +446,11 @@ struct HomeRefreshPipelineTests {
             )
         }
 
-        let refreshStillActive = await waitUntil(timeout: .seconds(5)) {
-            pipeline.resolutionState.isRefreshing
+        let completedProgressObserved = await waitUntil(timeout: .seconds(5)) {
+            await coordinator.progressHistory().contains(.completed(.lane(.hotAlerts)))
         }
-        #expect(refreshStillActive)
+        #expect(completedProgressObserved)
+        #expect(pipeline.resolutionState.isRefreshing)
         #expect(pipeline.resolutionState.isResolving(.alerts) == false)
 
         await gate.open()
@@ -1254,6 +1255,7 @@ private actor RecordingHomeIngestionCoordinator: HomeIngestionCoordinating {
     private let runGate: AsyncGate?
     private let progressEvents: [HomeIngestionProgressEvent]
     private var submittedRequests: [HomeIngestionRequest] = []
+    private var recordedProgressEvents: [HomeIngestionProgressEvent] = []
 
     init(
         snapshot: HomeSnapshot = .empty,
@@ -1308,6 +1310,7 @@ private actor RecordingHomeIngestionCoordinator: HomeIngestionCoordinating {
     ) async throws -> HomeSnapshot {
         submittedRequests.append(request)
         for event in progressEvents {
+            recordedProgressEvents.append(event)
             await progress?(event)
         }
         if let runGate {
@@ -1326,6 +1329,10 @@ private actor RecordingHomeIngestionCoordinator: HomeIngestionCoordinating {
 
     func requestCount() -> Int {
         submittedRequests.count
+    }
+
+    func progressHistory() -> [HomeIngestionProgressEvent] {
+        recordedProgressEvents
     }
 }
 

--- a/Tests/UnitTests/HomeRefreshPipelineTests.swift
+++ b/Tests/UnitTests/HomeRefreshPipelineTests.swift
@@ -303,6 +303,126 @@ struct HomeRefreshPipelineTests {
         }
     }
 
+    @Test("progress started keeps cached Today display state steady until snapshot commit")
+    func progressStarted_keepsCachedTodayDisplayStateSteady() async {
+        let context = makeContext()
+        let weather = sampleWeather()
+        let gate = AsyncGate()
+        let coordinator = RecordingHomeIngestionCoordinator(
+            runGate: gate,
+            progressEvents: [
+                .started(.lane(.weather))
+            ]
+        )
+        let locationSession = FakeLocationSession(currentContext: context, preparedContext: context)
+        let pipeline = HomeRefreshPipeline(
+            initialSnap: context.snapshot,
+            initialStormRisk: .slight,
+            initialSevereRisk: .wind(probability: 0.15),
+            initialFireRisk: .critical,
+            initialMesos: [MD.sampleDiscussionDTOs[0]],
+            initialAlerts: [Watch.sampleWatchRows[0]]
+        )
+
+        let refreshTask = Task { @MainActor in
+            await pipeline.forceRefreshCurrentContext(
+                showsLoading: true,
+                environment: makeEnvironment(
+                    coordinator: coordinator,
+                    locationSession: locationSession
+                )
+            )
+        }
+
+        let started = await waitUntil(timeout: .seconds(5)) {
+            pipeline.resolutionState.isResolving(.conditions)
+        }
+        #expect(started)
+        #expect(pipeline.isRefreshInFlight)
+        #expect(
+            TodayContentState.from(
+                readinessState: .ready,
+                hasCachedContent: true,
+                hasLiveContent: false,
+                isRefreshing: pipeline.isRefreshInFlight,
+                isOffline: false
+            ) == .cachedRefreshing
+        )
+
+        let weatherState = TodayVisibleWeatherState.resolve(
+            liveWeather: nil,
+            displayedWeather: weather,
+            isRefreshing: pipeline.isRefreshInFlight,
+            displayedWeatherLocationIdentity: SummaryWeatherLocationIdentity(snapshot: context.snapshot),
+            weatherLocationIdentity: SummaryWeatherLocationIdentity(snapshot: context.snapshot)
+        )
+        #expect(weatherState.weather == weather)
+
+        await gate.open()
+        await refreshTask.value
+    }
+
+    @Test("progress completion before snapshot commit does not clear cached Today display state")
+    func progressCompleted_beforeSnapshotCommitKeepsCachedTodayDisplayState() async {
+        let context = makeContext()
+        let weather = sampleWeather()
+        let gate = AsyncGate()
+        let coordinator = RecordingHomeIngestionCoordinator(
+            runGate: gate,
+            progressEvents: [
+                .started(.lane(.weather)),
+                .completed(.lane(.weather))
+            ]
+        )
+        let locationSession = FakeLocationSession(currentContext: context, preparedContext: context)
+        let pipeline = HomeRefreshPipeline(
+            initialSnap: context.snapshot,
+            initialStormRisk: .slight,
+            initialSevereRisk: .wind(probability: 0.15),
+            initialFireRisk: .critical,
+            initialMesos: [MD.sampleDiscussionDTOs[0]],
+            initialAlerts: [Watch.sampleWatchRows[0]]
+        )
+
+        let refreshTask = Task { @MainActor in
+            await pipeline.forceRefreshCurrentContext(
+                showsLoading: true,
+                environment: makeEnvironment(
+                    coordinator: coordinator,
+                    locationSession: locationSession
+                )
+            )
+        }
+
+        let progressCompleted = await waitUntil(timeout: .seconds(5)) {
+            pipeline.resolutionState.isResolving(.conditions) == false && pipeline.isRefreshInFlight
+        }
+        #expect(progressCompleted)
+        #expect(pipeline.resolutionState.isResolving(.conditions) == false)
+        #expect(pipeline.isRefreshInFlight)
+        #expect(
+            TodayContentState.from(
+                readinessState: .ready,
+                hasCachedContent: true,
+                hasLiveContent: false,
+                isRefreshing: pipeline.isRefreshInFlight,
+                isOffline: false
+            ) == .cachedRefreshing
+        )
+
+        let weatherState = TodayVisibleWeatherState.resolve(
+            liveWeather: nil,
+            displayedWeather: weather,
+            isRefreshing: pipeline.isRefreshInFlight,
+            displayedWeatherLocationIdentity: SummaryWeatherLocationIdentity(snapshot: context.snapshot),
+            weatherLocationIdentity: SummaryWeatherLocationIdentity(snapshot: context.snapshot)
+        )
+        #expect(weatherState.weather == weather)
+
+        await gate.open()
+        await refreshTask.value
+    }
+
     @Test("completed progress clears mapped sections before refresh completion")
     func completedProgress_clearsMappedSectionsBeforeRefreshCompletion() async {
         let gate = AsyncGate()

--- a/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
+++ b/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
@@ -361,6 +361,16 @@ struct SummaryViewLocalAlertsTests {
         )
     }
 
+    @Test("existing alerts stay visible when loading arrives transiently")
+    func localAlerts_existingAlertsOverrideTransientLoading() {
+        #expect(
+            ActiveAlertSummaryView.contentState(
+                for: .noCacheResolving,
+                hasRenderableAlerts: true
+            ) == .alerts
+        )
+    }
+
     @Test("cached populated alerts stay calm during refresh")
     func localAlerts_refreshTreatment_cachedPopulated() {
         let state = LocalAlertsDisplayState.from(
@@ -376,6 +386,68 @@ struct SummaryViewLocalAlertsTests {
         #expect(state.usesSummaryResolvingTreatment == false)
         #expect(state.showsLoadingCopy == false)
         #expect(state.showsOfflineStatusCopy == false)
+    }
+
+    @Test("cached refreshing populated alerts stay alerts in the card")
+    func localAlerts_cardState_cachedRefreshingPopulated() {
+        #expect(
+            ActiveAlertSummaryView.contentState(
+                for: .cachedRefreshing(content: .populated),
+                hasRenderableAlerts: true
+            ) == .alerts
+        )
+    }
+
+    @Test("cached refreshing known empty alerts stay empty in the card")
+    func localAlerts_cardState_cachedRefreshingEmpty() {
+        #expect(
+            ActiveAlertSummaryView.contentState(
+                for: .cachedRefreshing(content: .empty),
+                hasRenderableAlerts: false
+            ) == .empty
+        )
+    }
+
+    @Test("no-cache resolving without useful content can still show loading")
+    func localAlerts_cardState_noCacheResolvingWithoutContent() {
+        #expect(
+            ActiveAlertSummaryView.contentState(
+                for: .noCacheResolving,
+                hasRenderableAlerts: false
+            ) == .loading
+        )
+    }
+
+    @Test("alerts-to-empty transitions keep flexible height smoothing")
+    func localAlerts_heightPolicy_alertsToEmpty() {
+        #expect(
+            ActiveAlertSummaryView.usesFlexibleAlertHeight(
+                currentState: .empty,
+                isLeavingAlerts: true
+            )
+        )
+    }
+
+    @Test("loading to alerts does not animate the card branch")
+    func localAlerts_animationPolicy_loadingToAlertsDoesNotAnimate() {
+        #expect(
+            ActiveAlertSummaryView.shouldAnimateContentStateTransition(
+                from: .loading,
+                to: .alerts,
+                suppressesRoutineRefreshMotion: false
+            ) == false
+        )
+    }
+
+    @Test("empty to alerts can still animate the card branch")
+    func localAlerts_animationPolicy_emptyToAlertsCanAnimate() {
+        #expect(
+            ActiveAlertSummaryView.shouldAnimateContentStateTransition(
+                from: .empty,
+                to: .alerts,
+                suppressesRoutineRefreshMotion: false
+            )
+        )
     }
 
     @Test("known empty alerts stay calm during refresh")

--- a/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
+++ b/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
@@ -745,6 +745,101 @@ struct SummaryContentPresentationStateTests {
     }
 }
 
+@Suite("Today Content State")
+@MainActor
+struct TodayContentStateTests {
+    @Test("no cache while resolving maps to the resolving state")
+    func noCacheResolving_mapsToResolvingState() {
+        #expect(
+            TodayContentState.from(
+                readinessState: .loadingLocalData,
+                hasCachedContent: false,
+                hasLiveContent: false,
+                isRefreshing: false,
+                isOffline: false
+            ) == .noCacheResolving
+        )
+    }
+
+    @Test("cached content refreshes while online")
+    func cachedContentRefreshing_mapsToCachedRefreshingState() {
+        #expect(
+            TodayContentState.from(
+                readinessState: .ready,
+                hasCachedContent: true,
+                hasLiveContent: false,
+                isRefreshing: true,
+                isOffline: false
+            ) == .cachedRefreshing
+        )
+    }
+
+    @Test("cached content remains current while idle and online")
+    func cachedContentIdle_mapsToCurrentState() {
+        #expect(
+            TodayContentState.from(
+                readinessState: .ready,
+                hasCachedContent: true,
+                hasLiveContent: false,
+                isRefreshing: false,
+                isOffline: false
+            ) == .current
+        )
+    }
+
+    @Test("live fallback content without cache is still current when idle")
+    func liveFallbackContentIdle_mapsToCurrentState() {
+        #expect(
+            TodayContentState.from(
+                readinessState: .ready,
+                hasCachedContent: false,
+                hasLiveContent: true,
+                isRefreshing: false,
+                isOffline: false
+            ) == .current
+        )
+    }
+
+    @Test("cached content becomes stale while refreshing offline")
+    func cachedContentRefreshingOffline_mapsToStaleRefreshingState() {
+        #expect(
+            TodayContentState.from(
+                readinessState: .ready,
+                hasCachedContent: true,
+                hasLiveContent: false,
+                isRefreshing: true,
+                isOffline: true
+            ) == .staleRefreshing
+        )
+    }
+
+    @Test("cached content becomes degraded while offline and idle")
+    func cachedContentOfflineIdle_mapsToDegradedState() {
+        #expect(
+            TodayContentState.from(
+                readinessState: .ready,
+                hasCachedContent: true,
+                hasLiveContent: false,
+                isRefreshing: false,
+                isOffline: true
+            ) == .degraded
+        )
+    }
+
+    @Test("no cache and no content maps to unavailable")
+    func noCacheNoContent_mapsToUnavailableState() {
+        #expect(
+            TodayContentState.from(
+                readinessState: .ready,
+                hasCachedContent: false,
+                hasLiveContent: false,
+                isRefreshing: false,
+                isOffline: false
+            ) == .unavailable
+        )
+    }
+}
+
 @Suite("Foreground Refresh Policies")
 struct ForegroundRefreshPolicyTests {
     private let alertPolicy = AlertRefreshPolicy(minimumSyncInterval: 120)

--- a/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
+++ b/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
@@ -341,77 +341,20 @@ struct HomeViewProjectionLaunchTests {
 @Suite("SummaryView Local Alerts")
 @MainActor
 struct SummaryViewLocalAlertsTests {
-    @Test("cached empty local alerts stay empty while refreshing")
-    func localAlertsPresentationState_cachedEmptyStaysEmptyWhileRefreshing() {
+    @Test("display states map to presentation states")
+    func localAlertsPresentationState_mapsDisplayStates() {
         #expect(
-            SummaryView.localAlertsPresentationState(
-                todayContentState: .cachedRefreshing,
-                hasActiveAlerts: false,
-                isLocationUnavailable: false
-            ) == .empty
+            LocalAlertsDisplayState.noCacheResolving.presentationState == .loading
         )
         #expect(
-            SummaryView.localAlertsPresentationState(
-                todayContentState: .current,
-                hasActiveAlerts: false,
-                isLocationUnavailable: false
-            ) == .empty
+            LocalAlertsDisplayState.current(content: .empty, source: .live).presentationState == .empty
         )
-    }
-
-    @Test("no-cache resolving local alerts show loading")
-    func localAlertsPresentationState_noCacheResolvingShowsLoading() {
         #expect(
-            SummaryView.localAlertsPresentationState(
-                todayContentState: .noCacheResolving,
-                hasActiveAlerts: false,
-                isLocationUnavailable: false
-            ) == .loading
+            LocalAlertsDisplayState.current(content: .populated, source: .cached).presentationState == .alerts
         )
-    }
-
-    @Test("location unavailable always wins local alerts presentation")
-    func localAlertsPresentationState_locationUnavailableWins() {
         #expect(
-            SummaryView.localAlertsPresentationState(
-                todayContentState: .current,
-                hasActiveAlerts: false,
-                isLocationUnavailable: true
-            ) == .unavailable
+            LocalAlertsDisplayState.unavailable(reason: .locationUnavailable).presentationState == .unavailable
         )
-    }
-
-    @Test("active alerts stay visible even while Today is still resolving")
-    func localAlertsPresentationState_activeAlertsWhileResolving() {
-        #expect(
-            SummaryView.localAlertsPresentationState(
-                todayContentState: .noCacheResolving,
-                hasActiveAlerts: true,
-                isLocationUnavailable: false
-            ) == .alerts
-        )
-    }
-
-    @Test("cached populated local alerts stay populated while refreshing")
-    func localAlertsPresentationState_cachedPopulatedStaysPopulatedWhileRefreshing() {
-        #expect(
-            SummaryView.localAlertsPresentationState(
-                todayContentState: .cachedRefreshing,
-                hasActiveAlerts: true,
-                isLocationUnavailable: false
-            ) == .alerts
-        )
-    }
-
-    @Test("cached empty local alerts stay empty during refresh")
-    func localAlertsPresentationState_cachedEmptyWhileRefreshingStaysEmpty() {
-        let resolving = SummaryView.localAlertsPresentationState(
-            todayContentState: .cachedRefreshing,
-            hasActiveAlerts: false,
-            isLocationUnavailable: false
-        )
-
-        #expect(resolving == .empty)
     }
 
     @Test("loading local alerts do not receive whole-card resolving treatment")
@@ -467,6 +410,146 @@ struct SummaryViewLocalAlertsTests {
                 resolutionState: resolutionState,
                 showsOfflineToken: true
             ) == false
+        )
+    }
+}
+
+@Suite("Local Alerts Display State")
+@MainActor
+struct LocalAlertsDisplayStateTests {
+    private let loadedAt = Date(timeIntervalSince1970: 1_000)
+
+    @Test("no-cache resolving stays calm")
+    func noCacheResolving_staysCalm() {
+        #expect(
+            LocalAlertsDisplayState.from(
+                todayContentState: .noCacheResolving,
+                hasCachedProjection: false,
+                isCurrentContextResolvedInPipeline: false,
+                lastHotAlertsLoadAt: nil,
+                hasActiveAlerts: false,
+                isLocationUnavailable: false
+            ) == .noCacheResolving
+        )
+    }
+
+    @Test("current live empty and populated states stay distinct")
+    func currentLiveStates_stayDistinct() {
+        #expect(
+            LocalAlertsDisplayState.from(
+                todayContentState: .current,
+                hasCachedProjection: false,
+                isCurrentContextResolvedInPipeline: true,
+                lastHotAlertsLoadAt: nil,
+                hasActiveAlerts: false,
+                isLocationUnavailable: false
+            ) == .current(content: .empty, source: .live)
+        )
+        #expect(
+            LocalAlertsDisplayState.from(
+                todayContentState: .current,
+                hasCachedProjection: false,
+                isCurrentContextResolvedInPipeline: true,
+                lastHotAlertsLoadAt: nil,
+                hasActiveAlerts: true,
+                isLocationUnavailable: false
+            ) == .current(content: .populated, source: .live)
+        )
+    }
+
+    @Test("cached empty and populated states stay explicit")
+    func cachedStates_stayExplicit() {
+        #expect(
+            LocalAlertsDisplayState.from(
+                todayContentState: .current,
+                hasCachedProjection: true,
+                isCurrentContextResolvedInPipeline: false,
+                lastHotAlertsLoadAt: loadedAt,
+                hasActiveAlerts: false,
+                isLocationUnavailable: false
+            ) == .current(content: .empty, source: .cached)
+        )
+        #expect(
+            LocalAlertsDisplayState.from(
+                todayContentState: .current,
+                hasCachedProjection: true,
+                isCurrentContextResolvedInPipeline: false,
+                lastHotAlertsLoadAt: loadedAt,
+                hasActiveAlerts: true,
+                isLocationUnavailable: false
+            ) == .current(content: .populated, source: .cached)
+        )
+    }
+
+    @Test("cached refreshing states stay explicit while refresh is active")
+    func cachedRefreshingStates_stayExplicit() {
+        #expect(
+            LocalAlertsDisplayState.from(
+                todayContentState: .cachedRefreshing,
+                hasCachedProjection: true,
+                isCurrentContextResolvedInPipeline: false,
+                lastHotAlertsLoadAt: loadedAt,
+                hasActiveAlerts: false,
+                isLocationUnavailable: false
+            ) == .cachedRefreshing(content: .empty)
+        )
+        #expect(
+            LocalAlertsDisplayState.from(
+                todayContentState: .cachedRefreshing,
+                hasCachedProjection: true,
+                isCurrentContextResolvedInPipeline: false,
+                lastHotAlertsLoadAt: loadedAt,
+                hasActiveAlerts: true,
+                isLocationUnavailable: false
+            ) == .cachedRefreshing(content: .populated)
+        )
+    }
+
+    @Test("offline stale and degraded states retain cached content")
+    func staleOrDegradedStates_retainCachedContent() {
+        #expect(
+            LocalAlertsDisplayState.from(
+                todayContentState: .degraded,
+                hasCachedProjection: true,
+                isCurrentContextResolvedInPipeline: false,
+                lastHotAlertsLoadAt: loadedAt,
+                hasActiveAlerts: false,
+                isLocationUnavailable: false
+            ) == .staleOrDegraded(content: .empty)
+        )
+        #expect(
+            LocalAlertsDisplayState.from(
+                todayContentState: .staleRefreshing,
+                hasCachedProjection: true,
+                isCurrentContextResolvedInPipeline: false,
+                lastHotAlertsLoadAt: loadedAt,
+                hasActiveAlerts: true,
+                isLocationUnavailable: false
+            ) == .staleOrDegraded(content: .populated)
+        )
+    }
+
+    @Test("location unavailable and true unavailable states stay distinct")
+    func unavailableStates_stayDistinct() {
+        #expect(
+            LocalAlertsDisplayState.from(
+                todayContentState: .current,
+                hasCachedProjection: false,
+                isCurrentContextResolvedInPipeline: false,
+                lastHotAlertsLoadAt: nil,
+                hasActiveAlerts: false,
+                isLocationUnavailable: true
+            ) == .unavailable(reason: .locationUnavailable)
+        )
+        #expect(
+            LocalAlertsDisplayState.from(
+                todayContentState: .unavailable,
+                hasCachedProjection: false,
+                isCurrentContextResolvedInPipeline: false,
+                lastHotAlertsLoadAt: nil,
+                hasActiveAlerts: false,
+                isLocationUnavailable: false
+            ) == .unavailable(reason: .noUsefulAlertState)
         )
     }
 }
@@ -648,11 +731,14 @@ struct TodayContentStateTests {
         #expect(TodayContentState.noCacheResolving.suppressesRoutineRefreshMotion == false)
 
         #expect(
-            SummaryView.localAlertsPresentationState(
+            LocalAlertsDisplayState.from(
                 todayContentState: .cachedRefreshing,
+                hasCachedProjection: true,
+                isCurrentContextResolvedInPipeline: false,
+                lastHotAlertsLoadAt: Date(timeIntervalSince1970: 1_000),
                 hasActiveAlerts: false,
                 isLocationUnavailable: false
-            ) == .empty
+            ).presentationState == .empty
         )
 
         #expect(
@@ -762,11 +848,14 @@ struct TodayContentStateTests {
         #expect(TodayContentState.staleRefreshing.showsCalmUpdatingCue)
         #expect(TodayContentState.staleRefreshing.showsResolvingSurface == false)
         #expect(
-            SummaryView.localAlertsPresentationState(
+            LocalAlertsDisplayState.from(
                 todayContentState: .staleRefreshing,
+                hasCachedProjection: true,
+                isCurrentContextResolvedInPipeline: false,
+                lastHotAlertsLoadAt: Date(timeIntervalSince1970: 1_000),
                 hasActiveAlerts: false,
                 isLocationUnavailable: false
-            ) == .empty
+            ).presentationState == .empty
         )
     }
 

--- a/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
+++ b/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
@@ -650,6 +650,8 @@ struct TodayContentStateTests {
     func cachedRefreshing_exposesCalmCueAndSuppressesSectionLoadingBranches() {
         #expect(TodayContentState.cachedRefreshing.showsCalmUpdatingCue)
         #expect(TodayContentState.cachedRefreshing.allowsSectionResolvingTreatment == false)
+        #expect(TodayContentState.cachedRefreshing.suppressesRoutineRefreshMotion)
+        #expect(TodayContentState.noCacheResolving.suppressesRoutineRefreshMotion == false)
 
         #expect(
             SummaryView.localAlertsPresentationState(

--- a/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
+++ b/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
@@ -354,6 +354,12 @@ struct SummaryViewLocalAlertsTests {
             LocalAlertsDisplayState.current(content: .empty, source: .live).presentationState == .empty
         )
         #expect(
+            LocalAlertsDisplayState.cachedRefreshing(content: .populated).presentationState == .alerts
+        )
+        #expect(
+            LocalAlertsDisplayState.cachedRefreshing(content: .empty).presentationState == .empty
+        )
+        #expect(
             LocalAlertsDisplayState.current(content: .populated, source: .cached).presentationState == .alerts
         )
         #expect(
@@ -386,6 +392,26 @@ struct SummaryViewLocalAlertsTests {
         #expect(state.usesSummaryResolvingTreatment == false)
         #expect(state.showsLoadingCopy == false)
         #expect(state.showsOfflineStatusCopy == false)
+    }
+
+    @Test("cached refreshing populated alerts never fall back to loading")
+    func localAlerts_refreshTreatment_cachedRefreshingPopulatedNeverLoads() {
+        let state = LocalAlertsDisplayState.from(
+            todayContentState: .cachedRefreshing,
+            hasCachedProjection: true,
+            isCurrentContextResolvedInPipeline: false,
+            lastHotAlertsLoadAt: loadedAt,
+            hasActiveAlerts: true,
+            isLocationUnavailable: false
+        )
+
+        #expect(state.presentationState == .alerts)
+        #expect(
+            ActiveAlertSummaryView.contentState(
+                for: state,
+                hasRenderableAlerts: true
+            ) == .alerts
+        )
     }
 
     @Test("cached refreshing populated alerts stay alerts in the card")
@@ -428,6 +454,23 @@ struct SummaryViewLocalAlertsTests {
         )
     }
 
+    @Test("routine cached refresh stays on the alerts height path")
+    func localAlerts_heightPolicy_cachedRefreshingPopulatedStaysOnAlertsHeightPath() {
+        #expect(
+            ActiveAlertSummaryView.usesFlexibleAlertHeight(
+                currentState: .alerts,
+                isLeavingAlerts: false
+            )
+        )
+        #expect(
+            ActiveAlertSummaryView.shouldAnimateContentStateTransition(
+                from: .alerts,
+                to: .alerts,
+                suppressesRoutineRefreshMotion: true
+            ) == false
+        )
+    }
+
     @Test("loading to alerts does not animate the card branch")
     func localAlerts_animationPolicy_loadingToAlertsDoesNotAnimate() {
         #expect(
@@ -465,6 +508,12 @@ struct SummaryViewLocalAlertsTests {
         #expect(state.usesSummaryResolvingTreatment == false)
         #expect(state.showsLoadingCopy == false)
         #expect(state.showsOfflineStatusCopy == false)
+        #expect(
+            ActiveAlertSummaryView.contentState(
+                for: state,
+                hasRenderableAlerts: false
+            ) == .empty
+        )
     }
 
     @Test("no-cache resolving preserves first-load feedback")
@@ -516,6 +565,12 @@ struct SummaryViewLocalAlertsTests {
         #expect(state.usesSummaryResolvingTreatment == false)
         #expect(state.showsLoadingCopy == false)
         #expect(state.showsOfflineStatusCopy == false)
+        #expect(
+            ActiveAlertSummaryView.contentState(
+                for: state,
+                hasRenderableAlerts: false
+            ) == .empty
+        )
     }
 
     @Test("degraded cached populated alerts stay visible without duplicate treatment")
@@ -550,6 +605,12 @@ struct SummaryViewLocalAlertsTests {
         #expect(state.usesSummaryResolvingTreatment == false)
         #expect(state.showsLoadingCopy == false)
         #expect(state.showsOfflineStatusCopy == false)
+        #expect(
+            ActiveAlertSummaryView.contentState(
+                for: state,
+                hasRenderableAlerts: false
+            ) == .empty
+        )
     }
 }
 
@@ -679,6 +740,16 @@ struct LocalAlertsDisplayStateTests {
                 hasActiveAlerts: false,
                 isLocationUnavailable: true
             ) == .unavailable(reason: .locationUnavailable)
+        )
+        #expect(
+            LocalAlertsDisplayState.from(
+                todayContentState: .current,
+                hasCachedProjection: true,
+                isCurrentContextResolvedInPipeline: false,
+                lastHotAlertsLoadAt: nil,
+                hasActiveAlerts: false,
+                isLocationUnavailable: false
+            ) == .unavailable(reason: .noUsefulAlertState)
         )
         #expect(
             LocalAlertsDisplayState.from(

--- a/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
+++ b/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
@@ -187,21 +187,21 @@ struct HomeViewProjectionLaunchTests {
         #expect(
             HomeView.showsBootstrapLoading(
                 readinessState: .loadingLocalData,
-                resolutionState: SummaryResolutionState(),
+                isRefreshInFlight: false,
                 hasProjection: false
             )
         )
         #expect(
             HomeView.showsBootstrapLoading(
                 readinessState: .loadingLocalData,
-                resolutionState: SummaryResolutionState(),
+                isRefreshInFlight: false,
                 hasProjection: true
             ) == false
         )
         #expect(
             HomeView.showsBootstrapLoading(
                 readinessState: .locationUnavailable,
-                resolutionState: SummaryResolutionState(),
+                isRefreshInFlight: false,
                 hasProjection: false
             ) == false
         )
@@ -209,13 +209,10 @@ struct HomeViewProjectionLaunchTests {
 
     @Test("bootstrap loading remains visible with no cache during active refresh even when readiness is ready")
     func bootstrapLoading_noCacheActiveRefresh() {
-        var resolutionState = SummaryResolutionState()
-        resolutionState.begin(task: .weather, sections: [.conditions])
-
         #expect(
             HomeView.showsBootstrapLoading(
                 readinessState: .ready,
-                resolutionState: resolutionState,
+                isRefreshInFlight: true,
                 hasProjection: false
             )
         )
@@ -226,7 +223,7 @@ struct HomeViewProjectionLaunchTests {
         #expect(
             HomeView.showsBootstrapLoading(
                 readinessState: .ready,
-                resolutionState: SummaryResolutionState(),
+                isRefreshInFlight: false,
                 hasProjection: false
             ) == false
         )
@@ -234,13 +231,10 @@ struct HomeViewProjectionLaunchTests {
 
     @Test("bootstrap loading stays hidden while cached projection is available during active refresh")
     func bootstrapLoading_cacheActiveRefresh() {
-        var resolutionState = SummaryResolutionState()
-        resolutionState.begin(task: .alerts, sections: [.alerts])
-
         #expect(
             HomeView.showsBootstrapLoading(
                 readinessState: .loadingLocalData,
-                resolutionState: resolutionState,
+                isRefreshInFlight: true,
                 hasProjection: true
             ) == false
         )
@@ -763,6 +757,19 @@ struct TodayContentStateTests {
         )
     }
 
+    @Test("stale refreshing keeps cached content visible instead of collapsing to unavailable")
+    func staleRefreshing_keepsCachedContentVisible() {
+        #expect(TodayContentState.staleRefreshing.showsCalmUpdatingCue)
+        #expect(TodayContentState.staleRefreshing.showsResolvingSurface == false)
+        #expect(
+            SummaryView.localAlertsPresentationState(
+                todayContentState: .staleRefreshing,
+                hasActiveAlerts: false,
+                isLocationUnavailable: false
+            ) == .empty
+        )
+    }
+
     @Test("no cache and no content maps to unavailable")
     func noCacheNoContent_mapsToUnavailableState() {
         #expect(
@@ -773,6 +780,50 @@ struct TodayContentStateTests {
                 isRefreshing: false,
                 isOffline: false
             ) == .unavailable
+        )
+    }
+}
+
+@Suite("HomeView Outlook Display")
+@MainActor
+struct HomeViewOutlookDisplayTests {
+    @Test("cached outlooks stay visible when a fresh snapshot returns no outlooks")
+    func cachedOutlooks_stayVisibleWhenLiveResultsAreEmpty() {
+        let cachedOutlooks = [
+            makeOutlook(title: "Cached Outlook A"),
+            makeOutlook(title: "Cached Outlook B")
+        ]
+
+        #expect(
+            HomeView.preferredOutlooks(
+                cachedOutlooks: cachedOutlooks,
+                liveOutlooks: []
+            ) == cachedOutlooks
+        )
+        #expect(
+            HomeView.preferredOutlook(
+                cachedOutlook: cachedOutlooks.first,
+                liveOutlooks: [],
+                liveOutlook: nil
+            ) == cachedOutlooks.first
+        )
+    }
+
+    private func makeOutlook(title: String) -> ConvectiveOutlookDTO {
+        guard let url = URL(string: "https://www.weather.gov") else {
+            preconditionFailure("Invalid outlook URL")
+        }
+
+        return ConvectiveOutlookDTO(
+            title: title,
+            link: url,
+            published: Date(timeIntervalSince1970: 1_000),
+            summary: "Summary for \(title)",
+            fullText: "Full text for \(title)",
+            day: 1,
+            riskLevel: "SLGT",
+            issued: Date(timeIntervalSince1970: 900),
+            validUntil: Date(timeIntervalSince1970: 2_000)
         )
     }
 }

--- a/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
+++ b/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
@@ -646,6 +646,43 @@ struct SummaryContentPresentationStateTests {
 @Suite("Today Content State")
 @MainActor
 struct TodayContentStateTests {
+    @Test("cached refreshing exposes the calm page cue and suppresses section loading branches")
+    func cachedRefreshing_exposesCalmCueAndSuppressesSectionLoadingBranches() {
+        #expect(TodayContentState.cachedRefreshing.showsCalmUpdatingCue)
+        #expect(TodayContentState.cachedRefreshing.allowsSectionResolvingTreatment == false)
+
+        #expect(
+            SummaryView.localAlertsPresentationState(
+                todayContentState: .cachedRefreshing,
+                hasActiveAlerts: false,
+                isLocationUnavailable: false
+            ) == .empty
+        )
+
+        #expect(
+            SummaryAwarenessPrimaryState.resolve(
+                stormRisk: nil,
+                severeRisk: nil,
+                fireRisk: nil,
+                alerts: [],
+                todayContentState: .cachedRefreshing,
+                isStormRiskResolving: true,
+                isSevereRiskResolving: true,
+                isFireRiskResolving: true,
+                isOffline: false
+            ) == .quiet
+        )
+
+        #expect(
+            OutlookSummaryCard.outlookSummaryText(
+                outlook: nil,
+                todayContentState: .cachedRefreshing,
+                isLoading: false,
+                isPending: true
+            ) == "Outlook details will appear here when available."
+        )
+    }
+
     @Test("no cache while resolving maps to the resolving state")
     func noCacheResolving_mapsToResolvingState() {
         #expect(

--- a/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
+++ b/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
@@ -347,42 +347,31 @@ struct HomeViewProjectionLaunchTests {
 @Suite("SummaryView Local Alerts")
 @MainActor
 struct SummaryViewLocalAlertsTests {
-    @Test("shows empty state when no local alerts are available after context resolution")
-    func localAlertsPresentationState_showsEmptyStateWithoutAlerts() {
+    @Test("cached empty local alerts stay empty while refreshing")
+    func localAlertsPresentationState_cachedEmptyStaysEmptyWhileRefreshing() {
         #expect(
             SummaryView.localAlertsPresentationState(
-                readinessState: .loadingLocalData,
+                todayContentState: .cachedRefreshing,
                 hasActiveAlerts: false,
-                isLocationUnavailable: false,
-                isAlertsResolving: false
+                isLocationUnavailable: false
             ) == .empty
         )
         #expect(
             SummaryView.localAlertsPresentationState(
-                readinessState: .ready,
+                todayContentState: .current,
                 hasActiveAlerts: false,
-                isLocationUnavailable: false,
-                isAlertsResolving: false
+                isLocationUnavailable: false
             ) == .empty
         )
     }
 
-    @Test("keeps placeholder only while location context is still loading")
-    func localAlertsPresentationState_limitsPlaceholderToLocationResolution() {
+    @Test("no-cache resolving local alerts show loading")
+    func localAlertsPresentationState_noCacheResolvingShowsLoading() {
         #expect(
             SummaryView.localAlertsPresentationState(
-                readinessState: .loadingLocation,
+                todayContentState: .noCacheResolving,
                 hasActiveAlerts: false,
-                isLocationUnavailable: false,
-                isAlertsResolving: false
-            ) == .loading
-        )
-        #expect(
-            SummaryView.localAlertsPresentationState(
-                readinessState: .resolvingLocalContext,
-                hasActiveAlerts: false,
-                isLocationUnavailable: false,
-                isAlertsResolving: false
+                isLocationUnavailable: false
             ) == .loading
         )
     }
@@ -391,118 +380,44 @@ struct SummaryViewLocalAlertsTests {
     func localAlertsPresentationState_locationUnavailableWins() {
         #expect(
             SummaryView.localAlertsPresentationState(
-                readinessState: .ready,
+                todayContentState: .current,
                 hasActiveAlerts: false,
-                isLocationUnavailable: true,
-                isAlertsResolving: false
+                isLocationUnavailable: true
             ) == .unavailable
         )
     }
 
-    @Test("active alerts are shown even while readiness is loading")
-    func localAlertsPresentationState_activeAlertsWhileLoading() {
+    @Test("active alerts stay visible even while Today is still resolving")
+    func localAlertsPresentationState_activeAlertsWhileResolving() {
         #expect(
             SummaryView.localAlertsPresentationState(
-                readinessState: .loadingLocation,
+                todayContentState: .noCacheResolving,
                 hasActiveAlerts: true,
-                isLocationUnavailable: false,
-                isAlertsResolving: false
-            ) == .alerts
-        )
-        #expect(
-            SummaryView.localAlertsPresentationState(
-                readinessState: .resolvingLocalContext,
-                hasActiveAlerts: true,
-                isLocationUnavailable: false,
-                isAlertsResolving: false
+                isLocationUnavailable: false
             ) == .alerts
         )
     }
 
-    @Test("empty local alerts state is used after local data loading completes")
-    func localAlertsPresentationState_emptyAfterLocalDataLoad() {
+    @Test("cached populated local alerts stay populated while refreshing")
+    func localAlertsPresentationState_cachedPopulatedStaysPopulatedWhileRefreshing() {
         #expect(
             SummaryView.localAlertsPresentationState(
-                readinessState: .loadingLocalData,
-                hasActiveAlerts: false,
-                isLocationUnavailable: false,
-                isAlertsResolving: false
-            ) == .empty
+                todayContentState: .cachedRefreshing,
+                hasActiveAlerts: true,
+                isLocationUnavailable: false
+            ) == .alerts
         )
     }
 
-    @Test("resolving alerts keeps the local alerts placeholder visible")
-    func localAlertsPresentationState_alertsResolvingShowsLoading() {
-        #expect(
-            SummaryView.localAlertsPresentationState(
-                readinessState: .ready,
-                hasActiveAlerts: false,
-                isLocationUnavailable: false,
-                isAlertsResolving: true
-            ) == .loading
-        )
-    }
-
-    @Test("loading local alerts resolve to empty when alerts finish with no watches or mesos")
-    func localAlertsPresentationState_loadingToEmptySequence() {
+    @Test("cached empty local alerts stay empty during refresh")
+    func localAlertsPresentationState_cachedEmptyWhileRefreshingStaysEmpty() {
         let resolving = SummaryView.localAlertsPresentationState(
-            readinessState: .loadingLocalData,
+            todayContentState: .cachedRefreshing,
             hasActiveAlerts: false,
-            isLocationUnavailable: false,
-            isAlertsResolving: true
-        )
-        let resolved = SummaryView.localAlertsPresentationState(
-            readinessState: .loadingLocalData,
-            hasActiveAlerts: false,
-            isLocationUnavailable: false,
-            isAlertsResolving: false
+            isLocationUnavailable: false
         )
 
-        #expect(resolving == .loading)
-        #expect(resolved == .empty)
-    }
-
-    @Test("loading local alerts resolve to alerts when watches or mesos become available")
-    func localAlertsPresentationState_loadingToPopulatedSequence() {
-        let resolving = SummaryView.localAlertsPresentationState(
-            readinessState: .loadingLocalData,
-            hasActiveAlerts: false,
-            isLocationUnavailable: false,
-            isAlertsResolving: true
-        )
-        let resolvedWithAlerts = SummaryView.localAlertsPresentationState(
-            readinessState: .loadingLocalData,
-            hasActiveAlerts: true,
-            isLocationUnavailable: false,
-            isAlertsResolving: false
-        )
-
-        #expect(resolving == .loading)
-        #expect(resolvedWithAlerts == .alerts)
-    }
-
-    @Test("cached active alerts remain in alerts state while alerts are resolving")
-    func localAlertsPresentationState_cachedContentWhileResolvingStaysPopulated() {
-        #expect(
-            SummaryView.localAlertsPresentationState(
-                readinessState: .ready,
-                hasActiveAlerts: true,
-                isLocationUnavailable: false,
-                isAlertsResolving: true
-            ) == .alerts
-        )
-    }
-
-    @Test("empty cached projection while alerts are resolving remains loading")
-    func localAlertsPresentationState_emptyCachedProjectionWhileResolvingStaysLoading() {
-        #expect(
-            SummaryView.localAlertsPresentationState(
-                readinessState: .ready,
-                hasActiveAlerts: false,
-                isLocationUnavailable: false,
-                isAlertsResolving: true
-            ) == .loading
-        )
+        #expect(resolving == .empty)
     }
 
     @Test("loading local alerts do not receive whole-card resolving treatment")
@@ -623,40 +538,25 @@ struct SummaryViewEmptyResolvingTests {
 @Suite("SummaryView Risk Placeholder Presentation")
 @MainActor
 struct SummaryViewRiskPlaceholderPresentationTests {
-    @Test("nil risk shows resolving placeholder while section is actively resolving")
-    func riskPlaceholder_nilRiskWhileSectionResolving() {
+    @Test("nil risk shows resolving placeholder only during no-cache resolving")
+    func riskPlaceholder_nilRiskWhileNoCacheResolving() {
         #expect(
             SummaryView.showsRiskResolvingPlaceholder(
                 hasRiskValue: false,
-                readinessState: .ready,
-                isSectionResolving: true,
+                todayContentState: .noCacheResolving,
                 showsOfflineToken: false
             )
         )
     }
 
-    @Test("nil risk allows resolving placeholder during local data loading")
-    func riskPlaceholder_nilRiskDuringLoadingLocalData() {
+    @Test("nil risk stays hidden during cached refreshes")
+    func riskPlaceholder_nilRiskDuringCachedRefresh() {
         #expect(
             SummaryView.showsRiskResolvingPlaceholder(
                 hasRiskValue: false,
-                readinessState: .loadingLocalData,
-                isSectionResolving: false,
-                showsOfflineToken: false
-            )
-        )
-    }
-
-    @Test("nil risk keeps the resolving placeholder visible while a refresh batch is still active")
-    func riskPlaceholder_nilRiskDuringActiveRefreshBatch() {
-        #expect(
-            SummaryView.showsRiskResolvingPlaceholder(
-                hasRiskValue: false,
-                readinessState: .ready,
-                isSectionResolving: false,
+                todayContentState: .cachedRefreshing,
                 showsOfflineToken: false,
-                isRefreshing: true
-            )
+            ) == false
         )
     }
 
@@ -665,8 +565,7 @@ struct SummaryViewRiskPlaceholderPresentationTests {
         #expect(
             SummaryView.showsRiskResolvingPlaceholder(
                 hasRiskValue: false,
-                readinessState: .ready,
-                isSectionResolving: false,
+                todayContentState: .current,
                 showsOfflineToken: false
             ) == false
         )
@@ -677,8 +576,7 @@ struct SummaryViewRiskPlaceholderPresentationTests {
         #expect(
             SummaryView.showsRiskResolvingPlaceholder(
                 hasRiskValue: false,
-                readinessState: .loadingLocalData,
-                isSectionResolving: true,
+                todayContentState: .noCacheResolving,
                 showsOfflineToken: true
             ) == false
         )

--- a/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
+++ b/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
@@ -341,11 +341,15 @@ struct HomeViewProjectionLaunchTests {
 @Suite("SummaryView Local Alerts")
 @MainActor
 struct SummaryViewLocalAlertsTests {
+    private let loadedAt = Date(timeIntervalSince1970: 1_000)
+
     @Test("display states map to presentation states")
     func localAlertsPresentationState_mapsDisplayStates() {
         #expect(
             LocalAlertsDisplayState.noCacheResolving.presentationState == .loading
         )
+        #expect(LocalAlertsDisplayState.noCacheResolving.showsLoadingCopy)
+        #expect(LocalAlertsDisplayState.noCacheResolving.usesSummaryResolvingTreatment == false)
         #expect(
             LocalAlertsDisplayState.current(content: .empty, source: .live).presentationState == .empty
         )
@@ -357,60 +361,123 @@ struct SummaryViewLocalAlertsTests {
         )
     }
 
-    @Test("loading local alerts do not receive whole-card resolving treatment")
-    func localAlertsResolvingTreatment_suppressesLoadingCardOpacity() {
-        var resolutionState = SummaryResolutionState()
-        resolutionState.begin(task: .alerts, sections: [.alerts])
-
-        #expect(
-            SummaryView.appliesLocalAlertsResolving(
-                presentationState: .loading,
-                resolutionState: resolutionState,
-                showsOfflineToken: false
-            ) == false
+    @Test("cached populated alerts stay calm during refresh")
+    func localAlerts_refreshTreatment_cachedPopulated() {
+        let state = LocalAlertsDisplayState.from(
+            todayContentState: .cachedRefreshing,
+            hasCachedProjection: true,
+            isCurrentContextResolvedInPipeline: false,
+            lastHotAlertsLoadAt: loadedAt,
+            hasActiveAlerts: true,
+            isLocationUnavailable: false
         )
+
+        #expect(state == .cachedRefreshing(content: .populated))
+        #expect(state.usesSummaryResolvingTreatment == false)
+        #expect(state.showsLoadingCopy == false)
+        #expect(state.showsOfflineStatusCopy == false)
     }
 
-    @Test("active or empty local alerts keep whole-card resolving treatment during refresh")
-    func localAlertsResolvingTreatment_preservesSettledCardOpacity() {
-        var resolutionState = SummaryResolutionState()
-        resolutionState.begin(task: .alerts, sections: [.alerts])
+    @Test("known empty alerts stay calm during refresh")
+    func localAlerts_refreshTreatment_cachedEmpty() {
+        let state = LocalAlertsDisplayState.from(
+            todayContentState: .cachedRefreshing,
+            hasCachedProjection: true,
+            isCurrentContextResolvedInPipeline: false,
+            lastHotAlertsLoadAt: loadedAt,
+            hasActiveAlerts: false,
+            isLocationUnavailable: false
+        )
 
-        #expect(
-            SummaryView.appliesLocalAlertsResolving(
-                presentationState: .alerts,
-                resolutionState: resolutionState,
-                showsOfflineToken: false
-            )
-        )
-        #expect(
-            SummaryView.appliesLocalAlertsResolving(
-                presentationState: .empty,
-                resolutionState: resolutionState,
-                showsOfflineToken: false
-            )
-        )
+        #expect(state == .cachedRefreshing(content: .empty))
+        #expect(state.usesSummaryResolvingTreatment == false)
+        #expect(state.showsLoadingCopy == false)
+        #expect(state.showsOfflineStatusCopy == false)
     }
 
-    @Test("local alerts resolving treatment stays off when alerts are not resolving or offline")
-    func localAlertsResolvingTreatment_requiresResolvingOnlineAlerts() {
-        var resolutionState = SummaryResolutionState()
-        resolutionState.begin(task: .alerts, sections: [.alerts])
+    @Test("no-cache resolving preserves first-load feedback")
+    func localAlerts_refreshTreatment_noCacheResolving() {
+        let state = LocalAlertsDisplayState.from(
+            todayContentState: .noCacheResolving,
+            hasCachedProjection: false,
+            isCurrentContextResolvedInPipeline: false,
+            lastHotAlertsLoadAt: nil,
+            hasActiveAlerts: false,
+            isLocationUnavailable: false
+        )
 
-        #expect(
-            SummaryView.appliesLocalAlertsResolving(
-                presentationState: .alerts,
-                resolutionState: SummaryResolutionState(),
-                showsOfflineToken: false
-            ) == false
+        #expect(state == .noCacheResolving)
+        #expect(state.usesSummaryResolvingTreatment == false)
+        #expect(state.showsLoadingCopy)
+        #expect(state.showsOfflineStatusCopy == false)
+    }
+
+    @Test("offline cached populated alerts stay visible without duplicate treatment")
+    func localAlerts_refreshTreatment_offlineCachedPopulated() {
+        let state = LocalAlertsDisplayState.from(
+            todayContentState: .staleRefreshing,
+            hasCachedProjection: true,
+            isCurrentContextResolvedInPipeline: false,
+            lastHotAlertsLoadAt: loadedAt,
+            hasActiveAlerts: true,
+            isLocationUnavailable: false
         )
-        #expect(
-            SummaryView.appliesLocalAlertsResolving(
-                presentationState: .alerts,
-                resolutionState: resolutionState,
-                showsOfflineToken: true
-            ) == false
+
+        #expect(state == .staleOrDegraded(content: .populated))
+        #expect(state.usesSummaryResolvingTreatment == false)
+        #expect(state.showsLoadingCopy == false)
+        #expect(state.showsOfflineStatusCopy)
+    }
+
+    @Test("offline known empty alerts stay calm without duplicate treatment")
+    func localAlerts_refreshTreatment_offlineCachedEmpty() {
+        let state = LocalAlertsDisplayState.from(
+            todayContentState: .staleRefreshing,
+            hasCachedProjection: true,
+            isCurrentContextResolvedInPipeline: false,
+            lastHotAlertsLoadAt: loadedAt,
+            hasActiveAlerts: false,
+            isLocationUnavailable: false
         )
+
+        #expect(state == .staleOrDegraded(content: .empty))
+        #expect(state.usesSummaryResolvingTreatment == false)
+        #expect(state.showsLoadingCopy == false)
+        #expect(state.showsOfflineStatusCopy == false)
+    }
+
+    @Test("degraded cached populated alerts stay visible without duplicate treatment")
+    func localAlerts_refreshTreatment_degradedCachedPopulated() {
+        let state = LocalAlertsDisplayState.from(
+            todayContentState: .degraded,
+            hasCachedProjection: true,
+            isCurrentContextResolvedInPipeline: false,
+            lastHotAlertsLoadAt: loadedAt,
+            hasActiveAlerts: true,
+            isLocationUnavailable: false
+        )
+
+        #expect(state == .staleOrDegraded(content: .populated))
+        #expect(state.usesSummaryResolvingTreatment == false)
+        #expect(state.showsLoadingCopy == false)
+        #expect(state.showsOfflineStatusCopy)
+    }
+
+    @Test("degraded known empty alerts stay calm without duplicate treatment")
+    func localAlerts_refreshTreatment_degradedCachedEmpty() {
+        let state = LocalAlertsDisplayState.from(
+            todayContentState: .degraded,
+            hasCachedProjection: true,
+            isCurrentContextResolvedInPipeline: false,
+            lastHotAlertsLoadAt: loadedAt,
+            hasActiveAlerts: false,
+            isLocationUnavailable: false
+        )
+
+        #expect(state == .staleOrDegraded(content: .empty))
+        #expect(state.usesSummaryResolvingTreatment == false)
+        #expect(state.showsLoadingCopy == false)
+        #expect(state.showsOfflineStatusCopy == false)
     }
 }
 

--- a/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
+++ b/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
@@ -1083,6 +1083,218 @@ struct TodayContentStateTests {
     }
 }
 
+@Suite("Today Surface State Flow")
+@MainActor
+struct TodaySurfaceStateFlowTests {
+    private let loadedAt = Date(timeIntervalSince1970: 1_000)
+
+    @Test("first launch without cache keeps the calm resolving surface")
+    func firstLaunchWithoutCache_keepsCalmResolvingSurface() {
+        let state = TodayContentState.from(
+            readinessState: .loadingLocalData,
+            hasCachedContent: false,
+            hasLiveContent: false,
+            isRefreshing: false,
+            isOffline: false
+        )
+
+        #expect(state == .noCacheResolving)
+        #expect(state.showsResolvingSurface)
+        #expect(state.showsCalmUpdatingCue == false)
+        #expect(state.allowsSectionResolvingTreatment)
+        #expect(
+            SummaryView.showsEmptyResolving(
+                readinessState: .loadingLocalData,
+                resolutionState: SummaryResolutionState(),
+                hasMeaningfulContent: false,
+                isLocationUnavailable: false
+            )
+        )
+    }
+
+    @Test("valid cached launch stays on content and avoids resolving theater")
+    func validCachedLaunch_avoidsResolvingTheater() {
+        let state = TodayContentState.from(
+            readinessState: .ready,
+            hasCachedContent: true,
+            hasLiveContent: false,
+            isRefreshing: false,
+            isOffline: false
+        )
+
+        #expect(state == .current)
+        #expect(state.showsResolvingSurface == false)
+        #expect(state.showsCalmUpdatingCue == false)
+        #expect(state.suppressesRoutineRefreshMotion == false)
+        #expect(
+            SummaryView.showsEmptyResolving(
+                readinessState: .ready,
+                resolutionState: SummaryResolutionState(),
+                hasMeaningfulContent: true,
+                isLocationUnavailable: false
+            ) == false
+        )
+    }
+
+    @Test("cached refresh keeps the page calm and suppresses full-content transitions")
+    func cachedRefresh_keepsThePageCalm() {
+        #expect(TodayContentState.cachedRefreshing.showsCalmUpdatingCue)
+        #expect(TodayContentState.cachedRefreshing.suppressesRoutineRefreshMotion)
+        #expect(TodayContentState.cachedRefreshing.allowsSectionResolvingTreatment == false)
+        #expect(TodayContentState.cachedRefreshing.showsResolvingSurface == false)
+        #expect(TodayContentState.staleRefreshing.suppressesRoutineRefreshMotion == false)
+        #expect(
+            SummaryView.showsEmptyResolving(
+                readinessState: .ready,
+                resolutionState: SummaryResolutionState(),
+                hasMeaningfulContent: true,
+                isLocationUnavailable: false
+            ) == false
+        )
+    }
+
+    @Test("stale cache keeps useful content visible during offline refresh")
+    func staleCache_keepsUsefulContentVisible() {
+        #expect(
+            TodayContentState.from(
+                readinessState: .ready,
+                hasCachedContent: true,
+                hasLiveContent: false,
+                isRefreshing: true,
+                isOffline: true
+            ) == .staleRefreshing
+        )
+        #expect(TodayContentState.staleRefreshing.showsCalmUpdatingCue)
+        #expect(TodayContentState.staleRefreshing.showsResolvingSurface == false)
+        #expect(
+            SummaryContentPresentationState.from(
+                isOffline: true,
+                hasContent: true,
+                isResolving: false
+            ) == .stale
+        )
+
+        let localAlertsState = LocalAlertsDisplayState.from(
+            todayContentState: .staleRefreshing,
+            hasCachedProjection: true,
+            isCurrentContextResolvedInPipeline: false,
+            lastHotAlertsLoadAt: loadedAt,
+            hasActiveAlerts: false,
+            isLocationUnavailable: false
+        )
+
+        #expect(localAlertsState == .staleOrDegraded(content: .empty))
+        #expect(localAlertsState.presentationState == .empty)
+        #expect(localAlertsState.showsOfflineStatusCopy == false)
+    }
+
+    @Test("degraded cache keeps useful content visible when refresh is idle offline")
+    func degradedCache_keepsUsefulContentVisible() {
+        #expect(
+            TodayContentState.from(
+                readinessState: .ready,
+                hasCachedContent: true,
+                hasLiveContent: false,
+                isRefreshing: false,
+                isOffline: true
+            ) == .degraded
+        )
+        #expect(TodayContentState.degraded.showsCalmUpdatingCue == false)
+        #expect(TodayContentState.degraded.showsResolvingSurface == false)
+        #expect(
+            SummaryContentPresentationState.from(
+                isOffline: true,
+                hasContent: true,
+                isResolving: false
+            ) == .stale
+        )
+
+        let localAlertsState = LocalAlertsDisplayState.from(
+            todayContentState: .degraded,
+            hasCachedProjection: true,
+            isCurrentContextResolvedInPipeline: false,
+            lastHotAlertsLoadAt: loadedAt,
+            hasActiveAlerts: true,
+            isLocationUnavailable: false
+        )
+
+        #expect(localAlertsState == .staleOrDegraded(content: .populated))
+        #expect(localAlertsState.presentationState == .alerts)
+        #expect(localAlertsState.showsOfflineStatusCopy)
+    }
+
+    @Test("unavailable only appears when no useful data exists")
+    func unavailable_requiresNoUsefulData() {
+        #expect(
+            TodayContentState.from(
+                readinessState: .ready,
+                hasCachedContent: false,
+                hasLiveContent: false,
+                isRefreshing: false,
+                isOffline: false
+            ) == .unavailable
+        )
+        #expect(TodayContentState.unavailable.showsCalmUpdatingCue == false)
+        #expect(TodayContentState.unavailable.showsResolvingSurface == false)
+        #expect(
+            SummaryContentPresentationState.from(
+                isOffline: true,
+                hasContent: false,
+                isResolving: true
+            ) == .unavailable
+        )
+
+        let localAlertsState = LocalAlertsDisplayState.from(
+            todayContentState: .unavailable,
+            hasCachedProjection: false,
+            isCurrentContextResolvedInPipeline: false,
+            lastHotAlertsLoadAt: nil,
+            hasActiveAlerts: false,
+            isLocationUnavailable: false
+        )
+
+        #expect(localAlertsState == .unavailable(reason: .noUsefulAlertState))
+        #expect(localAlertsState.presentationState == .unavailable)
+    }
+
+    @Test("foreground-return weather retention stays aligned at the Today level")
+    func foregroundReturn_weatherRetentionStaysAligned() {
+        let weather = SummaryWeather(
+            temperature: Measurement(value: 76, unit: .fahrenheit),
+            symbolName: "sun.max.fill",
+            conditionText: "Clear",
+            asOf: .now,
+            dewPoint: Measurement(value: 50, unit: .fahrenheit),
+            humidity: 0.35,
+            windSpeed: Measurement(value: 8, unit: .milesPerHour),
+            windGust: nil,
+            windDirection: "NW",
+            pressure: Measurement(value: 29.92, unit: .inchesOfMercury),
+            pressureTrend: "steady"
+        )
+        let identity = SummaryWeatherLocationIdentity(
+            snapshot: .init(
+                coordinates: .init(latitude: 39.7392, longitude: -104.9903),
+                timestamp: .now,
+                accuracy: 20,
+                placemarkSummary: "Denver, CO",
+                h3Cell: nil
+            )
+        )
+
+        let retained = TodayVisibleWeatherState.resolve(
+            liveWeather: nil,
+            displayedWeather: weather,
+            isRefreshing: true,
+            displayedWeatherLocationIdentity: identity,
+            weatherLocationIdentity: identity
+        )
+
+        #expect(retained.weather == weather)
+        #expect(retained.locationIdentity == identity)
+    }
+}
+
 @Suite("HomeView Outlook Display")
 @MainActor
 struct HomeViewOutlookDisplayTests {

--- a/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
+++ b/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
@@ -918,14 +918,14 @@ struct WeatherKitRefreshPolicyTests {
     }
 }
 
-@Suite("SummaryStatus Weather Retention")
-struct SummaryStatusWeatherRetentionTests {
+@Suite("Today Visible Weather State")
+struct TodayVisibleWeatherStateTests {
     @Test("keeps displayed weather during refresh when location identity is unchanged")
     func keepsDisplayedWeather_sameIdentityRefreshing() {
         let weather = makeWeather()
         let identity = makeIdentity(latitude: 39.7392, longitude: -104.9903, placemark: "Denver, CO")
 
-        let resolved = SummaryStatus.resolveDisplayedWeather(
+        let resolved = TodayVisibleWeatherState.resolve(
             liveWeather: nil,
             displayedWeather: weather,
             isRefreshing: true,
@@ -943,7 +943,7 @@ struct SummaryStatusWeatherRetentionTests {
         let previousIdentity = makeIdentity(latitude: 39.7392, longitude: -104.9903, placemark: "Denver, CO")
         let newIdentity = makeIdentity(latitude: 34.0522, longitude: -118.2437, placemark: "Los Angeles, CA")
 
-        let resolved = SummaryStatus.resolveDisplayedWeather(
+        let resolved = TodayVisibleWeatherState.resolve(
             liveWeather: nil,
             displayedWeather: weather,
             isRefreshing: true,
@@ -960,7 +960,7 @@ struct SummaryStatusWeatherRetentionTests {
         let weather = makeWeather()
         let identity = makeIdentity(latitude: 39.7392, longitude: -104.9903, placemark: "Denver, CO")
 
-        let resolved = SummaryStatus.resolveDisplayedWeather(
+        let resolved = TodayVisibleWeatherState.resolve(
             liveWeather: nil,
             displayedWeather: weather,
             isRefreshing: false,
@@ -979,7 +979,7 @@ struct SummaryStatusWeatherRetentionTests {
         let previousIdentity = makeIdentity(latitude: 39.7392, longitude: -104.9903, placemark: "Denver, CO")
         let currentIdentity = makeIdentity(latitude: 34.0522, longitude: -118.2437, placemark: "Los Angeles, CA")
 
-        let resolved = SummaryStatus.resolveDisplayedWeather(
+        let resolved = TodayVisibleWeatherState.resolve(
             liveWeather: liveWeather,
             displayedWeather: previousWeather,
             isRefreshing: true,
@@ -997,7 +997,7 @@ struct SummaryStatusWeatherRetentionTests {
         let oldIdentity = makeIdentity(latitude: 39.7392, longitude: -104.9903, placemark: "Denver, CO")
         let newIdentity = makeIdentity(latitude: 47.6062, longitude: -122.3321, placemark: "Seattle, WA")
 
-        let rendered = SummaryStatus.resolveDisplayedWeather(
+        let rendered = TodayVisibleWeatherState.resolve(
             liveWeather: nil,
             displayedWeather: retainedWeather,
             isRefreshing: true,

--- a/Tests/UnitTests/SummaryAwarenessPanelTests.swift
+++ b/Tests/UnitTests/SummaryAwarenessPanelTests.swift
@@ -349,7 +349,8 @@ struct SummaryAwarenessPanelTests {
         let contract = SummaryAwarenessPrimaryState.storm(.moderate).accessibilityContract
 
         #expect(contract.label == "Storm Risk")
-        #expect(contract.value == "Moderate Risk. Widespread severe storms expected.")
+        #expect(contract.value.contains("Moderate Risk"))
+        #expect(contract.value.contains("Widespread severe storms expected"))
         #expect(contract.hint == "Opens the severe risk map.")
     }
 
@@ -367,10 +368,9 @@ struct SummaryAwarenessPanelTests {
         let contract = SummaryAwarenessPrimaryState.fire(.critical).accessibilityContract
 
         #expect(contract.label == "Fire Risk")
-        #expect(
-            contract.value ==
-            "Critical Fire Risk. Critical fire weather is forecast. Strong winds and dry air could support rapid fire spread."
-        )
+        #expect(contract.value.contains("Critical Fire Risk"))
+        #expect(contract.value.contains("Critical fire weather is forecast"))
+        #expect(contract.value.contains("rapid fire spread"))
         #expect(contract.hint == "Opens the fire risk map.")
     }
 

--- a/Tests/UnitTests/SummaryAwarenessPanelTests.swift
+++ b/Tests/UnitTests/SummaryAwarenessPanelTests.swift
@@ -17,6 +17,7 @@ struct SummaryAwarenessPanelTests {
                     headline: "A tornado warning is active for your area."
                 )
             ],
+            todayContentState: .current,
             isStormRiskResolving: false,
             isSevereRiskResolving: false,
             isFireRiskResolving: false,
@@ -43,6 +44,7 @@ struct SummaryAwarenessPanelTests {
             severeRisk: .hail(probability: 0.20),
             fireRisk: .extreme,
             alerts: [alert],
+            todayContentState: .current,
             isStormRiskResolving: false,
             isSevereRiskResolving: false,
             isFireRiskResolving: false,
@@ -134,21 +136,44 @@ struct SummaryAwarenessPanelTests {
         #expect(subtitle.contains("NWS Chicago IL") == false)
     }
 
-    @Test("refreshing without a resolved risk keeps the primary hero calm")
-    func refreshWithoutResolvedRisk_keepsPrimaryHeroCalm() {
+    @Test("cached refreshing without a resolved risk keeps the primary hero calm")
+    func cachedRefreshingWithoutResolvedRisk_keepsPrimaryHeroCalm() {
         let selected = SummaryAwarenessPrimaryState.resolve(
             stormRisk: nil,
             severeRisk: nil,
             fireRisk: nil,
             alerts: [],
-            isStormRiskResolving: false,
+            todayContentState: .cachedRefreshing,
+            isStormRiskResolving: true,
             isSevereRiskResolving: false,
             isFireRiskResolving: false,
-            isOffline: false,
-            isRefreshing: true
+            isOffline: false
         )
 
         #expect(selected == .quiet)
+    }
+
+    @Test("no-cache resolving still shows the primary loading hero")
+    func noCacheResolving_showsPrimaryLoading() {
+        let selected = SummaryAwarenessPrimaryState.resolve(
+            stormRisk: nil,
+            severeRisk: nil,
+            fireRisk: nil,
+            alerts: [],
+            todayContentState: .noCacheResolving,
+            isStormRiskResolving: true,
+            isSevereRiskResolving: false,
+            isFireRiskResolving: false,
+            isOffline: false
+        )
+
+        #expect(
+            selected == .loading(
+                title: "Storm Risk",
+                detail: "Getting storm risk…",
+                symbolName: "clock.arrow.trianglehead.2.counterclockwise.rotate.90"
+            )
+        )
     }
 
     @Test("tornado outranks hail and wind within severe risk")
@@ -158,6 +183,7 @@ struct SummaryAwarenessPanelTests {
             severeRisk: .tornado(probability: 0.05),
             fireRisk: .clear,
             alerts: [],
+            todayContentState: .current,
             isStormRiskResolving: false,
             isSevereRiskResolving: false,
             isFireRiskResolving: false,
@@ -174,6 +200,7 @@ struct SummaryAwarenessPanelTests {
             severeRisk: .allClear,
             fireRisk: .critical,
             alerts: [],
+            todayContentState: .current,
             isStormRiskResolving: false,
             isSevereRiskResolving: false,
             isFireRiskResolving: false,
@@ -190,6 +217,7 @@ struct SummaryAwarenessPanelTests {
             severeRisk: .allClear,
             fireRisk: .critical,
             alerts: [],
+            todayContentState: .current,
             isStormRiskResolving: false,
             isSevereRiskResolving: false,
             isFireRiskResolving: false,
@@ -206,6 +234,7 @@ struct SummaryAwarenessPanelTests {
             severeRisk: .allClear,
             fireRisk: .clear,
             alerts: [],
+            todayContentState: .current,
             isStormRiskResolving: false,
             isSevereRiskResolving: false,
             isFireRiskResolving: false,

--- a/docs/plans/today-state-flow-progress.md
+++ b/docs/plans/today-state-flow-progress.md
@@ -25,7 +25,7 @@ deliberately left alone, and what the next session should know.
 | 6 | TV-06 | [#254](https://github.com/justinrooks/project-arcus/issues/254) | Stabilize Today snapshot application and display-model updates during partial data arrival | `gpt-5.4-mini / high` | Complete | Provider progress now gates orchestration only; Today keeps cached content visible until coherent snapshot commit, and empty-success outlooks preserve cached values explicitly. |
 | 7 | TV-07 | [#255](https://github.com/justinrooks/project-arcus/issues/255) | Add Today state-flow previews and transition mapping tests | `gpt-5.4-mini / medium` | Not started | Final validation/support issue after TV-01 through TV-06. |
 | 8 | LA-01 | [#256](https://github.com/justinrooks/project-arcus/issues/256) | Define Local Alerts display state with cache provenance | `gpt-5.4-mini / high` | Complete | Alert-specific state semantics now preserve live vs cached provenance, cached refresh, stale/degraded, and true unavailable boundaries. |
-| 9 | LA-02 | [#257](https://github.com/justinrooks/project-arcus/issues/257) | Make Local Alerts refresh treatment calm and non-duplicative | `gpt-5.4-mini / medium` | Not started | Depends on LA-01 and the page-level calm cue from TV-04. |
+| 9 | LA-02 | [#257](https://github.com/justinrooks/project-arcus/issues/257) | Make Local Alerts refresh treatment calm and non-duplicative | `gpt-5.4-mini / medium` | Complete | Local Alerts now derives refresh treatment from `LocalAlertsDisplayState` so cached refreshes stay steady and only useful offline status copy remains. |
 | 10 | LA-03 | [#258](https://github.com/justinrooks/project-arcus/issues/258) | Stabilize ActiveAlertSummaryView transitions and height behavior | `gpt-5.4-mini / high` | Not started | Alert card local state/height mechanics. Depends on LA-01/LA-02. |
 | 11 | LA-04 | [#259](https://github.com/justinrooks/project-arcus/issues/259) | Add Local Alerts state-flow previews and tests | `gpt-5.4-mini / medium` | Not started | Final alert-specific validation support after LA-01 through LA-03. |
 
@@ -706,3 +706,60 @@ Model used: `gpt-5.4-mini / high`
   transition work isolated.
 - `HomeRefreshPipeline` did not change, so any remaining alert churn should be addressed in #257 or #258, not by
   reopening provider cadence or refresh sequencing here.
+
+### LA-02 / GitHub #257 - Make Local Alerts refresh treatment calm and non-duplicative
+
+Status: Complete
+Date: 2026-06-16
+Model used: `gpt-5.4-mini / medium`
+
+#### Scope
+
+- Added display-state-derived refresh treatment helpers to `LocalAlertsDisplayState`:
+  - `showsLoadingCopy`
+  - `showsOfflineStatusCopy`
+  - `usesSummaryResolvingTreatment`
+- Suppressed Local Alerts card-level resolving treatment for ordinary cached refresh states, including populated and
+  known-empty content.
+- Kept calm first-load/no-cache behavior available through the display state boundary.
+- Constrained offline copy so only cached offline content with useful alerts/mesos surfaces the offline note.
+- Updated Local Alerts tests to cover the cached populated, known-empty, no-cache resolving, offline cached populated,
+  offline known-empty, degraded cached populated, and degraded known-empty scenarios.
+
+#### Files Changed
+
+- `Sources/Features/Summary/LocalAlertsDisplayState.swift`
+- `Sources/Features/Summary/SummaryView.swift`
+- `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+- `docs/plans/today-state-flow-progress.md`
+
+#### Behavior Preserved
+
+- Cached-first Today rendering stayed intact.
+- Alert provider behavior, cadence, and payload semantics were not changed.
+- Local Alerts row layout, transition mechanics, and height behavior were not changed.
+- Today-level calm update cue from #252 remained the only routine refresh cue for cached Local Alerts.
+- No provider, persistence, or notification delivery changes were introduced.
+
+#### Validation
+
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:SkyAwareTests/SummaryViewLocalAlertsTests -only-testing:SkyAwareTests/LocalAlertsDisplayStateTests test`
+  - Passed.
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build`
+  - Passed.
+- `xcrun xccov view --report /Users/justin/Library/Developer/Xcode/DerivedData/SkyAware-agjazkpfcnuppmaofanownrwirhh/Logs/Test/Test-SkyAware-2026.06.16_13-25-20--0600.xcresult`
+  - Succeeded; overall app coverage reported as 19.50% in the generated report.
+
+#### Deferred Work
+
+- #258 should stabilize `ActiveAlertSummaryView` transition/height behavior on top of the now-stable alert display
+  policy.
+- #259 should add alert-focused previews and remaining presentation validation after the transition/height pass lands.
+
+#### Handoff Notes
+
+- The new alert refresh policy is intentionally conservative: cached populated and known-empty content should not add
+  a second resolving cue while Today already provides the calm page-level update state.
+- `showsOfflineStatusCopy` is intentionally narrower than `isOffline`; it only surfaces the offline note when cached
+  alerts/mesos are actually useful.
+- Do not reintroduce card-level dimming here unless #258 exposes a specific transition bug that genuinely requires it.

--- a/docs/plans/today-state-flow-progress.md
+++ b/docs/plans/today-state-flow-progress.md
@@ -23,7 +23,7 @@ deliberately left alone, and what the next session should know.
 | 4 | TV-04 | [#252](https://github.com/justinrooks/project-arcus/issues/252) | Consolidate Today refresh indicators into one calm updating state | `gpt-5.4-mini / medium` | Complete | Canonical Today state now drives the lone calm update cue; section resolving treatment is suppressed during cached refresh. |
 | 5 | TV-05 | [#253](https://github.com/justinrooks/project-arcus/issues/253) | Tighten Today animation and transition scope during refresh | `gpt-5.4-mini / medium` | Complete | Narrowed Today motion scope so cached-refreshing no longer rekeys alert content or participates in broad stack transitions. |
 | 6 | TV-06 | [#254](https://github.com/justinrooks/project-arcus/issues/254) | Stabilize Today snapshot application and display-model updates during partial data arrival | `gpt-5.4-mini / high` | Complete | Provider progress now gates orchestration only; Today keeps cached content visible until coherent snapshot commit, and empty-success outlooks preserve cached values explicitly. |
-| 7 | TV-07 | [#255](https://github.com/justinrooks/project-arcus/issues/255) | Add Today state-flow previews and transition mapping tests | `gpt-5.4-mini / medium` | Not started | Final validation/support issue after TV-01 through TV-06. |
+| 7 | TV-07 | [#255](https://github.com/justinrooks/project-arcus/issues/255) | Add Today state-flow previews and transition mapping tests | `gpt-5.4-mini / medium` | Complete | Final validation/support issue after TV-01 through TV-06. |
 | 8 | LA-01 | [#256](https://github.com/justinrooks/project-arcus/issues/256) | Define Local Alerts display state with cache provenance | `gpt-5.4-mini / high` | Complete | Alert-specific state semantics now preserve live vs cached provenance, cached refresh, stale/degraded, and true unavailable boundaries. |
 | 9 | LA-02 | [#257](https://github.com/justinrooks/project-arcus/issues/257) | Make Local Alerts refresh treatment calm and non-duplicative | `gpt-5.4-mini / medium` | Complete | Local Alerts now derives refresh treatment from `LocalAlertsDisplayState` so cached refreshes stay steady and only useful offline status copy remains. |
 | 10 | LA-03 | [#258](https://github.com/justinrooks/project-arcus/issues/258) | Stabilize ActiveAlertSummaryView transitions and height behavior | `gpt-5.4-mini / high` | Not started | Alert card local state/height mechanics. Depends on LA-01/LA-02. |
@@ -578,11 +578,10 @@ Model used: `gpt-5.4-mini / high`
 - `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iPhone Simulator,name=iPhone 17" test -only-testing:SkyAwareTests/HomeViewLoadingOverlayStateTests`
   - Passed.
 - `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iPhone Simulator,name=iPhone 17" build`
-  - Pending at the time of this ledger update; rerun required before final signoff.
+  - Passed.
 
 #### Deferred Work
 
-- TV-07 remains open for Today previews and transition mapping tests.
 - Provider-side sequencing and cadence work remain out of scope.
 - Any broader Outlook tab behavior beyond explicit empty-success preservation is deferred.
 
@@ -594,7 +593,74 @@ Model used: `gpt-5.4-mini / high`
   “first live array entry wins.”
 - If the next issue wants more visual polish, it should build on this stable display boundary instead of reintroducing
   raw progress-driven section resets.
-- #255 should focus on preview and transition coverage, not on more display-state mechanics.
+- #255 has now closed the preview and transition coverage gap for the composed Today surface.
+
+### TV-07 / GitHub #255 - Add Today state-flow previews and transition mapping tests
+
+Status: Complete
+Date: 2026-06-16
+Model used: `gpt-5.4-mini / medium`
+
+#### Scope
+
+- Added a focused Today surface state-flow suite covering:
+  - first launch with no cache
+  - valid cached launch
+  - cached-refreshing transition policy
+  - stale cache
+  - degraded cache
+  - unavailable/no useful data
+  - foreground-return visible-weather retention
+- Kept the Local Alerts matrix out of this issue beyond composed Today representation.
+- Expanded `SummaryView` preview fixtures so the Today surface can be previewed in self-contained states without live
+  services.
+- Added explicit previews for:
+  - no-cache resolving
+  - valid cache/current
+  - cached-refreshing composite
+  - cached-refreshing with empty Local Alerts
+  - stale cache
+  - stale refreshing
+  - degraded with useful cached content
+  - unavailable/no useful data
+  - partial data available
+  - current weather retained during refresh
+  - atmospheric values retained during refresh
+  - Local Alerts update present
+  - light mode, dark mode, and Large Dynamic Type coverage
+
+#### Files Changed
+
+- `Sources/Features/Summary/SummaryView.swift`
+- `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+- `docs/plans/today-state-flow-progress.md`
+
+#### Behavior Preserved
+
+- Cached-first Today rendering preserved.
+- Provider and refresh cadence behavior unchanged.
+- Local Alerts section-specific provenance and transition details were not re-opened here.
+- Weather, risk, and outlook semantics were not changed.
+- No live network dependencies were introduced.
+
+#### Validation
+
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iPhone Simulator,name=iPhone 17" test -only-testing:SkyAwareTests/HomeViewLoadingOverlayStateTests -only-testing:SkyAwareTests/HomeRefreshPipelineTests`
+  - Passed.
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iPhone Simulator,name=iPhone 17" build`
+  - Passed.
+
+#### Deferred Work
+
+- Local Alerts detailed transition cleanup remains in #259.
+- No smoke UI test was needed because the unit tests and previews covered the requested Today-level acceptance matrix.
+
+#### Handoff Notes
+
+- The Today surface now has durable page-level validation for cache roll-forward behavior.
+- Local Alerts is represented in composed Today scenarios, but the finer alert-card microscope remains with #259.
+- If a future regression appears in page motion or top-level cue count, start with the Today state-flow tests in
+  `HomeViewLoadingOverlayStateTests.swift` and the new Summary previews.
 
 ### LA-00 / GitHub #248 - Local Alerts Section State-Flow Follow-Up Audit
 

--- a/docs/plans/today-state-flow-progress.md
+++ b/docs/plans/today-state-flow-progress.md
@@ -823,3 +823,70 @@ Model used: `gpt-5.4-mini / high`
 - The card now suppresses loading-to-content branch animation, so startup refreshes should no longer visibly flip.
 - The remaining Local Alerts validation work should focus on visual preview coverage, not another state-machine rewrite.
 - If a future flash appears again, check for upstream clearing of alert arrays before changing the card logic.
+
+### LA-04 / GitHub #259 - Add Local Alerts state-flow previews and tests
+
+Status: Complete
+Date: 2026-06-16
+Model used: `gpt-5.4-mini / medium`
+
+#### Scope
+
+- Expanded `HomeViewLoadingOverlayStateTests` with the final Local Alerts state-flow cases that were still missing:
+  - cached-refreshing populated maps to alerts and never regresses to loading
+  - cached-refreshing known-empty stays empty and never regresses to loading
+  - no-cache resolving remains the only loading-first path
+  - offline cached populated/empty states remain calm and non-duplicative
+  - degraded cached populated/empty states remain calm and non-duplicative
+  - location-unavailable remains distinct from true no-useful-data unavailable
+  - genuine no-useful-data cached states map to the unavailable fallback
+  - cached refresh height behavior does not reintroduce leaving-alerts churn
+  - genuine alerts-to-empty still preserves the intended flexible-height policy
+- Added Local Alerts preview fixtures directly on `ActiveAlertSummaryView` for:
+  - populated alerts
+  - populated mesos
+  - mixed alert + meso
+  - known empty
+  - no-cache resolving
+  - cached-refreshing populated
+  - cached-refreshing empty
+  - offline cached populated
+  - offline cached empty
+  - degraded cached populated
+  - degraded cached empty
+  - large Dynamic Type
+- Added a Summary preview for the Local Alerts location-unavailable case so the composed card replacement remains visible in the matrix.
+
+#### Files Changed
+
+- `Sources/Features/Summary/ActiveAlertSummaryView.swift`
+- `Sources/Features/Summary/SummaryView.swift`
+- `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+- `docs/plans/today-state-flow-progress.md`
+
+#### Behavior Preserved
+
+- Local Alerts display-state provenance from #256 stayed intact.
+- Calmer cached-refresh treatment from #257 stayed intact.
+- Existing alert content still wins over transient loading input.
+- ActiveAlertSummaryView height smoothing from #258 stayed intact.
+- No live network dependencies were introduced.
+- Alert sorting, filtering, row layout, navigation, and detail-sheet behavior were not changed.
+
+#### Validation
+
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2" -only-testing:SkyAwareTests/HomeViewLoadingOverlayStateTests test`
+  - Passed.
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build`
+  - Passed.
+
+#### Deferred Work
+
+- None for Local Alerts state-flow coverage.
+- No separate follow-up issue is required for the work in #259.
+
+#### Handoff Notes
+
+- Local Alerts now has deterministic test coverage for the full alert-state matrix requested in #259.
+- The previews intentionally live at the section boundary, because that is where the regressions have been showing up.
+- The worktree still contains unrelated dirty audit docs that were not touched.

--- a/docs/plans/today-state-flow-progress.md
+++ b/docs/plans/today-state-flow-progress.md
@@ -17,7 +17,7 @@ deliberately left alone, and what the next session should know.
 |---:|---|---|---|---|---|---|
 | 0 | TV-00 | [#248](https://github.com/justinrooks/project-arcus/issues/248) | Audit Today View State Flow | `gpt-5.4-mini / medium` | Planned | Parent tracking issue created from source-backed investigation. |
 | 1 | TV-01 | [#249](https://github.com/justinrooks/project-arcus/issues/249) | Introduce canonical Today content state for cache roll-forward rendering | `gpt-5.4-mini / high` | Complete | Foundation boundary added; `HomeView` and `SummaryView` now share `TodayContentState`. |
-| 2 | TV-02 | [#250](https://github.com/justinrooks/project-arcus/issues/250) | Keep Today section content stable during resolving refreshes | `gpt-5.4-mini / high` | Not started | Depends on TV-01. Highest visible flicker risk. |
+| 2 | TV-02 | [#250](https://github.com/justinrooks/project-arcus/issues/250) | Keep Today section content stable during resolving refreshes | `gpt-5.4-mini / high` | Complete | Canonical Today state now stabilizes Local Alerts, Today's Awareness, and risk placeholders during cached refreshes. |
 | 3 | TV-03 | [#251](https://github.com/justinrooks/project-arcus/issues/251) | Align Current Conditions and Atmospheric Conditions weather roll-forward behavior | `gpt-5.4-mini / high` | Not started | Depends on TV-01. Header/weather split is source-backed. |
 | 4 | TV-04 | [#252](https://github.com/justinrooks/project-arcus/issues/252) | Consolidate Today refresh indicators into one calm updating state | `gpt-5.4-mini / medium` | Not started | Depends on TV-01 and TV-02. |
 | 5 | TV-05 | [#253](https://github.com/justinrooks/project-arcus/issues/253) | Tighten Today animation and transition scope during refresh | `gpt-5.4-mini / medium` | Not started | Depends on TV-01, TV-02, and TV-04. |
@@ -272,3 +272,59 @@ Model used: GPT-5 Codex
   needed.
 - `HomeRefreshPipeline` did not change, so any remaining flicker or card-by-card churn is still coming from section
   presentation logic, not the new boundary.
+
+### TV-02 / GitHub #250 - Keep Today section content stable during resolving refreshes
+
+Status: Complete
+Date: 2026-06-15
+Model used: `gpt-5.4-mini / high`
+
+#### Scope
+
+- Kept Local Alerts on stable surfaces during cached refreshes by driving the section from the canonical
+  `TodayContentState`.
+- Kept Today’s Awareness and the storm/severe/fire resolving placeholders calm during cached refreshes by gating the
+  placeholder branches on the canonical Today state instead of raw refresh progress.
+- Preserved true no-cache resolving behavior so the first-load loading surface still appears when Today has no useful
+  content yet.
+- Updated focused previews to show cached-refreshing empty alerts, cached-refreshing populated alerts, and
+  cached-refreshing risk content.
+
+#### Files Changed
+
+- `Sources/Features/Summary/SummaryView.swift`
+- `Sources/Features/Summary/PrimaryAwarenessPanel.swift`
+- `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+- `Tests/UnitTests/SummaryAwarenessPanelTests.swift`
+- `docs/plans/today-state-flow-progress.md`
+
+#### Behavior Preserved
+
+- Cached-first Today rendering remained intact.
+- `HomeRefreshPipeline` behavior, cadence, and provider orchestration were left alone.
+- True no-cache resolving still uses the calm loading surface.
+- Whole-page resolving and refresh cadence policy were not redesigned.
+- Weather roll-forward behavior, page-level refresh indicators, and animation policy were intentionally left for later
+  issues.
+
+#### Validation
+
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iPhone Simulator,name=iPhone 17" -only-testing:SkyAwareTests/SummaryViewLocalAlertsTests -only-testing:SkyAwareTests/SummaryViewRiskPlaceholderPresentationTests -only-testing:SkyAwareTests/SummaryAwarenessPanelTests/cachedRefreshingWithoutResolvedRisk_keepsPrimaryHeroCalm -only-testing:SkyAwareTests/SummaryAwarenessPanelTests/noCacheResolving_showsPrimaryLoading test`
+  - Passed.
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iPhone Simulator,name=iPhone 17" build`
+  - Passed.
+
+#### Deferred Work
+
+- Weather roll-forward consistency across Current Conditions and Atmospheric Conditions is deferred to #251.
+- Consolidated Today update indicators are deferred to #252.
+- Global animation and transition scope cleanup is deferred to #253.
+- `HomeRefreshPipeline` restructuring and partial-arrival snapshot stabilization are deferred to #254.
+
+#### Handoff Notes
+
+- The next issue should keep using `TodayContentState` as the boundary and focus on weather retention rather than
+  re-opening section content branching.
+- Local Alerts and the Today awareness/risk surfaces now stay visually stable during cached refreshes, so any new
+  churn will likely come from weather-specific value retention or page-level indicator changes.
+- Do not widen this into refresh-indicator policy or animation cleanup; those belong to #252 and #253.

--- a/docs/plans/today-state-flow-progress.md
+++ b/docs/plans/today-state-flow-progress.md
@@ -21,7 +21,7 @@ deliberately left alone, and what the next session should know.
 | 3 | TV-03 | [#251](https://github.com/justinrooks/project-arcus/issues/251) | Align Current Conditions and Atmospheric Conditions weather roll-forward behavior | `gpt-5.4-mini / high` | Complete | Today boundary now owns visible-weather retention so Current Conditions and Atmospheric Conditions stay aligned during same-location refresh. |
 | 4 | TV-04 | [#252](https://github.com/justinrooks/project-arcus/issues/252) | Consolidate Today refresh indicators into one calm updating state | `gpt-5.4-mini / medium` | Complete | Canonical Today state now drives the lone calm update cue; section resolving treatment is suppressed during cached refresh. |
 | 5 | TV-05 | [#253](https://github.com/justinrooks/project-arcus/issues/253) | Tighten Today animation and transition scope during refresh | `gpt-5.4-mini / medium` | Complete | Narrowed Today motion scope so cached-refreshing no longer rekeys alert content or participates in broad stack transitions. |
-| 6 | TV-06 | [#254](https://github.com/justinrooks/project-arcus/issues/254) | Stabilize Today snapshot application and display-model updates during partial data arrival | `gpt-5.4-mini / high` | Not started | Depends on TV-01. Keep provider progress internal. |
+| 6 | TV-06 | [#254](https://github.com/justinrooks/project-arcus/issues/254) | Stabilize Today snapshot application and display-model updates during partial data arrival | `gpt-5.4-mini / high` | Complete | Provider progress now gates orchestration only; Today keeps cached content visible until coherent snapshot commit, and empty-success outlooks preserve cached values explicitly. |
 | 7 | TV-07 | [#255](https://github.com/justinrooks/project-arcus/issues/255) | Add Today state-flow previews and transition mapping tests | `gpt-5.4-mini / medium` | Not started | Final validation/support issue after TV-01 through TV-06. |
 
 ## Global Constraints
@@ -510,3 +510,60 @@ Model used: `gpt-5.4-mini / medium`
 - `TodayContentState.suppressesRoutineRefreshMotion` is the narrow motion hint now available for follow-up work.
 - If future motion work needs to reintroduce a broader page transition, it should be done from the canonical Today
   state boundary, not from per-card identity churn.
+
+### TV-06 / GitHub #254 - Stabilize Today snapshot application and display-model updates during partial data arrival
+
+Status: Complete
+Date: 2026-06-16
+Model used: `gpt-5.4-mini / high`
+
+#### Scope
+
+- Separated provider progress from destructive Today display changes by using refresh-in-flight state as the
+  user-visible gating signal.
+- Kept cached Today content visible while progress starts and completes before the final snapshot commit.
+- Preserved cached outlook content explicitly when a fresh snapshot returns empty outlook values.
+- Added degraded-state coverage so stale refreshing stays calm and useful instead of collapsing into unavailable.
+- Kept the ingestion executor, provider cadence, and network/data semantics untouched.
+
+#### Files Changed
+
+- `Sources/App/HomeRefreshPipeline.swift`
+- `Sources/App/HomeView.swift`
+- `Sources/Features/Summary/SummaryStatus.swift`
+- `Tests/UnitTests/HomeRefreshPipelineTests.swift`
+- `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+- `docs/plans/today-state-flow-progress.md`
+
+#### Behavior Preserved
+
+- Cached-first Today rendering preserved.
+- Provider progress observability preserved internally.
+- Refresh cadence preserved.
+- Hot-alert and other live content remain eligible to appear as soon as their snapshot data is ready.
+- No provider rewrite, serialization change, or broad Today redesign was introduced.
+
+#### Validation
+
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iPhone Simulator,name=iPhone 17" test -only-testing:SkyAwareTests/HomeRefreshPipelineTests`
+  - Passed.
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iPhone Simulator,name=iPhone 17" test -only-testing:SkyAwareTests/HomeViewLoadingOverlayStateTests`
+  - Passed.
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iPhone Simulator,name=iPhone 17" build`
+  - Pending at the time of this ledger update; rerun required before final signoff.
+
+#### Deferred Work
+
+- TV-07 remains open for Today previews and transition mapping tests.
+- Provider-side sequencing and cadence work remain out of scope.
+- Any broader Outlook tab behavior beyond explicit empty-success preservation is deferred.
+
+#### Handoff Notes
+
+- `HomeRefreshPipeline.isRefreshInFlight` is now the narrow signal for whether Today should keep cached display state
+  steady while final snapshot values are still pending.
+- `HomeView` now chooses cached outlooks explicitly when live refresh output is empty; do not regress that back to
+  “first live array entry wins.”
+- If the next issue wants more visual polish, it should build on this stable display boundary instead of reintroducing
+  raw progress-driven section resets.
+- #255 should focus on preview and transition coverage, not on more display-state mechanics.

--- a/docs/plans/today-state-flow-progress.md
+++ b/docs/plans/today-state-flow-progress.md
@@ -20,7 +20,7 @@ deliberately left alone, and what the next session should know.
 | 2 | TV-02 | [#250](https://github.com/justinrooks/project-arcus/issues/250) | Keep Today section content stable during resolving refreshes | `gpt-5.4-mini / high` | Complete | Canonical Today state now stabilizes Local Alerts, Today's Awareness, and risk placeholders during cached refreshes. |
 | 3 | TV-03 | [#251](https://github.com/justinrooks/project-arcus/issues/251) | Align Current Conditions and Atmospheric Conditions weather roll-forward behavior | `gpt-5.4-mini / high` | Complete | Today boundary now owns visible-weather retention so Current Conditions and Atmospheric Conditions stay aligned during same-location refresh. |
 | 4 | TV-04 | [#252](https://github.com/justinrooks/project-arcus/issues/252) | Consolidate Today refresh indicators into one calm updating state | `gpt-5.4-mini / medium` | Complete | Canonical Today state now drives the lone calm update cue; section resolving treatment is suppressed during cached refresh. |
-| 5 | TV-05 | [#253](https://github.com/justinrooks/project-arcus/issues/253) | Tighten Today animation and transition scope during refresh | `gpt-5.4-mini / medium` | Not started | Depends on TV-01, TV-02, and TV-04. |
+| 5 | TV-05 | [#253](https://github.com/justinrooks/project-arcus/issues/253) | Tighten Today animation and transition scope during refresh | `gpt-5.4-mini / medium` | Complete | Narrowed Today motion scope so cached-refreshing no longer rekeys alert content or participates in broad stack transitions. |
 | 6 | TV-06 | [#254](https://github.com/justinrooks/project-arcus/issues/254) | Stabilize Today snapshot application and display-model updates during partial data arrival | `gpt-5.4-mini / high` | Not started | Depends on TV-01. Keep provider progress internal. |
 | 7 | TV-07 | [#255](https://github.com/justinrooks/project-arcus/issues/255) | Add Today state-flow previews and transition mapping tests | `gpt-5.4-mini / medium` | Not started | Final validation/support issue after TV-01 through TV-06. |
 
@@ -451,3 +451,62 @@ Model used: `gpt-5.4-mini / medium`
 - Outlook now uses neutral copy instead of "Getting outlook details…" outside true no-cache resolving.
 - Keep the remaining noisy Summary Awareness accessibility tests out of this thread; they are not part of the calm
   update fix.
+
+### TV-05 / GitHub #253 - Tighten Today animation and transition scope during refresh
+
+Status: Complete
+Date: 2026-06-16
+Model used: `gpt-5.4-mini / medium`
+
+#### Scope
+
+- Added `TodayContentState.suppressesRoutineRefreshMotion` so cached-refreshing can explicitly opt out of routine
+  branch animation.
+- Removed the root `HomeView` ZStack transition so the Today stack no longer participates in an unnecessary full-screen
+  fade.
+- Removed `ActiveAlertSummaryView` content identity swapping and branch transition behavior, then gated its content
+  animation so cached-refreshing updates stay anchored instead of crossfading empty/loading/populated branches.
+- Added display-state coverage proving cached-refreshing suppresses routine refresh motion while no-cache resolving
+  remains the state that is allowed to drive page entrance motion.
+
+#### Files Changed
+
+- `Sources/App/HomeView.swift`
+- `Sources/Features/Summary/ActiveAlertSummaryView.swift`
+- `Sources/Features/Summary/TodayContentState.swift`
+- `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+- `docs/plans/today-state-flow-progress.md`
+
+#### Behavior Preserved
+
+- Cached-first Today rendering preserved.
+- True no-cache resolving still uses the calm loading surface and its existing entrance transition.
+- Section resolving treatment still stays suppressed for cached-refreshing via the canonical Today state.
+- Provider behavior, refresh cadence, and snapshot sequencing were not changed.
+- Reduce Motion checks remain in the existing SwiftUI branches; no new motion policy was introduced.
+
+#### Validation
+
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iPhone Simulator,name=iPhone 17" build`
+  - Passed.
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iPhone Simulator,name=iPhone 17" test -only-testing:SkyAwareTests/HomeViewLoadingOverlayStateTests/TodayContentStateTests`
+  - First attempt failed because it collided with the concurrent build database lock.
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iPhone Simulator,name=iPhone 17" -derivedDataPath /private/tmp/skyaware-tv253-test test -only-testing:SkyAwareTests/HomeViewLoadingOverlayStateTests/TodayContentStateTests`
+  - Passed.
+- `git diff --check -- Sources/App/HomeView.swift Sources/Features/Summary/ActiveAlertSummaryView.swift Sources/Features/Summary/TodayContentState.swift Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+  - Passed.
+
+#### Deferred Work
+
+- Simulator-level motion observation for cached-refreshing with Reduce Motion on/off remains a good follow-up sanity
+  check, but the code paths now explicitly suppress the routine branch animation source.
+- Refresh sequencing and partial-arrival stabilization remain deferred to #254.
+- Preview/test expansion for the full transition matrix remains deferred to #255.
+
+#### Handoff Notes
+
+- The important motion fix is in `ActiveAlertSummaryView`: stop rekeying the alert card on `contentState` changes and
+  keep cached-refreshing out of the branch animation path.
+- `TodayContentState.suppressesRoutineRefreshMotion` is the narrow motion hint now available for follow-up work.
+- If future motion work needs to reintroduce a broader page transition, it should be done from the canonical Today
+  state boundary, not from per-card identity churn.

--- a/docs/plans/today-state-flow-progress.md
+++ b/docs/plans/today-state-flow-progress.md
@@ -1,0 +1,274 @@
+# Today State Flow Progress
+
+This is the durable handoff ledger for the Today state-flow issue set.
+
+Update this file after each issue is implemented. Keep entries factual: what changed, what was validated, what was
+deliberately left alone, and what the next session should know.
+
+## GitHub Coordination
+
+- Parent epic: [#248](https://github.com/justinrooks/project-arcus/issues/248)
+- Sub-issues created 2026-06-15: #249 through #255
+- Runbook: `docs/plans/today-state-flow-runbook.md`
+
+## Current Status
+
+| Order | ID | GitHub | Title | Model | Status | Notes |
+|---:|---|---|---|---|---|---|
+| 0 | TV-00 | [#248](https://github.com/justinrooks/project-arcus/issues/248) | Audit Today View State Flow | `gpt-5.4-mini / medium` | Planned | Parent tracking issue created from source-backed investigation. |
+| 1 | TV-01 | [#249](https://github.com/justinrooks/project-arcus/issues/249) | Introduce canonical Today content state for cache roll-forward rendering | `gpt-5.4-mini / high` | Complete | Foundation boundary added; `HomeView` and `SummaryView` now share `TodayContentState`. |
+| 2 | TV-02 | [#250](https://github.com/justinrooks/project-arcus/issues/250) | Keep Today section content stable during resolving refreshes | `gpt-5.4-mini / high` | Not started | Depends on TV-01. Highest visible flicker risk. |
+| 3 | TV-03 | [#251](https://github.com/justinrooks/project-arcus/issues/251) | Align Current Conditions and Atmospheric Conditions weather roll-forward behavior | `gpt-5.4-mini / high` | Not started | Depends on TV-01. Header/weather split is source-backed. |
+| 4 | TV-04 | [#252](https://github.com/justinrooks/project-arcus/issues/252) | Consolidate Today refresh indicators into one calm updating state | `gpt-5.4-mini / medium` | Not started | Depends on TV-01 and TV-02. |
+| 5 | TV-05 | [#253](https://github.com/justinrooks/project-arcus/issues/253) | Tighten Today animation and transition scope during refresh | `gpt-5.4-mini / medium` | Not started | Depends on TV-01, TV-02, and TV-04. |
+| 6 | TV-06 | [#254](https://github.com/justinrooks/project-arcus/issues/254) | Stabilize Today snapshot application and display-model updates during partial data arrival | `gpt-5.4-mini / high` | Not started | Depends on TV-01. Keep provider progress internal. |
+| 7 | TV-07 | [#255](https://github.com/justinrooks/project-arcus/issues/255) | Add Today state-flow previews and transition mapping tests | `gpt-5.4-mini / medium` | Not started | Final validation/support issue after TV-01 through TV-06. |
+
+## Global Constraints
+
+- Preserve cached-first, resolve-forward behavior.
+- Preserve full-screen resolving only for true empty/no-cache startup.
+- Preserve current Today layout and section visual design.
+- Avoid spinner-first, shimmer, or flashy loading behavior.
+- Avoid provider, persistence, notification, Map, or app-wide architecture changes unless the issue explicitly requires
+  a narrow state-flow correction.
+- Do not hide useful cached data during refresh.
+- Do not show unavailable/offline states unless no useful cached or fresh data exists.
+- Do not touch unrelated dirty files.
+
+## Baseline Investigation
+
+### Current Flow
+
+1. `HomeView` reads cached `HomeProjection` and `ConvectiveOutlook` records via SwiftData `@Query`.
+2. `HomeView` selects `displayedProjection` for the current location context and computes displayed values by mixing
+   cached projection data with `HomeRefreshPipeline` state.
+3. `TodayTabView` renders `SummaryView` with raw section inputs plus `SummaryResolutionState`.
+4. `HomeRefreshPipeline` starts refreshes from scene activation, pull refresh, timer, or context change.
+5. Scene activation/context change can run a non-visible prime request, then schedule a follow-up refresh.
+6. Ingestion progress mutates `SummaryResolutionState` before the final `HomeSnapshot` is applied.
+7. `SummaryView` and child components independently decide whether they are loading, empty, resolving, stale, current,
+   or unavailable.
+8. Final snapshot application updates section values, but visual state has already reacted to progress events.
+
+### Evidence Map
+
+- `Sources/App/HomeView.swift`
+  - SwiftData cache queries: lines 20-24.
+  - Cached/pipeline value selection: lines 53-135.
+  - Today receives raw values plus `SummaryResolutionState`: lines 204-229.
+  - Bootstrap loading helper: lines 426-434.
+- `Sources/App/HomeRefreshPipeline.swift`
+  - Progress event handling: lines 334-343.
+  - Lane-to-section mapping: lines 346-384.
+  - Prime request can skip visible commit: lines 261-272.
+  - Final snapshot apply: lines 472-499.
+- `Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift`
+  - Progress reporting and snapshot load: lines 101-163.
+  - Weather progress: lines 347-386.
+- `Sources/Features/Summary/SummaryView.swift`
+  - Multiple state enums: lines 10-93 and 127-132.
+  - Section-level state derivation: lines 184-210, 247-343, 400-431, and 475-553.
+  - Empty resolving transition: lines 436-450 and 556-576.
+- `Sources/Features/Summary/SummaryStatus.swift`
+  - Weather retention exists for Current Conditions: lines 31-64 and 297-313.
+  - Secondary progress line animates messages: lines 373-446.
+- `Sources/Features/Badges/AtmosphereRailView.swift`
+  - Atmospheric Conditions derives directly from raw `weather`: lines 18-20.
+  - Nil weather becomes unavailable instrumentation: lines 124-156 and 206-212.
+- `Sources/Features/Summary/ActiveAlertSummaryView.swift`
+  - Loading wins in local content state: lines 59-67.
+  - Content identity changes on `contentState`: lines 208-213.
+  - Content state animates locally: line 159.
+- `Sources/Features/Summary/OutlookSummaryCard.swift`
+  - Missing outlook becomes `Getting outlook details...`: lines 36-44.
+  - Loading placeholder: lines 73-78.
+- `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+  - Local alerts loading-to-empty/populated sequences: lines 446-482.
+  - Risk placeholder behavior: lines 626-684.
+  - Weather retention tests: lines 928-1016.
+- `Tests/UnitTests/HomeRefreshPipelineTests.swift`
+  - Progress mapping tests: lines 104-339.
+  - Empty outlook refresh marked completed: lines 817-836.
+
+### Primary Findings
+
+- No single canonical Today display state exists today.
+- Sections independently decide loading/empty/stale/current/unavailable.
+- Provider progress is currently user-visible presentation state.
+- Current Conditions and Atmospheric Conditions can disagree on weather availability.
+- Local Alerts can flip through loading before empty or populated states.
+- Risk and awareness placeholders are selected locally and can diverge from the desired page-level behavior.
+- Refresh indicators and animations are duplicated across sections.
+
+## Target State
+
+The implementation should converge on a small layered model:
+
+1. Raw provider/cache state.
+2. Today orchestration state: no cache, cached refreshing, current, stale refreshing, degraded, unavailable.
+3. Stable Today display model: section values, section presentation states, one update indicator, and transition hints.
+4. SwiftUI views render the display model without independently reconstructing business state.
+
+## Cross-Issue Decisions
+
+Record facts that affect more than one issue here. Include the date, source issue, affected later issues, and the
+decision made.
+
+- 2026-06-15, audit: `SummaryStatus` already demonstrates same-location value retention for weather; prefer moving
+  that decision up into the Today display model rather than duplicating local retention in Atmospheric Conditions.
+- 2026-06-15, audit: `SummaryResolutionState` should remain useful orchestration/progress input, but provider progress
+  should not directly force destructive section presentation branches.
+- 2026-06-15, audit: Empty-but-known content is meaningful content. A known empty Local Alerts state should not become
+  loading during ordinary refresh.
+- 2026-06-16, planning: all Today state-flow issues are scoped for `gpt-5.4-mini`. Use `/high` for state-boundary,
+  retained-weather, multi-section stability, and async snapshot sequencing work. Use `/medium` for coordination,
+  indicators, animation scope, previews, tests, and docs. If an issue starts crossing these boundaries, split it rather
+  than expanding the implementation pass.
+
+## Issue Log Template
+
+Copy this section for each completed or active issue.
+
+### TV-XX / GitHub #NNN - Title
+
+Status: Not started
+Date:
+Model used:
+
+#### Scope
+
+Describe the implemented scope in concrete bullets.
+
+When implementing a sub-issue, list the mini-sized chunks completed from the GitHub issue body.
+
+#### Files Changed
+
+List every changed file.
+
+#### Behavior Preserved
+
+- Cached-first Today rendering preserved.
+- Provider behavior preserved unless explicitly scoped.
+- Refresh cadence preserved.
+- Persistence preserved.
+- User-facing design hierarchy preserved.
+
+#### Validation
+
+List every validation command run and result.
+
+#### Deferred Work
+
+List intentionally deferred work, or state `None`.
+
+#### Handoff Notes
+
+Record details the next session needs.
+
+## Implementation Log
+
+### TV-00 / GitHub #248 - Audit Today View State Flow
+
+Status: Complete
+Date: 2026-06-15
+Model used: GPT-5 Codex
+
+#### Scope
+
+- Investigated Today view composition, cache loading, refresh sequencing, section-level display state, weather
+  roll-forward behavior, local alert transitions, outlook behavior, and animation scope.
+- Created parent issue #248 and sub-issues #249 through #255.
+- Created this runbook and progress ledger for durable execution handoff.
+
+#### Files Changed
+
+- `docs/plans/today-state-flow-runbook.md`
+- `docs/plans/today-state-flow-progress.md`
+
+#### Behavior Preserved
+
+- No production source files changed.
+- No tests changed.
+- No providers, refresh orchestration, persistence, UI layout, or SwiftUI components changed.
+- No branch, commit, or PR created.
+
+#### Validation
+
+- Source-backed investigation only.
+- GitHub issues created through the GitHub connector.
+- No build or test run was required because no production or test code changed.
+
+#### Deferred Work
+
+- Simulator observation of the transition matrix remains for implementation/validation passes.
+- No Instruments trace was captured; raw performance profiling was intentionally secondary to state-flow mapping.
+
+#### Handoff Notes
+
+- Start implementation with TV-01 / #249.
+- Do not jump directly into card polish before the canonical Today display state exists; that repeats the current
+  split-brain state pattern with fresher paint.
+- Preserve the distinction between provider progress and user-visible presentation state.
+
+### TV-01 / GitHub #249 - Introduce canonical Today content state for cache roll-forward rendering
+
+Status: Complete
+Date: 2026-06-15
+Model used: GPT-5 Codex
+
+#### Scope
+
+- Added `TodayContentState` as the canonical Today page state with the expected page-level cases:
+  - `noCacheResolving`
+  - `cachedRefreshing`
+  - `current`
+  - `staleRefreshing`
+  - `degraded`
+  - `unavailable`
+- Added mapping tests for no-cache resolving, cached refreshing, current content, stale refreshing, degraded cached
+  content, and unavailable.
+- Wired `HomeView` to derive the canonical Today state from cache availability, pipeline fallback visibility, refresh
+  progress, readiness, and offline state.
+- Passed the canonical state into `SummaryView` and used it at the page boundary to drive the top-level resolving
+  surface, without changing the individual card visuals yet.
+
+#### Files Changed
+
+- `Sources/App/HomeView.swift`
+- `Sources/Features/Summary/SummaryView.swift`
+- `Sources/Features/Summary/TodayContentState.swift`
+- `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+- `docs/plans/today-state-flow-progress.md`
+
+#### Behavior Preserved
+
+- Cached-first rendering behavior was preserved.
+- `HomeRefreshPipeline` behavior, cadence, and provider orchestration were left alone.
+- Card visuals and local section presentation logic were not redesigned.
+- Refresh animations and indicator behavior were not intentionally changed in this issue.
+- No new provider, persistence, or data-mutation paths were added.
+
+#### Validation
+
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17,OS=26.5" test -only-testing:SkyAwareTests/HomeViewLoadingOverlayStateTests/TodayContentStateTests`
+  - Passed.
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iPhone Simulator,name=iPhone 17" build`
+  - Passed.
+
+#### Deferred Work
+
+- Section-level adoption of the canonical state is deferred to #250.
+- Current Conditions, Atmospheric Conditions, alerts, and risk cards still infer some loading/empty/unavailable behavior
+  locally.
+- Refresh indicators and animation scope were intentionally left unchanged.
+- Any broader response to partial failures or richer degraded reasons is deferred.
+
+#### Handoff Notes
+
+- #250 should start moving section presentation decisions behind this canonical boundary instead of reading raw
+  readiness/resolution booleans directly.
+- `TodayContentState` is intentionally small; extend it only when a later issue proves the extra state is actually
+  needed.
+- `HomeRefreshPipeline` did not change, so any remaining flicker or card-by-card churn is still coming from section
+  presentation logic, not the new boundary.

--- a/docs/plans/today-state-flow-progress.md
+++ b/docs/plans/today-state-flow-progress.md
@@ -19,7 +19,7 @@ deliberately left alone, and what the next session should know.
 | 1 | TV-01 | [#249](https://github.com/justinrooks/project-arcus/issues/249) | Introduce canonical Today content state for cache roll-forward rendering | `gpt-5.4-mini / high` | Complete | Foundation boundary added; `HomeView` and `SummaryView` now share `TodayContentState`. |
 | 2 | TV-02 | [#250](https://github.com/justinrooks/project-arcus/issues/250) | Keep Today section content stable during resolving refreshes | `gpt-5.4-mini / high` | Complete | Canonical Today state now stabilizes Local Alerts, Today's Awareness, and risk placeholders during cached refreshes. |
 | 3 | TV-03 | [#251](https://github.com/justinrooks/project-arcus/issues/251) | Align Current Conditions and Atmospheric Conditions weather roll-forward behavior | `gpt-5.4-mini / high` | Complete | Today boundary now owns visible-weather retention so Current Conditions and Atmospheric Conditions stay aligned during same-location refresh. |
-| 4 | TV-04 | [#252](https://github.com/justinrooks/project-arcus/issues/252) | Consolidate Today refresh indicators into one calm updating state | `gpt-5.4-mini / medium` | Not started | Depends on TV-01 and TV-02. |
+| 4 | TV-04 | [#252](https://github.com/justinrooks/project-arcus/issues/252) | Consolidate Today refresh indicators into one calm updating state | `gpt-5.4-mini / medium` | Complete | Canonical Today state now drives the lone calm update cue; section resolving treatment is suppressed during cached refresh. |
 | 5 | TV-05 | [#253](https://github.com/justinrooks/project-arcus/issues/253) | Tighten Today animation and transition scope during refresh | `gpt-5.4-mini / medium` | Not started | Depends on TV-01, TV-02, and TV-04. |
 | 6 | TV-06 | [#254](https://github.com/justinrooks/project-arcus/issues/254) | Stabilize Today snapshot application and display-model updates during partial data arrival | `gpt-5.4-mini / high` | Not started | Depends on TV-01. Keep provider progress internal. |
 | 7 | TV-07 | [#255](https://github.com/justinrooks/project-arcus/issues/255) | Add Today state-flow previews and transition mapping tests | `gpt-5.4-mini / medium` | Not started | Final validation/support issue after TV-01 through TV-06. |
@@ -388,3 +388,66 @@ Model used: `gpt-5.4-mini / high`
   is likely coming from refresh indicator policy or transition scope, not weather data flow.
 - Keep the current boundary narrow when working on #252 and #253; they should build on this shared weather input rather
   than reopening card-level retention logic.
+
+### TV-04 / GitHub #252 - Consolidate Today refresh indicators into one calm updating state
+
+Status: Complete
+Date: 2026-06-15
+Model used: `gpt-5.4-mini / medium`
+
+#### Scope
+
+- Added calm cached-refresh cue helpers on `TodayContentState`.
+- Routed the Current Conditions secondary line to the canonical Today cue instead of animating completed messages.
+- Suppressed section-level resolving treatment during cached-refreshing so cached content stays visible without multiple
+  simultaneous blur/opacity treatments.
+- Suppressed local loading copy in alerts, awareness, and outlook during cached-refreshing when stable cached or
+  known-empty content already exists.
+- Added a focused display-model test proving cached-refreshing exposes one calm page cue and suppresses local loading
+  branches.
+- Added cached-refreshing and no-cache resolving previews for the Today surface.
+
+#### Files Changed
+
+- `Sources/Features/Summary/TodayContentState.swift`
+- `Sources/Features/Summary/SummaryResolving.swift`
+- `Sources/Features/Summary/SummaryStatus.swift`
+- `Sources/Features/Summary/SummaryView.swift`
+- `Sources/Features/Summary/ActiveAlertSummaryView.swift`
+- `Sources/Features/Summary/OutlookSummaryCard.swift`
+- `Sources/Features/Summary/PrimaryAwarenessPanel.swift`
+- `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+- `docs/plans/today-state-flow-progress.md`
+
+#### Behavior Preserved
+
+- Cached-first Today rendering remained intact.
+- First-load no-cache resolving still shows the full-screen loading surface.
+- Offline/degraded content remains visible and meaningful.
+- Provider cadence, refresh sequencing, and snapshot application logic were not changed.
+- The Today layout and card hierarchy were left alone.
+
+#### Validation
+
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,id=F5154D35-3398-4BEB-943E-E8D174B32832" test -only-testing:SkyAwareTests/TodayContentStateTests`
+  - Passed.
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,id=F5154D35-3398-4BEB-943E-E8D174B32832" test -only-testing:SkyAwareTests/SummaryAwarenessPanelTests`
+  - Failed on pre-existing accessibility contract assertions unrelated to this issue:
+    - `stormHeroAccessibilityContract_separatesCategoryValueAndHint()`
+    - `fireHeroAccessibilityContract_keepsTheFireValueReadable()`
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,id=F5154D35-3398-4BEB-943E-E8D174B32832" build`
+  - Passed.
+
+#### Deferred Work
+
+- TV-05 and TV-06 remain untouched.
+- The unrelated Summary Awareness accessibility-contract failures should be handled separately.
+
+#### Handoff Notes
+
+- `TodayContentState` now owns the calm cached-refresh cue via `showsCalmUpdatingCue`.
+- `summaryResolving` now suppresses section-level resolving treatment for cached refreshes; TV-05 should tighten any
+  remaining animation scope rather than reintroducing local loading branches.
+- Outlook now uses neutral copy instead of "Getting outlook details…" outside true no-cache resolving.
+- Keep the remaining noisy Summary Awareness accessibility tests out of this thread; they are not part of the calm
+  update fix.

--- a/docs/plans/today-state-flow-progress.md
+++ b/docs/plans/today-state-flow-progress.md
@@ -763,3 +763,63 @@ Model used: `gpt-5.4-mini / medium`
 - `showsOfflineStatusCopy` is intentionally narrower than `isOffline`; it only surfaces the offline note when cached
   alerts/mesos are actually useful.
 - Do not reintroduce card-level dimming here unless #258 exposes a specific transition bug that genuinely requires it.
+
+### LA-03 / GitHub #258 - Stabilize ActiveAlertSummaryView transitions and height behavior
+
+Status: Complete
+Date: 2026-06-16
+Model used: `gpt-5.4-mini / high`
+
+#### Scope
+
+- Reproduced the visible startup flip from the screen recording: the card was still animating a transient
+  loading-to-alerts branch swap on initial load, which made the Local Alerts section visibly flip at the bottom edge.
+- Replaced the child card's loading boolean with the authoritative `LocalAlertsDisplayState` from `SummaryView`.
+- Made the card's content selection prefer existing renderable alerts over transient loading or empty bookkeeping.
+- Kept first-load no-cache loading available when the Local Alerts display state truly has no useful alert content.
+- Suppressed non-essential branch animation when loading is part of the transition, so populated alerts can replace a
+  transient loading branch without crossfading.
+- Preserved the existing flexible-height hold for genuine alerts-to-empty transitions.
+- Added regression tests covering:
+  - existing alerts with transient loading input
+  - cached-refreshing populated alerts
+  - cached-refreshing known-empty alerts
+  - no-cache resolving without useful content
+  - alerts-to-empty height smoothing
+  - loading-to-alerts branch animation suppression
+  - empty-to-alerts branch animation allowance
+
+#### Files Changed
+
+- `Sources/Features/Summary/ActiveAlertSummaryView.swift`
+- `Sources/Features/Summary/SummaryView.swift`
+- `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+- `docs/plans/today-state-flow-progress.md`
+
+#### Behavior Preserved
+
+- Cached populated alerts remain visible during routine refresh.
+- Cached known-empty alerts remain empty during routine refresh.
+- Sheet selection and Alert Center navigation continue to work.
+- Reduce Motion still suppresses non-essential motion.
+- Provider cadence, alert semantics, and refresh orchestration were not changed.
+
+#### Validation
+
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:SkyAwareTests/SummaryViewLocalAlertsTests test`
+  - Passed.
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build`
+  - Passed.
+
+#### Deferred Work
+
+- #259 should add the remaining Local Alerts preview matrix and any visual validation needed for the alert-card state
+  transitions.
+- No provider, cadence, or notification follow-up was required for this issue.
+
+#### Handoff Notes
+
+- The important boundary now lives in `LocalAlertsDisplayState` and the card consumes that state directly.
+- The card now suppresses loading-to-content branch animation, so startup refreshes should no longer visibly flip.
+- The remaining Local Alerts validation work should focus on visual preview coverage, not another state-machine rewrite.
+- If a future flash appears again, check for upstream clearing of alert arrays before changing the card logic.

--- a/docs/plans/today-state-flow-progress.md
+++ b/docs/plans/today-state-flow-progress.md
@@ -9,6 +9,7 @@ deliberately left alone, and what the next session should know.
 
 - Parent epic: [#248](https://github.com/justinrooks/project-arcus/issues/248)
 - Sub-issues created 2026-06-15: #249 through #255
+- Local Alerts follow-up sub-issues created 2026-06-16: #256 through #259
 - Runbook: `docs/plans/today-state-flow-runbook.md`
 
 ## Current Status
@@ -23,6 +24,10 @@ deliberately left alone, and what the next session should know.
 | 5 | TV-05 | [#253](https://github.com/justinrooks/project-arcus/issues/253) | Tighten Today animation and transition scope during refresh | `gpt-5.4-mini / medium` | Complete | Narrowed Today motion scope so cached-refreshing no longer rekeys alert content or participates in broad stack transitions. |
 | 6 | TV-06 | [#254](https://github.com/justinrooks/project-arcus/issues/254) | Stabilize Today snapshot application and display-model updates during partial data arrival | `gpt-5.4-mini / high` | Complete | Provider progress now gates orchestration only; Today keeps cached content visible until coherent snapshot commit, and empty-success outlooks preserve cached values explicitly. |
 | 7 | TV-07 | [#255](https://github.com/justinrooks/project-arcus/issues/255) | Add Today state-flow previews and transition mapping tests | `gpt-5.4-mini / medium` | Not started | Final validation/support issue after TV-01 through TV-06. |
+| 8 | LA-01 | [#256](https://github.com/justinrooks/project-arcus/issues/256) | Define Local Alerts display state with cache provenance | `gpt-5.4-mini / high` | Complete | Alert-specific state semantics now preserve live vs cached provenance, cached refresh, stale/degraded, and true unavailable boundaries. |
+| 9 | LA-02 | [#257](https://github.com/justinrooks/project-arcus/issues/257) | Make Local Alerts refresh treatment calm and non-duplicative | `gpt-5.4-mini / medium` | Not started | Depends on LA-01 and the page-level calm cue from TV-04. |
+| 10 | LA-03 | [#258](https://github.com/justinrooks/project-arcus/issues/258) | Stabilize ActiveAlertSummaryView transitions and height behavior | `gpt-5.4-mini / high` | Not started | Alert card local state/height mechanics. Depends on LA-01/LA-02. |
+| 11 | LA-04 | [#259](https://github.com/justinrooks/project-arcus/issues/259) | Add Local Alerts state-flow previews and tests | `gpt-5.4-mini / medium` | Not started | Final alert-specific validation support after LA-01 through LA-03. |
 
 ## Global Constraints
 
@@ -101,6 +106,22 @@ deliberately left alone, and what the next session should know.
 - Risk and awareness placeholders are selected locally and can diverge from the desired page-level behavior.
 - Refresh indicators and animations are duplicated across sections.
 
+### Local Alerts Follow-Up Findings
+
+- `SummaryView.LocalAlertsPresentationState` currently has only `.unavailable`, `.loading`, `.alerts`, and `.empty`,
+  which does not preserve alert-specific provenance such as unknown/no-cache, known empty, stale, or degraded.
+- `SummaryView` derives Local Alerts state from page state, location availability, and array emptiness, while
+  `HomeProjection` separately stores `activeAlerts`, `activeMesos`, and `lastHotAlertsLoadAt`.
+- `HomeView.displayedMesos` and `HomeView.displayedAlerts` switch independently between pipeline arrays and cached
+  projection arrays; the Local Alerts section does not receive one stable display model describing why those arrays are
+  empty or populated.
+- `SummaryView.appliesLocalAlertsResolving` still allows whole-card resolving treatment for settled `.alerts` and
+  `.empty` states when alert resolution is active.
+- `ActiveAlertSummaryView` owns local `ContentState`, `HeightPhase`, and a delayed main-actor height reset task. Those
+  mechanics can still create Local Alerts-specific churn unless constrained by an alert display-state policy.
+- Existing Local Alerts tests cover several helper outcomes, but not the complete alert-specific state/provenance,
+  refresh-treatment, transition, and preview matrix.
+
 ## Target State
 
 The implementation should converge on a small layered model:
@@ -125,6 +146,13 @@ decision made.
   retained-weather, multi-section stability, and async snapshot sequencing work. Use `/medium` for coordination,
   indicators, animation scope, previews, tests, and docs. If an issue starts crossing these boundaries, split it rather
   than expanding the implementation pass.
+- 2026-06-16, Local Alerts audit: the broad Today fixes have landed through TV-06, but Local Alerts still needs a
+  section-specific display-state/provenance layer and card-level transition cleanup. Track this as LA-01 through LA-04
+  under parent issue #248, with `/high` for provenance and height/transition semantics and `/medium` for presentation
+  treatment and validation.
+- 2026-06-16, LA-01 implementation: Local Alerts presentation should now be driven from `LocalAlertsDisplayState`
+  instead of raw array emptiness or page-level state alone. Preserve that boundary for LA-02 through LA-04 so refresh
+  treatment and height/transition cleanup do not reintroduce provenance drift.
 
 ## Issue Log Template
 
@@ -567,3 +595,114 @@ Model used: `gpt-5.4-mini / high`
 - If the next issue wants more visual polish, it should build on this stable display boundary instead of reintroducing
   raw progress-driven section resets.
 - #255 should focus on preview and transition coverage, not on more display-state mechanics.
+
+### LA-00 / GitHub #248 - Local Alerts Section State-Flow Follow-Up Audit
+
+Status: Complete
+Date: 2026-06-16
+Model used: GPT-5 Codex
+
+#### Scope
+
+- Re-audited the Local Alerts section after the broader Today state-flow work had landed through TV-06.
+- Focused on `SummaryView.LocalAlertsPresentationState`, `ActiveAlertSummaryView`, `SummaryResolutionState` alert
+  progress copy, cached alert provenance in `HomeProjection`, and Local Alerts-focused tests.
+- Created Local Alerts follow-up issues #256 through #259 under parent #248.
+- Updated #248, this progress ledger, and the runbook with the Local Alerts issue sequence and model guidance.
+
+#### Files Changed
+
+- `docs/plans/today-state-flow-runbook.md`
+- `docs/plans/today-state-flow-progress.md`
+
+#### Behavior Preserved
+
+- No production source files changed.
+- No tests changed.
+- No providers, refresh orchestration, persistence, UI layout, or SwiftUI components changed.
+- No branch, commit, or PR created.
+
+#### Validation
+
+- Source-backed investigation only.
+- GitHub issues #256 through #259 created through the GitHub connector.
+- Parent issue #248 updated through the GitHub connector.
+- No build or test run was required because no production or test code changed.
+
+#### Deferred Work
+
+- Implement LA-01 / #256 first so Local Alerts has explicit cache provenance before presentation/motion cleanup.
+- LA-02 / #257 should remove redundant/dimming refresh treatment only after LA-01 lands.
+- LA-03 / #258 should constrain `ActiveAlertSummaryView` local height/transition behavior after the alert display state
+  is authoritative.
+- LA-04 / #259 should add previews/tests after LA-01 through LA-03.
+
+#### Handoff Notes
+
+- Do not fold LA-01 through LA-03 into #255; #255 is page-level Today validation, while #256 through #259 are
+  alert-section correctness and polish.
+- The most important pre-LA-01 evidence was that `HomeProjection` tracks `lastHotAlertsLoadAt`, but `SummaryView`
+  previously only saw array emptiness plus `TodayContentState` when choosing the Local Alerts surface.
+- Keep provider cadence and hot-alert delivery semantics out of these issues unless new source evidence proves they are
+  the root cause.
+
+### LA-01 / GitHub #256 - Define Local Alerts display state with cache provenance
+
+Status: Complete
+Date: 2026-06-16
+Model used: `gpt-5.4-mini / high`
+
+#### Scope
+
+- Added `LocalAlertsDisplayState` as the narrow display boundary for Local Alerts provenance.
+- Distinguished:
+  - no-cache resolving
+  - current live empty/populated
+  - current cached empty/populated
+  - cached refreshing empty/populated
+  - offline stale/degraded empty/populated
+  - location unavailable
+  - true unavailable / no useful alert state
+- Wired `HomeView` to derive the display state from the rendered alert source, cached projection presence, and
+  `lastHotAlertsLoadAt`.
+- Wired `SummaryView` to derive `LocalAlertsPresentationState` from the display state before choosing the existing
+  `ActiveAlertSummaryView` branches.
+- Kept `ActiveAlertSummaryView` visuals and behavior unchanged.
+
+#### Files Changed
+
+- `Sources/App/HomeView.swift`
+- `Sources/Features/Summary/LocalAlertsDisplayState.swift`
+- `Sources/Features/Summary/SummaryView.swift`
+- `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+- `docs/plans/today-state-flow-progress.md`
+
+#### Behavior Preserved
+
+- Cached-first Today rendering was preserved.
+- `HomeRefreshPipeline` behavior, cadence, and provider orchestration were left alone.
+- `ActiveAlertSummaryView` visuals, row layout, height mechanics, and transition behavior were not changed.
+- Refresh cadence, notification delivery, and alert filtering semantics were not changed.
+- No new provider, persistence, or data-mutation paths were added.
+
+#### Validation
+
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" test -only-testing:SkyAwareTests/HomeViewLoadingOverlayStateTests/LocalAlertsDisplayStateTests -only-testing:SkyAwareTests/HomeViewLoadingOverlayStateTests/SummaryViewLocalAlertsTests -only-testing:SkyAwareTests/HomeViewLoadingOverlayStateTests/TodayContentStateTests`
+  - Passed.
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,id=F5154D35-3398-4BEB-943E-E8D174B32832" build`
+  - Passed.
+
+#### Deferred Work
+
+- #257 should refine alert refresh treatment now that the provenance boundary exists.
+- #258 should stabilize `ActiveAlertSummaryView` transitions and height behavior on top of the new display state.
+- #259 should add preview coverage for the new alert display-state matrix and any residual presentation edge cases.
+
+#### Handoff Notes
+
+- `LocalAlertsDisplayState` is the new boundary for alert provenance. Use it instead of rebuilding truth from raw array
+  emptiness or `TodayContentState` alone.
+- `SummaryView` now treats Local Alerts presentation as derived display state, which keeps later refresh-treatment and
+  transition work isolated.
+- `HomeRefreshPipeline` did not change, so any remaining alert churn should be addressed in #257 or #258, not by
+  reopening provider cadence or refresh sequencing here.

--- a/docs/plans/today-state-flow-progress.md
+++ b/docs/plans/today-state-flow-progress.md
@@ -18,7 +18,7 @@ deliberately left alone, and what the next session should know.
 | 0 | TV-00 | [#248](https://github.com/justinrooks/project-arcus/issues/248) | Audit Today View State Flow | `gpt-5.4-mini / medium` | Planned | Parent tracking issue created from source-backed investigation. |
 | 1 | TV-01 | [#249](https://github.com/justinrooks/project-arcus/issues/249) | Introduce canonical Today content state for cache roll-forward rendering | `gpt-5.4-mini / high` | Complete | Foundation boundary added; `HomeView` and `SummaryView` now share `TodayContentState`. |
 | 2 | TV-02 | [#250](https://github.com/justinrooks/project-arcus/issues/250) | Keep Today section content stable during resolving refreshes | `gpt-5.4-mini / high` | Complete | Canonical Today state now stabilizes Local Alerts, Today's Awareness, and risk placeholders during cached refreshes. |
-| 3 | TV-03 | [#251](https://github.com/justinrooks/project-arcus/issues/251) | Align Current Conditions and Atmospheric Conditions weather roll-forward behavior | `gpt-5.4-mini / high` | Not started | Depends on TV-01. Header/weather split is source-backed. |
+| 3 | TV-03 | [#251](https://github.com/justinrooks/project-arcus/issues/251) | Align Current Conditions and Atmospheric Conditions weather roll-forward behavior | `gpt-5.4-mini / high` | Complete | Today boundary now owns visible-weather retention so Current Conditions and Atmospheric Conditions stay aligned during same-location refresh. |
 | 4 | TV-04 | [#252](https://github.com/justinrooks/project-arcus/issues/252) | Consolidate Today refresh indicators into one calm updating state | `gpt-5.4-mini / medium` | Not started | Depends on TV-01 and TV-02. |
 | 5 | TV-05 | [#253](https://github.com/justinrooks/project-arcus/issues/253) | Tighten Today animation and transition scope during refresh | `gpt-5.4-mini / medium` | Not started | Depends on TV-01, TV-02, and TV-04. |
 | 6 | TV-06 | [#254](https://github.com/justinrooks/project-arcus/issues/254) | Stabilize Today snapshot application and display-model updates during partial data arrival | `gpt-5.4-mini / high` | Not started | Depends on TV-01. Keep provider progress internal. |
@@ -328,3 +328,63 @@ Model used: `gpt-5.4-mini / high`
 - Local Alerts and the Today awareness/risk surfaces now stay visually stable during cached refreshes, so any new
   churn will likely come from weather-specific value retention or page-level indicator changes.
 - Do not widen this into refresh-indicator policy or animation cleanup; those belong to #252 and #253.
+
+### TV-03 / GitHub #251 - Align Current Conditions and Atmospheric Conditions weather roll-forward behavior
+
+Status: Complete
+Date: 2026-06-15
+Model used: `gpt-5.4-mini / high`
+
+#### Scope
+
+- Added `TodayVisibleWeatherState` as the Today display-boundary model for retained visible weather.
+- Moved same-location visible-weather retention to `TodayTabView` so the Today surface resolves one visible weather
+  value before rendering both weather-dependent cards.
+- Passed the retained visible weather into `SummaryView`, which in turn feeds both `SummaryStatus` and
+  `AtmosphericConditionsCard` from the same input.
+- Removed the weather-retention state and helper from `SummaryStatus` so Current Conditions no longer owns a separate
+  retention path.
+- Added focused previews for:
+  - cached-refreshing weather
+  - no-cache resolving weather
+  - unavailable weather
+- Added unit coverage for same-location refresh retention and location-identity clearing.
+
+#### Files Changed
+
+- `Sources/App/HomeView.swift`
+- `Sources/Features/Badges/AtmosphereRailView.swift`
+- `Sources/Features/Summary/SummaryStatus.swift`
+- `Sources/Features/Summary/SummaryView.swift`
+- `Sources/Features/Summary/TodayVisibleWeatherState.swift`
+- `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+- `docs/plans/today-state-flow-progress.md`
+
+#### Behavior Preserved
+
+- Cached-first Today rendering remained intact.
+- Weather providers, refresh cadence, and location-resolution policy were not changed.
+- The Today layout and card design were not redesigned.
+- Existing cached-first and resolve-forward Today behavior was preserved.
+- No broad refresh-indicator consolidation or animation-scope work was introduced.
+
+#### Validation
+
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,id=F5154D35-3398-4BEB-943E-E8D174B32832" test -only-testing:SkyAwareTests/TodayVisibleWeatherStateTests`
+  - Passed.
+- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,id=F5154D35-3398-4BEB-943E-E8D174B32832" build`
+  - Passed.
+
+#### Deferred Work
+
+- Refresh-indicator consolidation is deferred to #252.
+- Animation and transition scope cleanup is deferred to #253.
+
+#### Handoff Notes
+
+- The visible-weather decision now lives at the Today boundary; later issues should not reintroduce section-local weather
+  retention.
+- Atmospheric Conditions now receives the same retained weather as Current Conditions, so any remaining churn in Today
+  is likely coming from refresh indicator policy or transition scope, not weather data flow.
+- Keep the current boundary narrow when working on #252 and #253; they should build on this shared weather input rather
+  than reopening card-level retention logic.

--- a/docs/plans/today-state-flow-runbook.md
+++ b/docs/plans/today-state-flow-runbook.md
@@ -1,0 +1,355 @@
+# Today State Flow Runbook
+
+Use this runbook when implementing the Today state-flow issue set derived from GitHub issue #248.
+
+This work is a focused refinement of the existing cached-first, resolve-forward Today experience. It is not a visual
+redesign, provider rewrite, refresh-cadence project, or permission to add theatrical loading behavior. The goal is a
+calm, predictable landing surface where cached content appears immediately and fresh data resolves forward quietly.
+
+## GitHub Coordination
+
+- Parent epic: [#248](https://github.com/justinrooks/project-arcus/issues/248)
+- Sub-issues: #249 through #255, ordered as listed below
+
+## Source Of Truth
+
+- Parent issue: [#248](https://github.com/justinrooks/project-arcus/issues/248)
+- Progress ledger: `docs/plans/today-state-flow-progress.md`
+- Product direction: `docs/SkyAware North Star Spec.md`
+- Repository guidance: `AGENTS.md` and `Sources/AGENTS.md`
+- Prior related UI polish ledger: `docs/plans/resolve-forward-ui-polish-progress.md`
+
+## Required Read Order
+
+Before implementing any work item:
+
+1. Read `AGENTS.md`.
+2. Read `Sources/AGENTS.md`.
+3. Read `tasks/lessons.md`.
+4. Read the current GitHub issue.
+5. Read this runbook.
+6. Read `docs/plans/today-state-flow-progress.md`.
+7. Read the relevant production and test files named by the issue.
+8. For SwiftUI state, animation, or preview work, use the SwiftUI expert guidance available in the workspace.
+9. For async sequencing, `@MainActor`, or refresh pipeline work, use the Swift concurrency guidance available in the
+   workspace.
+
+## Non-Negotiables
+
+- Preserve cached-first, resolve-forward behavior.
+- Preserve full-screen resolving only for true no-cache startup.
+- Do not replace meaningful cached content with loading, empty, unavailable, or placeholder states during refresh.
+- Do not add flashy loading states, shimmer, or spinner-first behavior.
+- Do not redesign the Today layout, Today's Awareness, Atmospheric Conditions, or risk cards.
+- Do not change weather, SPC, NWS, Arcus, or WeatherKit data semantics.
+- Do not broaden this into Map performance, notification delivery, persistence, or app-wide architecture work.
+- Do not expose provider names, system jargon, or debug language in user-facing copy.
+- Keep each issue independently reviewable.
+- Update `docs/plans/today-state-flow-progress.md` before finishing any issue.
+
+## Design North Star
+
+The Today view is the landing surface for a severe-weather awareness app. It should answer what matters now without
+making normal refreshes feel alarming.
+
+Prefer:
+
+- cached content in place
+- one calm updating cue
+- stable card identity
+- value-level updates
+- deterministic state transitions
+- subtle degraded/stale treatment when useful
+- true unavailable states only when no useful data exists
+
+Avoid:
+
+- multiple local `Getting...` messages during ordinary refresh
+- empty/loading/unavailable flashes while cached data exists
+- section-by-section nervous motion
+- broad `.animation` scopes for refresh bookkeeping
+- clearing display values before a replacement display model is ready
+- presenting provider progress as product state
+
+## Current Implementation Map
+
+Today entry and orchestration:
+
+- `Sources/App/HomeView.swift`
+- `Sources/App/HomeRefreshPipeline.swift`
+- `Sources/App/HomeRefreshPolicies.swift`
+- `Sources/App/HomeRefreshV2/HomeSnapshot.swift`
+- `Sources/App/HomeRefreshV2/HomeSnapshotStore.swift`
+- `Sources/App/HomeRefreshV2/HomeIngestionCoordinator.swift`
+- `Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift`
+- `Sources/App/HomeRefreshV2/HomeFreshnessState.swift`
+
+Today/Summary UI:
+
+- `Sources/Features/Summary/SummaryView.swift`
+- `Sources/Features/Summary/SummaryResolving.swift`
+- `Sources/Features/Summary/SummaryStatus.swift`
+- `Sources/Features/Summary/PrimaryAwarenessPanel.swift`
+- `Sources/Features/Summary/ActiveAlertSummaryView.swift`
+- `Sources/Features/Summary/OutlookSummaryCard.swift`
+- `Sources/Features/Badges/AtmosphereRailView.swift`
+- `Sources/Features/Badges/StormRiskBadgeView.swift`
+- `Sources/Features/Badges/SevereWeatherBadgeView.swift`
+- `Sources/Features/Badges/FireWeatherRailView.swift`
+
+Relevant tests:
+
+- `Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift`
+- `Tests/UnitTests/HomeRefreshPipelineTests.swift`
+- `Tests/UnitTests/SummaryAwarenessPanelTests.swift`
+
+## Baseline State Flow
+
+Current flow:
+
+1. `HomeView` reads cached `HomeProjection` and `ConvectiveOutlook` records through SwiftData `@Query`.
+2. `HomeView` selects a cached projection for the current context, then mixes projection values with
+   `HomeRefreshPipeline` values.
+3. `TodayTabView` passes raw section values and `SummaryResolutionState` into `SummaryView`.
+4. `HomeRefreshPipeline` starts refreshes from scene activation, pull refresh, timer, or context change.
+5. Scene activation and context change can run a prime request that does not commit visible snapshot data, then schedule
+   a follow-up refresh.
+6. Ingestion progress events mutate `SummaryResolutionState` before the final `HomeSnapshot` is applied.
+7. `SummaryView` and child components independently infer loading, empty, resolving, stale, and unavailable states.
+8. Final snapshot application updates the raw values that the sections consume.
+
+Primary fragmentation points:
+
+- `SummaryReadinessState`, `SummaryResolutionState`, `SummaryContentPresentationState`,
+  `LocalAlertsPresentationState`, and per-card booleans each encode part of the Today display truth.
+- Provider progress events are consumed directly as visual state.
+- Current Conditions retains weather during same-location refresh; Atmospheric Conditions does not.
+- Local Alerts can intentionally transition through loading before empty or populated states.
+- Risk/awareness resolving placeholders are selected locally per section.
+- Refresh indicators and animations are distributed across multiple cards.
+
+## Target Design
+
+Use a layered model:
+
+1. Raw provider/domain state: SwiftData cache, pipeline snapshot, ingestion progress, reachability, freshness.
+2. Today orchestration state: no cache, cached refreshing, current, stale refreshing, degraded, unavailable.
+3. Stable Today display model: values shown by each section, section presentation states, one update indicator, and
+   transition hints.
+4. SwiftUI views: render stable display models and avoid making business/state decisions in view bodies.
+
+Suggested state shape:
+
+```swift
+enum TodayContentState: Equatable {
+    case emptyResolving
+    case cachedRefreshing(freshness: TodayFreshness)
+    case current
+    case staleRefreshing
+    case degraded(reason: TodayDegradedReason)
+    case unavailable(reason: TodayUnavailableReason)
+}
+```
+
+Keep this boring. If the implementation starts needing a grand state-machine framework, stop and re-plan. The app
+needs a clean display boundary, not a cathedral to loading.
+
+## Model Guidance
+
+This issue set is intentionally scoped so `gpt-5.4-mini` can execute it in sequential passes.
+
+- Use `gpt-5.4-mini / high` for state-boundary, refresh-sequencing, retained-weather, and multi-section presentation
+  work where small mistakes can create user-visible churn.
+- Use `gpt-5.4-mini / medium` for issue coordination, docs, previews, focused tests, indicator copy/policy, and
+  animation-scope cleanup after state correctness lands.
+- Do not escalate scope just because a thread can see a tempting adjacent fix. Split the work at the issue boundary.
+- Stop and re-plan if a chunk starts changing provider cadence, serializing refresh work, redesigning card layout, or
+  rewriting broad `HomeRefreshPipeline` behavior.
+
+## Ordered Work Items
+
+| Order | ID | GitHub | Title | Model | Priority | Effort | Dependency |
+|---:|---|---|---|---|---|---|---|
+| 0 | TV-00 | [#248](https://github.com/justinrooks/project-arcus/issues/248) | Audit Today View State Flow | `gpt-5.4-mini / medium` | Parent | - | Tracking issue |
+| 1 | TV-01 | [#249](https://github.com/justinrooks/project-arcus/issues/249) | Introduce canonical Today content state for cache roll-forward rendering | `gpt-5.4-mini / high` | P1 | M | None |
+| 2 | TV-02 | [#250](https://github.com/justinrooks/project-arcus/issues/250) | Keep Today section content stable during resolving refreshes | `gpt-5.4-mini / high` | P0 | M | TV-01 |
+| 3 | TV-03 | [#251](https://github.com/justinrooks/project-arcus/issues/251) | Align Current Conditions and Atmospheric Conditions weather roll-forward behavior | `gpt-5.4-mini / high` | P0 | M | TV-01 |
+| 4 | TV-04 | [#252](https://github.com/justinrooks/project-arcus/issues/252) | Consolidate Today refresh indicators into one calm updating state | `gpt-5.4-mini / medium` | P1 | S/M | TV-01, TV-02 |
+| 5 | TV-05 | [#253](https://github.com/justinrooks/project-arcus/issues/253) | Tighten Today animation and transition scope during refresh | `gpt-5.4-mini / medium` | P1 | S/M | TV-01, TV-02, TV-04 |
+| 6 | TV-06 | [#254](https://github.com/justinrooks/project-arcus/issues/254) | Stabilize Today snapshot application and display-model updates during partial data arrival | `gpt-5.4-mini / high` | P1 | M | TV-01 |
+| 7 | TV-07 | [#255](https://github.com/justinrooks/project-arcus/issues/255) | Add Today state-flow previews and transition mapping tests | `gpt-5.4-mini / medium` | P2/P3 | M | TV-01 through TV-06 |
+
+## Work Item Contracts
+
+### TV-01: Canonical Today Content State
+
+Introduce the smallest display-state boundary that distinguishes no cache, cached refreshing, current, stale/degraded,
+and unavailable. Keep raw provider progress out of SwiftUI section decision logic.
+
+Recommended model: `gpt-5.4-mini / high`.
+
+Mini-sized chunks:
+
+1. Add failing mapping tests for no cache, cached refresh, stale/degraded, unavailable, and partial failure inputs.
+2. Introduce the smallest `TodayContentState` and section-display model needed for those tests.
+3. Wire `HomeView`/`SummaryView` to consume display state at the boundary without changing section visuals yet.
+4. Run focused mapping tests and app build.
+
+Likely files: `HomeView.swift`, `HomeRefreshPipeline.swift`, `SummaryView.swift`, focused tests.
+
+### TV-02: Stable Section Content
+
+Make cached populated and cached empty section content remain visually stable during refresh. Do not transition through
+loading unless the section has no meaningful prior state.
+
+Recommended model: `gpt-5.4-mini / high`.
+
+Mini-sized chunks:
+
+1. Test cached empty alerts and cached populated alerts during active refresh.
+2. Refactor local-alert presentation to consume Today section display state.
+3. Refactor risk and awareness placeholders to respect canonical content state.
+4. Update focused previews and run focused tests/build.
+
+Likely files: `SummaryView.swift`, `ActiveAlertSummaryView.swift`, `PrimaryAwarenessPanel.swift`, risk badge views,
+focused tests.
+
+### TV-03: Weather Roll-Forward Consistency
+
+Move same-location weather retention out of `SummaryStatus`-only behavior so Current Conditions and Atmospheric
+Conditions render from the same visible-weather decision.
+
+Recommended model: `gpt-5.4-mini / high`.
+
+Mini-sized chunks:
+
+1. Test same-location refresh retention and location-identity clearing.
+2. Move/expose the visible-weather decision at the Today display-model boundary.
+3. Pass retained visible weather to both Current Conditions and Atmospheric Conditions.
+4. Add focused previews and run focused tests/build.
+
+Likely files: `HomeView.swift`, `SummaryView.swift`, `SummaryStatus.swift`, `AtmosphereRailView.swift`, focused tests.
+
+### TV-04: Calm Updating Indicator
+
+Consolidate normal refresh feedback into one page-level or top-section cue. Suppress local loading copy when stable
+cached or known-empty content exists.
+
+Recommended model: `gpt-5.4-mini / medium`.
+
+Mini-sized chunks:
+
+1. Test that cached-refreshing exposes one update indicator.
+2. Route the Current Conditions secondary line or page cue from canonical update state.
+3. Suppress local `Getting...` copy where stable content exists.
+4. Add cached-refreshing and no-cache resolving previews.
+
+Likely files: `SummaryView.swift`, `SummaryStatus.swift`, `SummaryResolving.swift`, `ActiveAlertSummaryView.swift`,
+`OutlookSummaryCard.swift`, `PrimaryAwarenessPanel.swift`.
+
+### TV-05: Animation Scope
+
+Narrow refresh animations to meaningful value changes. Avoid full-content transitions, identity swaps, or broad
+section animation for routine cached refreshes.
+
+Recommended model: `gpt-5.4-mini / medium`.
+
+Mini-sized chunks:
+
+1. Test that cached-refreshing does not request a full-content transition.
+2. Guard broad Today stack transitions so they apply only to true no-cache resolving.
+3. Adjust active-alert identity transitions for routine refresh.
+4. Verify Reduce Motion through previews or simulator observation.
+
+Likely files: `HomeView.swift`, `SummaryView.swift`, `SummaryResolving.swift`, `ActiveAlertSummaryView.swift`,
+`PrimaryAwarenessPanel.swift`, `SummaryStatus.swift`.
+
+### TV-06: Snapshot And Partial Arrival Stability
+
+Separate provider progress from user-visible display commits. Apply final values in coherent display-model updates,
+preserve cached display values on partial failure, and make empty outlook semantics explicit.
+
+Recommended model: `gpt-5.4-mini / high`.
+
+Mini-sized chunks:
+
+1. Test progress-started and progress-completed-before-snapshot display mapping.
+2. Map progress to non-destructive updating/degraded hints.
+3. Preserve cached Today outlook when fresh snapshot content is empty and useful cached outlook exists.
+4. Add partial-failure/degraded tests and run focused pipeline tests/build.
+
+Likely files: `HomeRefreshPipeline.swift`, `HomeIngestionExecutor.swift`, `HomeSnapshot.swift`,
+`HomeSnapshotStore.swift`, `HomeRefreshPipelineTests.swift`.
+
+### TV-07: Previews And Tests
+
+Add durable validation for the target state matrix: no cache, cached refreshing, stale, degraded, unavailable, and
+large Dynamic Type/color-scheme variants.
+
+Recommended model: `gpt-5.4-mini / medium`.
+
+Mini-sized chunks:
+
+1. Add transition mapping unit tests for the final Today state matrix.
+2. Add Summary/Today preview fixtures for no-cache, cached-refreshing, stale/degraded, unavailable, light/dark, and
+   Large Dynamic Type.
+3. Add one smoke UI test only if unit tests and previews cannot cover the scenario cleanly.
+4. Record validation results in the progress ledger.
+
+Likely files: `HomeViewLoadingOverlayStateTests.swift`, `HomeRefreshPipelineTests.swift`, `SummaryView.swift`, any new
+Today display-model test file.
+
+## Validation Expectations
+
+At minimum:
+
+- Run focused unit tests when derived state or transition mapping changes.
+- Build the app target when production Swift changes.
+- Inspect relevant previews or Simulator states when SwiftUI layout, copy, or motion changes.
+- Inspect `.xcresult` on test failure.
+- Update `docs/plans/today-state-flow-progress.md` before finishing.
+
+Preferred build command:
+
+```sh
+xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build
+```
+
+Use focused `-only-testing:` filters for issue-specific tests.
+
+## Scenario Matrix
+
+Every implementation pass should preserve or improve these scenarios:
+
+| Scenario | Expected behavior |
+|---|---|
+| First launch with no cache | Show calm resolving surface only because no meaningful content exists. |
+| Launch with valid cache | Show cached content immediately; begin refresh quietly. |
+| Launch with stale cache | Show stale/cached content with subtle freshness treatment; do not hide content. |
+| Refresh succeeds with cache | Keep content in place; update changed values intentionally. |
+| Partial refresh failure with cache | Keep cached content; show degraded/freshness treatment only where useful. |
+| Full refresh failure with no cache | Show true unavailable/resolving failure state calmly. |
+| Watch/risk data changes visible | Update affected values without animating the whole stack. |
+| Atmospheric values update visible | Keep instrumentation stable; update changed measurements. |
+| Local Alerts update visible | Avoid loading-to-empty-to-alerts churn; show new alerts promptly. |
+| App returns foreground | Cached content remains first paint; refresh indicator is subtle. |
+| Tab switch away/back | Do not restart visual resolving theater for existing content. |
+| Light/dark/large Dynamic Type | No clipping, overlap, or accidental hierarchy shifts. |
+
+## Progress Handoff Requirement
+
+Before finishing any issue, update:
+
+- `docs/plans/today-state-flow-progress.md`
+
+Record:
+
+- issue status
+- files changed
+- behavior intentionally preserved
+- validation run
+- screenshots/previews inspected, if any
+- deferred work
+- risk notes for the next issue
+
+The next agent should be able to resume without psychic powers. We keep those off by default for battery life.

--- a/docs/plans/today-state-flow-runbook.md
+++ b/docs/plans/today-state-flow-runbook.md
@@ -165,6 +165,9 @@ This issue set is intentionally scoped so `gpt-5.4-mini` can execute it in seque
 - Do not escalate scope just because a thread can see a tempting adjacent fix. Split the work at the issue boundary.
 - Stop and re-plan if a chunk starts changing provider cadence, serializing refresh work, redesigning card layout, or
   rewriting broad `HomeRefreshPipeline` behavior.
+- Use the Local Alerts follow-up issues (#256 through #259) for alert-specific provenance, refresh treatment,
+  `ActiveAlertSummaryView` transition behavior, and alert-specific validation. Do not reopen broad Today issues for
+  those narrower cleanup passes.
 
 ## Ordered Work Items
 
@@ -178,6 +181,10 @@ This issue set is intentionally scoped so `gpt-5.4-mini` can execute it in seque
 | 5 | TV-05 | [#253](https://github.com/justinrooks/project-arcus/issues/253) | Tighten Today animation and transition scope during refresh | `gpt-5.4-mini / medium` | P1 | S/M | TV-01, TV-02, TV-04 |
 | 6 | TV-06 | [#254](https://github.com/justinrooks/project-arcus/issues/254) | Stabilize Today snapshot application and display-model updates during partial data arrival | `gpt-5.4-mini / high` | P1 | M | TV-01 |
 | 7 | TV-07 | [#255](https://github.com/justinrooks/project-arcus/issues/255) | Add Today state-flow previews and transition mapping tests | `gpt-5.4-mini / medium` | P2/P3 | M | TV-01 through TV-06 |
+| 8 | LA-01 | [#256](https://github.com/justinrooks/project-arcus/issues/256) | Define Local Alerts display state with cache provenance | `gpt-5.4-mini / high` | P1 | M | TV-01, TV-02, TV-06 |
+| 9 | LA-02 | [#257](https://github.com/justinrooks/project-arcus/issues/257) | Make Local Alerts refresh treatment calm and non-duplicative | `gpt-5.4-mini / medium` | P1 | S/M | TV-04, LA-01 |
+| 10 | LA-03 | [#258](https://github.com/justinrooks/project-arcus/issues/258) | Stabilize ActiveAlertSummaryView transitions and height behavior | `gpt-5.4-mini / high` | P1 | M | TV-05, LA-01, LA-02 |
+| 11 | LA-04 | [#259](https://github.com/justinrooks/project-arcus/issues/259) | Add Local Alerts state-flow previews and tests | `gpt-5.4-mini / medium` | P2/P3 | M | LA-01 through LA-03 |
 
 ## Work Item Contracts
 
@@ -298,6 +305,75 @@ Mini-sized chunks:
 
 Likely files: `HomeViewLoadingOverlayStateTests.swift`, `HomeRefreshPipelineTests.swift`, `SummaryView.swift`, any new
 Today display-model test file.
+
+### LA-01: Local Alerts Display State With Cache Provenance
+
+Introduce a small alert-section display state that distinguishes unknown/no-cache, known empty, populated,
+stale/degraded with cached content, no local context, and true unavailable.
+
+Recommended model: `gpt-5.4-mini / high`.
+
+Mini-sized chunks:
+
+1. Add mapping tests for no-cache resolving, known empty cache, populated cache, cached refreshing, offline
+   stale/degraded, and location unavailable.
+2. Introduce the smallest Local Alerts display-state type needed for those tests.
+3. Wire `SummaryView` to derive Local Alerts presentation from that display state while preserving existing visuals.
+4. Run focused Local Alerts mapping tests and app build.
+
+Likely files: `HomeView.swift`, `SummaryView.swift`, `HomeProjection.swift`, `HomeViewLoadingOverlayStateTests.swift`.
+
+### LA-02: Local Alerts Refresh Treatment
+
+Keep Local Alerts visually calm during ordinary cached refresh. Suppress alert-card resolving/dimming and redundant
+status copy when useful cached or known-empty alert state exists.
+
+Recommended model: `gpt-5.4-mini / medium`.
+
+Mini-sized chunks:
+
+1. Test Local Alerts refresh treatment for cached populated, known empty, no-cache resolving, offline, and degraded
+   states.
+2. Replace or adjust `appliesLocalAlertsResolving` with display-state-derived policy.
+3. Suppress card-level resolving/dimming for ordinary cached-refreshing Local Alerts states.
+4. Keep first-load/no-cache feedback available where no useful alert state exists.
+
+Likely files: `SummaryView.swift`, `SummaryResolving.swift`, `ActiveAlertSummaryView.swift`,
+`HomeViewLoadingOverlayStateTests.swift`.
+
+### LA-03: Active Alert Transitions And Height
+
+Make `ActiveAlertSummaryView` render the parent Local Alerts display state without reintroducing local branch churn.
+Keep interaction state local; keep business/display state owned by the parent boundary.
+
+Recommended model: `gpt-5.4-mini / high`.
+
+Mini-sized chunks:
+
+1. Add tests for alert transition policy across cached-refreshing populated, cached-refreshing known-empty, no-cache
+   resolving, and genuine alerts-to-empty transitions.
+2. Replace or constrain local `ContentState` derivation so parent Local Alerts display state is authoritative.
+3. Suppress routine refresh animation/height changes while preserving meaningful alerts-to-empty smoothing.
+4. Verify `Task.sleep` height reset remains main-actor, cancelable, and not triggered by routine cached-refreshing.
+
+Likely files: `ActiveAlertSummaryView.swift`, `SummaryView.swift`, `HomeViewLoadingOverlayStateTests.swift`.
+
+### LA-04: Local Alerts Previews And Tests
+
+Add durable section-specific validation for the Local Alerts state matrix after LA-01 through LA-03 land.
+
+Recommended model: `gpt-5.4-mini / medium`.
+
+Mini-sized chunks:
+
+1. Add unit tests for no-cache resolving, known empty, populated, cached-refreshing empty, cached-refreshing populated,
+   offline cached, degraded cached, location unavailable, and true unavailable.
+2. Add tests for refresh-treatment policy and transition policy where practical.
+3. Add preview fixtures for populated alerts, known empty, no-cache resolving, cached-refreshing populated,
+   cached-refreshing known-empty, offline cached, degraded cached, light/dark, and Large Dynamic Type.
+4. Record validation results in the progress ledger.
+
+Likely files: `HomeViewLoadingOverlayStateTests.swift`, `SummaryView.swift`, `ActiveAlertSummaryView.swift`.
 
 ## Validation Expectations
 


### PR DESCRIPTION
# Summary
This branch completes the Today state-flow work by making cached-first rendering explicit, keeping useful content visible during refresh, and adding deterministic validation for the composed Today surface. It also carries the Local Alerts follow-up work needed to keep alert presentation calm, stable, and provenance-aware.

# What Changed
- Introduced and wired the canonical `TodayContentState` boundary for Today-level rendering decisions.
- Kept cached Today content visible during refresh, including visible-weather retention and coherent snapshot application.
- Consolidated routine update cues and tightened motion/transition scope so cached refreshes stay calm.
- Added Local Alerts display-state provenance, calmer refresh treatment, and card height/transition stabilization.
- Expanded Today/Summary and Local Alerts tests plus previews to cover cached, stale, degraded, unavailable, partial, light, dark, and Large Dynamic Type states.
- Updated the Today state-flow runbook and progress ledger with the implemented validation and handoff notes.

# User Impact
Today now opens with cached content immediately when available, keeps that content in place during refresh, and avoids the loading-flash theater that used to leak through the page. Local Alerts also behaves more consistently during refresh and state transitions, so the landing surface feels calmer and less jittery.

# Testing
- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iPhone Simulator,name=iPhone 17" test -only-testing:SkyAwareTests/HomeViewLoadingOverlayStateTests -only-testing:SkyAwareTests/HomeRefreshPipelineTests`
- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iPhone Simulator,name=iPhone 17" build`

# Notes
- No live WeatherKit, NWS, SPC, or Arcus feeds were introduced.
- The branch includes the Local Alerts follow-up work that complements the Today surface validation.