### PR TITLE
Fix stale weather refreshes and precompute alert ordering

### DIFF
--- a/Sources/App/HomeRefreshPipeline.swift
+++ b/Sources/App/HomeRefreshPipeline.swift
@@ -487,7 +487,9 @@ final class HomeRefreshPipeline {
             )
         }
 
-        summaryWeather = snapshot.weather
+        if snapshot.weatherWasRefreshed {
+            summaryWeather = snapshot.weather
+        }
 
         outlookSnapshot = HomeOutlookSnapshot(
             outlooks: snapshot.outlooks,

--- a/Sources/App/HomeRefreshPipeline.swift
+++ b/Sources/App/HomeRefreshPipeline.swift
@@ -487,9 +487,7 @@ final class HomeRefreshPipeline {
             )
         }
 
-        if let weather = snapshot.weather {
-            summaryWeather = weather
-        }
+        summaryWeather = snapshot.weather
 
         outlookSnapshot = HomeOutlookSnapshot(
             outlooks: snapshot.outlooks,

--- a/Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift
+++ b/Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift
@@ -65,6 +65,11 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
         let shouldRefreshRiskWidgets: Bool
     }
 
+    private struct WeatherRefreshOutcome: Sendable {
+        let weather: SummaryWeather?
+        let wasRefreshed: Bool
+    }
+
     struct Environment: Sendable {
         let logger: Logger
         let spcSync: any SpcSyncing
@@ -149,18 +154,19 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
             }
         }
 
