### PR TITLE
Precompute map warning legend data and stabilize location timing

### DIFF
--- a/Sources/Features/Map/MapAccessibilitySupport.swift
+++ b/Sources/Features/Map/MapAccessibilitySupport.swift
@@ -56,7 +56,7 @@ struct MapAccessibilitySummary: Equatable {
             return "Active warnings overlay hidden."
         }
 
-        let warningItems = WarningLegendItem.rendered(from: scene.canvasState.overlays)
+        let warningItems = scene.warningLegendItems
         guard warningItems.isEmpty == false else {
             return "Active warnings overlay on. No active warning areas are displayed."
         }

--- a/Sources/Features/Map/MapFeatureModel.swift
+++ b/Sources/Features/Map/MapFeatureModel.swift
@@ -331,6 +331,7 @@ final class MapFeatureModel {
 struct MapLayerScene {
     let canvasState: MapCanvasState
     let legendState: MapLegendState
+    let warningLegendItems: [WarningLegendItem]
 
     static func placeholder(
         for layer: MapLayer,
@@ -342,7 +343,8 @@ struct MapLayerScene {
                 overlayRevision: 0,
                 initialCenterCoordinate: initialCenterCoordinate
             ),
-            legendState: .loading(for: layer)
+            legendState: .loading(for: layer),
+            warningLegendItems: []
         )
     }
 
@@ -350,14 +352,16 @@ struct MapLayerScene {
         guard canvasState.initialCenterCoordinate == nil else { return self }
         return MapLayerScene(
             canvasState: canvasState.withInitialCenterCoordinate(coordinate),
-            legendState: legendState
+            legendState: legendState,
+            warningLegendItems: warningLegendItems
         )
     }
 
     func withPresentationState(_ presentationState: MapLegendPresentationState) -> MapLayerScene {
         MapLayerScene(
             canvasState: canvasState,
-            legendState: legendState.withPresentationState(presentationState)
+            legendState: legendState.withPresentationState(presentationState),
+            warningLegendItems: warningLegendItems
         )
     }
 }
@@ -675,7 +679,8 @@ private enum MapSceneMaterializer {
                 overlayRevision: overlayRevision(for: overlays),
                 initialCenterCoordinate: initialCenterCoordinate
             ),
-            legendState: plan.legendState
+            legendState: plan.legendState,
+            warningLegendItems: WarningLegendItem.rendered(from: overlays)
         )
     }
 

--- a/Sources/Features/Map/MapScreenView.swift
+++ b/Sources/Features/Map/MapScreenView.swift
@@ -140,7 +140,7 @@ private struct MapScreenContent: View {
     }
 
     private var warningLegendItems: [WarningLegendItem] {
-        WarningLegendItem.rendered(from: scene.canvasState.overlays)
+        scene.warningLegendItems
     }
 
     @ViewBuilder
@@ -309,7 +309,8 @@ private struct MapScreenContentPreview: View {
                     overlayRevision: warningOverlays.count,
                     initialCenterCoordinate: nil
                 ),
-                legendState: legendState
+                legendState: legendState,
+                warningLegendItems: WarningLegendItem.rendered(from: warningOverlays)
             ),
             locationCoordinate: CLLocationCoordinate2D(latitude: 39.75, longitude: -104.44)
         )

--- a/Sources/Features/Summary/PrimaryAwarenessPanel.swift
+++ b/Sources/Features/Summary/PrimaryAwarenessPanel.swift
@@ -16,11 +16,15 @@ enum SummaryAwarenessDestination: Equatable, Sendable {
     var accessibilityHint: String? {
         switch self {
         case .alerts:
-            "Opens the alert center."
+            return "Opens the alert center."
         case .map(let layer):
-            "Opens the \(layer.title.lowercased()) map."
+            if layer == .fire {
+                return "Opens the fire risk map."
+            }
+
+            return "Opens the \(layer.title.lowercased()) map."
         case .none:
-            nil
+            return nil
         }
     }
 }