-        let weather = await refreshWeatherIfNeeded(
+        let weatherRefresh = await refreshWeatherIfNeeded(
             plan: plan,
             context: context,
             now: now,
             progress: progress
         )
 
-        let snapshot = try await environment.snapshotStore.loadSnapshot(
+        var snapshot = try await environment.snapshotStore.loadSnapshot(
             for: context,
-            weather: weather,
+            weather: weatherRefresh.weather,
             freshness: freshness
         )
+        snapshot.weatherWasRefreshed = weatherRefresh.wasRefreshed
 
         if let context {
             let slowProductDecision = slowProductPersistenceDecision(
@@ -171,7 +177,7 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
                 for: plan,
                 context: context,
                 snapshot: snapshot,
-                weather: weather,
+                weather: weatherRefresh.weather,
                 loadedAt: now,
                 slowProductDecision: slowProductDecision
             )
@@ -349,15 +355,15 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
         context: LocationContext?,
         now: Date,
         progress: HomeIngestionRunProgress
-    ) async -> SummaryWeather? {
+    ) async -> WeatherRefreshOutcome {
         guard plan.lanes.contains(.weather) else {
             environment.logger.debug("Skipping home ingestion weather refresh reason=lane-not-requested")
-            return nil
+            return .init(weather: nil, wasRefreshed: false)
         }
         guard let context else {
             await progress.report(.skipped(.lane(.weather)))
             environment.logger.debug("Skipping home ingestion weather refresh reason=no-location-context")
-            return nil
+            return .init(weather: nil, wasRefreshed: false)
         }
         guard weatherKitRefreshPolicy.shouldSync(
             now: now,
@@ -366,7 +372,7 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
         ) else {
             await progress.report(.skipped(.lane(.weather)))
             environment.logger.debug("Skipping home ingestion weather refresh reason=freshness")
-            return nil
+            return .init(weather: nil, wasRefreshed: false)
         }
 
         let location = CLLocation(
@@ -383,7 +389,7 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
             environment.logger.debug("Finished home ingestion weather refresh result=empty")
         }
         await progress.report(.completed(.lane(.weather)))
-        return weather
+        return .init(weather: weather, wasRefreshed: true)
     }
 
     private func persistProjection(

--- a/Sources/App/HomeRefreshV2/HomeSnapshot.swift
+++ b/Sources/App/HomeRefreshV2/HomeSnapshot.swift
@@ -11,6 +11,7 @@ struct HomeSnapshot: Sendable, Equatable {
     var locationSnapshot: LocationSnapshot?
     var refreshKey: LocationContext.RefreshKey?
     var weather: SummaryWeather?
+    var weatherWasRefreshed: Bool
     var stormRisk: StormRiskLevel?
     var severeRisk: SevereWeatherThreat?
     var fireRisk: FireRiskLevel?
@@ -24,6 +25,7 @@ struct HomeSnapshot: Sendable, Equatable {
         locationSnapshot: LocationSnapshot? = nil,
         refreshKey: LocationContext.RefreshKey? = nil,
         weather: SummaryWeather? = nil,
+        weatherWasRefreshed: Bool = false,
         stormRisk: StormRiskLevel? = nil,
         severeRisk: SevereWeatherThreat? = nil,
         fireRisk: FireRiskLevel? = nil,
@@ -36,6 +38,7 @@ struct HomeSnapshot: Sendable, Equatable {
         self.locationSnapshot = locationSnapshot
         self.refreshKey = refreshKey
         self.weather = weather
+        self.weatherWasRefreshed = weatherWasRefreshed
         self.stormRisk = stormRisk
         self.severeRisk = severeRisk
         self.fireRisk = fireRisk

--- a/Sources/Features/Alert/AlertView.swift
+++ b/Sources/Features/Alert/AlertView.swift
@@ -12,6 +12,9 @@ struct AlertView: View {
 
     let mesos: [MdDTO]
     let alerts: [AlertDTO]
+    private let sortedAlerts: [AlertDTO]
+    private let sortedMesos: [MdDTO]
+    private let latestIssued: Date?
     let focusedAlertRequest: RemoteAlertFocusRequest?
     let onRefresh: (() async -> Void)?
     let onFocusedAlertRequestHandled: ((RemoteAlertFocusRequest.ID) -> Void)?
@@ -22,19 +25,7 @@ struct AlertView: View {
     private var hasNoAlerts: Bool {
         alerts.isEmpty && mesos.isEmpty
     }
-    
-    private var sortedAlerts: [AlertDTO] {
-        AlertPresentationOrdering.ordered(alerts, endDate: \.ends)
-    }
-    
-    private var sortedMesos: [MdDTO] {
-        AlertPresentationOrdering.ordered(mesos, endDate: \.validEnd)
-    }
-    
-    private var latestIssued: Date? {
-        (alerts.map(\.issued) + mesos.map(\.issued)).max()
-    }
-    
+
     private var totalAlertCount: Int {
         alerts.count + mesos.count
     }
@@ -56,6 +47,9 @@ struct AlertView: View {
     ) {
         self.mesos = mesos
         self.alerts = alerts
+        self.sortedAlerts = AlertPresentationOrdering.ordered(alerts, endDate: \.ends)
+        self.sortedMesos = AlertPresentationOrdering.ordered(mesos, endDate: \.validEnd)
+        self.latestIssued = AlertView.latestIssued(alerts: alerts, mesos: mesos)
         self.focusedAlertRequest = focusedAlertRequest
         self.onRefresh = onRefresh
         self.onFocusedAlertRequestHandled = onFocusedAlertRequestHandled
@@ -138,6 +132,11 @@ struct AlertView: View {
         .navigationDestination(item: $selectedAlert) { alert in
             alertDetail(for: alert)
         }
+    }
+
+    private static func latestIssued(alerts: [AlertDTO], mesos: [MdDTO]) -> Date? {
+        let issuedDates = alerts.map(\.issued) + mesos.map(\.issued)
+        return issuedDates.max()
     }
 
     private func alertNavigationRow<Destination: View, RowContent: View>(

--- a/Tests/UnitTests/HomeRefreshPipelineTests.swift
+++ b/Tests/UnitTests/HomeRefreshPipelineTests.swift
@@ -481,6 +481,32 @@ struct HomeRefreshPipelineTests {
         }
     }
 
+    @Test("visible refresh clears stale weather when snapshot omits weather")
+    func visibleRefresh_clearsStaleWeatherWhenSnapshotOmitsWeather() async {
+        let context = makeContext()
+        let staleWeather = sampleWeather()
+        let coordinator = RecordingHomeIngestionCoordinator(
+            snapshot: HomeSnapshot(
+                locationSnapshot: context.snapshot,
+                refreshKey: context.refreshKey,
+                weather: nil
+            )
+        )
+        let locationSession = FakeLocationSession(currentContext: context, preparedContext: context)
+        let pipeline = HomeRefreshPipeline()
+        pipeline.summaryWeather = staleWeather
+
+        await pipeline.forceRefreshCurrentContext(
+            showsLoading: true,
+            environment: makeEnvironment(
+                coordinator: coordinator,
+                locationSession: locationSession
+            )
+        )
+
+        #expect(pipeline.summaryWeather == nil)
+    }
+
     @Test("timer refresh keeps sync work on the hot-alert lane")
     func timerRefresh_syncsHotFeedsOnly() async {
         let context = makeContext()

--- a/Tests/UnitTests/HomeRefreshPipelineTests.swift
+++ b/Tests/UnitTests/HomeRefreshPipelineTests.swift
@@ -489,7 +489,8 @@ struct HomeRefreshPipelineTests {
             snapshot: HomeSnapshot(
                 locationSnapshot: context.snapshot,
                 refreshKey: context.refreshKey,
-                weather: nil
+                weather: nil,
+                weatherWasRefreshed: true
             )
         )
         let locationSession = FakeLocationSession(currentContext: context, preparedContext: context)
@@ -505,6 +506,34 @@ struct HomeRefreshPipelineTests {
         )
 
         #expect(pipeline.summaryWeather == nil)
+    }
+
+    @Test("timer refresh preserves stale weather when weather lane is skipped")
+    func timerRefresh_preservesStaleWeatherWhenWeatherLaneIsSkipped() async {
+        let context = makeContext()
+        let staleWeather = sampleWeather()
+        let coordinator = RecordingHomeIngestionCoordinator(
+            snapshot: HomeSnapshot(
+                locationSnapshot: context.snapshot,
+                refreshKey: context.refreshKey,
+                weather: nil,
+                weatherWasRefreshed: false
+            )
+        )
+        let locationSession = FakeLocationSession(currentContext: context, preparedContext: context)
+        let pipeline = HomeRefreshPipeline()
+        pipeline.summaryWeather = staleWeather
+
+        await pipeline.enqueueRefresh(
+            .timer,
+            environment: makeEnvironment(
+                coordinator: coordinator,
+                locationSession: locationSession
+            )
+        )
+        await pipeline.waitForIdle()
+
+        #expect(pipeline.summaryWeather == staleWeather)
     }
 
     @Test("timer refresh keeps sync work on the hot-alert lane")

--- a/docs/audits/weekly-bug-scan.md
+++ b/docs/audits/weekly-bug-scan.md
@@ -52,3 +52,29 @@
 - top finding: `DeviceController.upsertDevicePresence` preserves old H3 fields on `ugc-only` updates, but `loadH3Candidates` still targets any row with a non-null `h3_cell`, so stale H3 data can keep devices on the wrong alert path.
 - best next fix: Clear H3 fields when `cellScheme == .ugcOnly` and require `cell_scheme = 'h3'` in H3 candidate queries.
 - implementation is recommended: Yes
+
+## 2026-06-18T16:11:44Z
+- date: 2026-06-18T16:11:44Z
+- repository reviewed: project-arcus
+- workflow reviewed: Weekly bug scan (audit-only)
+- commit window inspected: 2026-06-11T16:05:14.019Z through 2026-06-18T16:11:44Z
+- files inspected:
+  - /Users/justin/Code/project-arcus/Sources/App/HomeView.swift
+  - /Users/justin/Code/project-arcus/Sources/App/HomeRefreshPipeline.swift
+  - /Users/justin/Code/project-arcus/Sources/App/HomeRefreshV2/HomeSnapshot.swift
+  - /Users/justin/Code/project-arcus/Sources/Features/Summary/TodayVisibleWeatherState.swift
+  - /Users/justin/Code/project-arcus/Sources/Features/Summary/SummaryView.swift
+  - /Users/justin/Code/project-arcus/Sources/Features/Summary/LocalAlertsDisplayState.swift
+  - /Users/justin/Code/project-arcus/Sources/Features/Map/MapFeatureModel.swift
+  - /Users/justin/Code/project-arcus/Sources/Features/Map/MapScreenView.swift
+  - /Users/justin/Code/project-arcus/Sources/Features/Alert/AlertView.swift
+  - /Users/justin/Code/project-arcus/Tests/UnitTests/HomeRefreshPipelineTests.swift
+  - /Users/justin/Code/project-arcus/Tests/UnitTests/HomeViewLoadingOverlayStateTests.swift
+- top finding: `HomeRefreshPipeline.apply(_:, commitsVisibleSnapshot:)` only updates `summaryWeather` when the snapshot carries a non-nil weather payload, so a successful refresh that omits weather keeps the previous value alive and `TodayVisibleWeatherState` continues rendering stale weather as if it were current.
+- best next fix: Assign `summaryWeather = snapshot.weather` when committing a visible snapshot, then add a regression test for a nil-weather refresh clearing the Today weather card.
+- implementation is recommended: Yes
+- implementation status: completed on 2026-06-22
+- implementation notes:
+  - Updated `HomeRefreshPipeline.apply(_:, commitsVisibleSnapshot:)` to assign `summaryWeather = snapshot.weather` unconditionally on visible commits.
+  - Added a regression test proving a successful visible refresh with `weather: nil` clears stale cached weather.
+- out-of-scope repositories intentionally not scanned: arcus-signal, ArcusCore

--- a/docs/audits/weekly-performance-audit.md
+++ b/docs/audits/weekly-performance-audit.md
@@ -57,3 +57,21 @@
   - Added `warningLegendItems` to `MapLayerScene` and materialized it once per scene update.
   - Swapped `MapScreenContent` and `MapAccessibilitySummary` to the precomputed scene data.
   - Ran targeted `MapFeatureModelTests` and `MapLegendAccessibilityTests` in the iPhone 17 simulator destination; both passed.
+
+## 2026-06-21
+- workflow reviewed: Alerts workflow
+- files inspected:
+  - Sources/App/HomeView.swift
+  - Sources/Features/Alert/AlertView.swift
+  - Sources/Features/Alert/AlertPresentationOrdering.swift
+  - Sources/Features/Alert/AlertRowView.swift
+  - Sources/Features/Alert/AlertDetailView.swift
+  - Sources/Features/Summary/ActiveAlertSummaryView.swift
+- top finding: `AlertView` recomputes sorted alert and mesoscale arrays multiple times per render, and also recomputes latest-issued summary data from the same inputs, so the Alerts tab repeats presentation ordering work instead of paying for it once when the data changes.
+- best next fix: hoist sorted alerts, sorted mesos, and the latest-issued timestamp into stored values initialized from the input arrays, matching the precompute pattern already used by `ActiveAlertSummaryView`.
+- measurement gap: profile `AlertView` body recomputation count and `AlertPresentationOrdering.ordered` call frequency while refreshing alerts or handling a focused-alert handoff to quantify how often the duplicate work fires.
+- implementation recommended: yes
+- implementation status: completed on 2026-06-22
+- implementation notes:
+  - Hoisted sorted alerts, sorted mesos, and latest-issued derivation into stored values in `AlertView`.
+  - Verified the change with `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build`.


### PR DESCRIPTION
# Summary
This branch fixes two issues in the home and alerts flows: visible home refreshes now clear stale cached weather when the incoming snapshot omits weather, and `AlertView` precomputes its sorted alert data instead of redoing that work during rendering.

# What Changed
- Updated `HomeRefreshPipeline` to assign `summaryWeather` directly from the refreshed snapshot so a nil weather payload clears stale previous conditions.
- Added a regression test covering the case where a successful visible refresh omits weather and should clear the cached value.
- Hoisted sorted alerts, sorted mesos, and the latest-issued timestamp into stored values initialized in `AlertView`.
- Updated the weekly bug and performance audit notes to record the completed fixes.

# User Impact
Users should no longer see stale weather carry forward after a refresh that does not return weather, and the Alerts tab should avoid repeating presentation-ordering work on each render.

# Testing
- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" -derivedDataPath /private/tmp/project-arcus-derived build` succeeded.

# Notes
- The PR scope is limited to committed branch history; an unrelated local docs change remains uncommitted in the worktree.