--- a/Sources/Infrastructure/Location/LocationContextResolver.swift
+++ b/Sources/Infrastructure/Location/LocationContextResolver.swift
@@ -212,13 +212,13 @@ actor LocationContextResolver: LocationContextResolving {
     }
 
     private func waitForAuthorizationResolution(timeout: Double) async throws -> CLAuthorizationStatus {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        while ContinuousClock.now < deadline {
             let status = await authorizationStatusProvider()
             if status != .notDetermined {
                 return status
             }
-            try? await Task.sleep(for: .milliseconds(100))
+            try? await Task.sleep(for: .milliseconds(50))
         }
 
         logger.notice("Timed out waiting for location authorization to resolve")

--- a/Tests/SkyAware_All_Tests.xctestplan
+++ b/Tests/SkyAware_All_Tests.xctestplan
@@ -14,13 +14,6 @@
   "testTargets" : [
     {
       "parallelizable" : true,
-      "skippedTests" : {
-        "suites" : [
-          {
-            "name" : "LocationManagerTests"
-          }
-        ]
-      },
       "target" : {
         "containerPath" : "container:SkyAware.xcodeproj",
         "identifier" : "D095EFB12E16F56A0074F867",

--- a/Tests/SkyAware_Tests.xctestplan
+++ b/Tests/SkyAware_Tests.xctestplan
@@ -14,13 +14,6 @@
   "testTargets" : [
     {
       "parallelizable" : true,
-      "skippedTests" : {
-        "suites" : [
-          {
-            "name" : "LocationManagerTests"
-          }
-        ]
-      },
       "target" : {
         "containerPath" : "container:SkyAware.xcodeproj",
         "identifier" : "D095EFB12E16F56A0074F867",

--- a/Tests/UITests/SkyAwareUITests.swift
+++ b/Tests/UITests/SkyAwareUITests.swift
@@ -15,12 +15,8 @@ final class SkyAwareUITests: XCTestCase {
     private let reliabilitySuppressedDayKey = "fb016.locationReliability.lastSuppressedQualifyingDay"
 
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+        resetSharedLaunchState()
     }
 
     override func tearDownWithError() throws {
@@ -885,6 +881,16 @@ final class SkyAwareUITests: XCTestCase {
         defaults.removeObject(forKey: reliabilityLastCountedDayKey)
         defaults.removeObject(forKey: reliabilitySuppressedDayKey)
         defaults.synchronize()
+    }
+
+    private func resetSharedLaunchState() {
+        guard let defaults = UserDefaults(suiteName: sharedDefaultsSuiteName) else { return }
+        defaults.removePersistentDomain(forName: sharedDefaultsSuiteName)
+        defaults.synchronize()
+        UserDefaults.standard.removeObject(forKey: "onboardingComplete")
+        UserDefaults.standard.removeObject(forKey: "disclaimerAcceptedVersion")
+        UserDefaults.standard.synchronize()
+        resetReliabilityLedgerDefaults()
     }
 
     private func configureLaunchDefaults(onboardingComplete: Bool, disclaimerAcceptedVersion: Int) {

--- a/Tests/UnitTests/ConvectiveOutlookRepoTests.swift
+++ b/Tests/UnitTests/ConvectiveOutlookRepoTests.swift
@@ -263,9 +263,9 @@ struct ConvectiveOutlookRepoTests {
         try await MainActor.run { try TestStore.reset(ConvectiveOutlook.self, in: container) }
         let ctx = container.mainContext
 
-        let now = Date()
-        let oldDate = Calendar.current.date(byAdding: .day, value: -3, to: now)!
-        let recentDate = Calendar.current.date(byAdding: .day, value: -1, to: now)!
+        let now = utcDate(2026, 6, 15, 12)
+        let oldDate = utcDate(2026, 6, 12, 12)
+        let recentDate = utcDate(2026, 6, 14, 12)
 
         let oldItem = ConvectiveOutlook(title: "Old Day 1 Convective Outlook",
                                         link: URL(string: "https://example.com/old")!,
@@ -295,6 +295,21 @@ struct ConvectiveOutlookRepoTests {
         let remaining = try await repo.fetchConvectiveOutlooks(for: 1)
         #expect(remaining.count == 1)
         #expect(remaining[0].title.contains("Recent"))
+    }
+
+    private func utcDate(_ year: Int, _ month: Int, _ day: Int, _ hour: Int, _ minute: Int = 0) -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let components = DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute
+        )
+        return calendar.date(from: components)!
     }
 }
 

--- a/Tests/UnitTests/HomeIngestionCoordinatorTests.swift
+++ b/Tests/UnitTests/HomeIngestionCoordinatorTests.swift
@@ -198,7 +198,7 @@ struct HomeIngestionCoordinatorTests {
             )
         }
 
-        try? await Task.sleep(for: .milliseconds(50))
+        await Task.yield()
         #expect(await executor.startedPlanCount() == 1)
 
         await gate.open()
@@ -243,7 +243,7 @@ struct HomeIngestionCoordinatorTests {
             )
         }
 
-        try? await Task.sleep(for: .milliseconds(50))
+        await Task.yield()
         #expect(await executor.startedPlanCount() == 1)
 
         await gate.open()

--- a/Tests/UnitTests/HomeRefreshPipelineTests.swift
+++ b/Tests/UnitTests/HomeRefreshPipelineTests.swift
@@ -92,7 +92,7 @@ struct HomeRefreshPipelineTests {
             environment: environment
         )
 
-        try? await Task.sleep(for: .milliseconds(50))
+        await Task.yield()
         #expect(await coordinator.requestCount() == 1)
 
         await gate.open()

--- a/Tests/UnitTests/LocationManagerTests.swift
+++ b/Tests/UnitTests/LocationManagerTests.swift
@@ -36,16 +36,35 @@ struct LocationManagerTests {
     }
 
     @MainActor
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        interval: Duration = .milliseconds(10),
+        _ condition: @escaping @MainActor () -> Bool
+    ) async -> Bool {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if condition() {
+                return true
+            }
+            try? await Task.sleep(for: interval)
+        }
+        return condition()
+    }
+
+    @MainActor
     @Test("authorization callback updates cached authStatus")
     func locationManagerDidChangeAuthorization_updatesAuthStatus() async throws {
-        let sut = LocationManager(onUpdate: { _ in })
+        let manager = StubAuthorizationManager(status: .notDetermined)
+        let sut = LocationManager(manager: manager, onUpdate: { _ in })
         #expect(sut.authStatus == .notDetermined)
 
-        let manager = StubAuthorizationManager(status: .authorizedAlways)
+        manager.stubStatus = .authorizedAlways
         sut.locationManagerDidChangeAuthorization(manager)
-        await Task.yield()
 
-        #expect(sut.authStatus == .authorizedAlways)
+        let updated = await waitUntil {
+            sut.authStatus == .authorizedAlways
+        }
+        #expect(updated == true)
     }
 
     @MainActor
@@ -57,9 +76,11 @@ struct LocationManagerTests {
 
         manager.stubAccuracy = .reducedAccuracy
         sut.locationManagerDidChangeAuthorization(manager)
-        await Task.yield()
 
-        #expect(sut.accuracyAuthorization == .reducedAccuracy)
+        let updated = await waitUntil {
+            sut.accuracyAuthorization == .reducedAccuracy
+        }
+        #expect(updated == true)
     }
 
     @MainActor

--- a/Tests/UnitTests/LocationManagerTests.swift
+++ b/Tests/UnitTests/LocationManagerTests.swift
@@ -43,7 +43,7 @@ struct LocationManagerTests {
 
         let manager = StubAuthorizationManager(status: .authorizedAlways)
         sut.locationManagerDidChangeAuthorization(manager)
-        try await Task.sleep(for: .milliseconds(20))
+        await Task.yield()
 
         #expect(sut.authStatus == .authorizedAlways)
     }
@@ -57,7 +57,7 @@ struct LocationManagerTests {
 
         manager.stubAccuracy = .reducedAccuracy
         sut.locationManagerDidChangeAuthorization(manager)
-        try await Task.sleep(for: .milliseconds(20))
+        await Task.yield()
 
         #expect(sut.accuracyAuthorization == .reducedAccuracy)
     }

--- a/Tests/UnitTests/LocationProviderTests.swift
+++ b/Tests/UnitTests/LocationProviderTests.swift
@@ -1704,7 +1704,14 @@ struct LocationProviderTests {
         let snap = try #require(next)
         #expect(snap.placemarkSummary == "Denver, CO")
 
-        try await Task.sleep(for: .milliseconds(20))
+        let afterReady = await waitUntilLocationSnapshot(timeout: .seconds(1)) {
+            if let snapshot = await provider.snapshot() {
+                snapshot.placemarkSummary == "Denver, CO"
+            } else {
+                false
+            }
+        }
+        #expect(afterReady == true)
         let after = await provider.snapshot()
         #expect(after?.placemarkSummary == "Denver, CO")
     }
@@ -1715,7 +1722,14 @@ struct LocationProviderTests {
         let t0 = Date()
         await provider.send(update: makeUpdate(lat: 40.0, lon: -105.0, timestamp: t0, accuracy: 50))
 
-        try await Task.sleep(for: .milliseconds(20))
+        let snapshotReady = await waitUntilLocationSnapshot(timeout: .seconds(1)) {
+            if let snapshot = await provider.snapshot() {
+                snapshot.placemarkSummary == nil
+            } else {
+                false
+            }
+        }
+        #expect(snapshotReady == true)
         let snap = await provider.snapshot()
         #expect(snap?.placemarkSummary == nil)
     }
@@ -1754,22 +1768,52 @@ struct LocationProviderTests {
         let t1 = t0.addingTimeInterval(70)
 
         await provider.send(update: makeUpdate(lat: 39.0, lon: -104.0, timestamp: t0, accuracy: 50))
-        try await Task.sleep(for: .milliseconds(10))
 
         await provider.send(update: makeUpdate(lat: 39.0, lon: -104.0, timestamp: t1, accuracy: 50))
-        try await Task.sleep(for: .milliseconds(20))
+
+        let afterSecondReady = await waitUntilLocationSnapshot(timeout: .seconds(1)) {
+            if let snapshot = await provider.snapshot() {
+                snapshot.timestamp == t1 && snapshot.placemarkSummary == "Latest City"
+            } else {
+                false
+            }
+        }
+        #expect(afterSecondReady == true)
 
         let afterSecond = try #require(await provider.snapshot())
         #expect(afterSecond.timestamp == t1)
         #expect(afterSecond.placemarkSummary == "Latest City")
 
         await geocoder.resolveFirst(with: "Old City")
-        try await Task.sleep(for: .milliseconds(20))
+
+        let finalReady = await waitUntilLocationSnapshot(timeout: .seconds(1)) {
+            if let snapshot = await provider.snapshot() {
+                snapshot.timestamp == t1 && snapshot.placemarkSummary == "Latest City"
+            } else {
+                false
+            }
+        }
+        #expect(finalReady == true)
 
         let final = try #require(await provider.snapshot())
         #expect(final.timestamp == t1)
         #expect(final.placemarkSummary == "Latest City")
     }
+}
+
+private func waitUntilLocationSnapshot(
+    timeout: Duration = .seconds(1),
+    interval: Duration = .milliseconds(10),
+    _ condition: @escaping @Sendable () async -> Bool
+) async -> Bool {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+        if await condition() {
+            return true
+        }
+        try? await Task.sleep(for: interval)
+    }
+    return await condition()
 }
 
 @Suite("LocationContextResolver", .serialized)
@@ -1796,6 +1840,18 @@ struct LocationContextResolverTests {
         }
     }
 
+    private actor AuthorizationRequestState {
+        private var requested = false
+
+        func markRequested() {
+            requested = true
+        }
+
+        func wasRequested() -> Bool {
+            requested
+        }
+    }
+
     private struct TestGeocoder: LocationGeocoding {
         let result: Result<String, TestError>
 
@@ -1818,6 +1874,21 @@ struct LocationContextResolverTests {
             }
             return h3Cell
         }
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        interval: Duration = .milliseconds(10),
+        _ condition: @escaping @Sendable () async -> Bool
+    ) async -> Bool {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if await condition() {
+                return true
+            }
+            try? await Task.sleep(for: interval)
+        }
+        return await condition()
     }
 
     private actor RefreshRequestTracker {
@@ -1896,6 +1967,7 @@ struct LocationContextResolverTests {
     @Test("waits for authorization result before preparing a ready context")
     func waitsForAuthorizationResult() async throws {
         let authorizationState = AuthorizationState(status: .notDetermined)
+        let requestState = AuthorizationRequestState()
         let locationProvider = LocationProvider(
             geocoder: TestGeocoder(result: .success("Norman, OK")),
             hasher: TestHasher(h3Cell: sampleH3Cell)
@@ -1914,9 +1986,7 @@ struct LocationContextResolverTests {
             gridPointProvider: gridPointProvider,
             authorizationStatusProvider: { await authorizationState.current() },
             authorizationRequester: { _ in
-                Task {
-                    await authorizationState.set(.authorizedWhenInUse)
-                }
+                await requestState.markRequested()
             },
             refreshCurrentLocation: { _ in
                 await locationProvider.send(update: .init(
@@ -1929,14 +1999,25 @@ struct LocationContextResolverTests {
             }
         )
 
-        let context = try await resolver.prepareCurrentContext(
-            requiresFreshLocation: true,
-            showsAuthorizationPrompt: true,
-            authorizationTimeout: 3,
-            locationTimeout: 2,
-            maximumAcceptedLocationAge: 300,
-            placemarkTimeout: 0.1
-        )
+        let contextTask = Task {
+            try await resolver.prepareCurrentContext(
+                requiresFreshLocation: true,
+                showsAuthorizationPrompt: true,
+                authorizationTimeout: 3,
+                locationTimeout: 2,
+                maximumAcceptedLocationAge: 300,
+                placemarkTimeout: 0.1
+            )
+        }
+
+        let authorizationRequested = await waitUntil(timeout: .seconds(1)) {
+            await requestState.wasRequested()
+        }
+        #expect(authorizationRequested)
+
+        await authorizationState.set(.authorizedWhenInUse)
+
+        let context = try await contextTask.value
 
         #expect(context.h3Cell == sampleH3Cell)
         #expect(context.grid.countyCode == "OKC109")

--- a/Tests/UnitTests/MapFeatureModelTests.swift
+++ b/Tests/UnitTests/MapFeatureModelTests.swift
@@ -1371,7 +1371,7 @@ struct MapFeatureModelTests {
     }
 
     private func warningLegendItems(in scene: MapLayerScene) -> [WarningLegendItem] {
-        WarningLegendItem.rendered(from: scene.canvasState.overlays)
+        scene.warningLegendItems
     }
 
     private func singleWarningPolygonCoordinates(in scene: MapLayerScene) -> [CLLocationCoordinate2D]? {

--- a/Tests/UnitTests/RemoteNotificationRegistrarTests.swift
+++ b/Tests/UnitTests/RemoteNotificationRegistrarTests.swift
@@ -101,7 +101,7 @@ struct RemoteNotificationRegistrarTests {
             await sut.waitForDeviceToken(timeout: .seconds(1))
         }
 
-        try await Task.sleep(for: .milliseconds(50))
+        await Task.yield()
         sut.storeDeviceToken(Data([0x00, 0xAB, 0x10]))
 
         let token = await tokenTask.value

--- a/docs/audits/weekly-performance-audit.md
+++ b/docs/audits/weekly-performance-audit.md
@@ -36,3 +36,24 @@
 - implementation notes:
   - Moved Today scroll-condense state into a dedicated `TodayTabView` subtree in `HomeView`.
   - Kept the visible behavior intact while preventing scroll progress from invalidating the full five-tab shell.
+
+## 2026-06-14
+- workflow reviewed: Layered Risk Map
+- files inspected:
+  - Sources/Features/Map/MapScreenView.swift
+  - Sources/Features/Map/MapAccessibilitySupport.swift
+  - Sources/Features/Map/MapLegendView.swift
+  - Sources/Features/Map/MapFeatureModel.swift
+  - Sources/Features/Map/MapCanvasView.swift
+  - Sources/Features/Map/MapPolygonMapper.swift
+  - Sources/Features/Map/MapCoordinator.swift
+  - Sources/Features/Map/RiskPolygonRenderer.swift
+- top finding: `MapScreenContent` recomputes warning legend items and accessibility summary data from the same overlay array multiple times per render, which adds avoidable overlay parsing and dedup work to the map tab's hottest SwiftUI body.
+- best next fix: hoist `WarningLegendItem.rendered(from:)` and the derived accessibility summary inputs into a single precomputed value per `scene` update, then thread that value through the legend sheet and summary element so the overlay array is walked once instead of several times.
+- measurement gap: profile `MapScreenContent` body recomputation count and overlay-derived item generation while toggling warning geometry and changing layers to confirm the duplicate work is visible in Instruments.
+- implementation recommended: yes
+- implementation status: completed on 2026-06-17
+- implementation notes:
+  - Added `warningLegendItems` to `MapLayerScene` and materialized it once per scene update.
+  - Swapped `MapScreenContent` and `MapAccessibilitySummary` to the precomputed scene data.
+  - Ran targeted `MapFeatureModelTests` and `MapLegendAccessibilityTests` in the iPhone 17 simulator destination; both passed.


### PR DESCRIPTION
# Summary
This branch reduces repeated overlay-derived work in the map screen by precomputing warning legend items once per scene and reusing them in the map UI and accessibility summary. It also tightens the location authorization wait loop, replaces brittle sleep-based test synchronization with polling helpers, and updates the audit notes and test plans to match the new behavior.

# What Changed
- Added `warningLegendItems` to `MapLayerScene` so warning legend rendering happens once per scene update instead of on every consumer read.
- Updated `MapScreenView` and `MapAccessibilitySummary` to reuse the precomputed warning legend data.
- Refined the fire map accessibility hint to say "fire risk map" instead of the generic layer title.
- Switched location authorization polling to `ContinuousClock` with a shorter retry interval.
- Reworked location-related tests to wait on observable state instead of relying on fixed sleeps, and made date-sensitive tests use deterministic UTC dates.
- Removed the temporary `LocationManagerTests` skip from the shared xctest plans.
- Reset shared UI-test launch state before each run to avoid cross-test contamination.
- Updated the weekly performance audit notes with the map performance finding and validation outcome.

# User Impact
Users should see less redundant work in the map flow, and accessibility text for the fire map is more specific. The location authorization path should also resolve more consistently under test and in timing-sensitive flows.

# Testing
- `xcodebuild -project /Users/justin/Code/project-arcus/SkyAware.xcodeproj -scheme SkyAware -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:SkyAwareTests/MapFeatureModelTests -only-testing:SkyAwareTests/MapLegendAccessibilityTests test` passed.
- No full test suite run was performed.