### PR TITLE
Preserve visible weather when WeatherKit refreshes fail

### DIFF
--- a/SkyAware.xcodeproj/project.pbxproj
+++ b/SkyAware.xcodeproj/project.pbxproj
@@ -868,7 +868,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.skyaware.app.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -896,7 +896,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.skyaware.app.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/SkyAware.xcodeproj/project.pbxproj
+++ b/SkyAware.xcodeproj/project.pbxproj
@@ -702,7 +702,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = SkyAware.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 58;
+				CURRENT_PROJECT_VERSION = 80;
 				DEVELOPMENT_TEAM = YVC4WFW94T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -722,7 +722,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.skyaware.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -746,7 +746,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = SkyAware.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 58;
+				CURRENT_PROJECT_VERSION = 80;
 				DEVELOPMENT_TEAM = YVC4WFW94T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -766,7 +766,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.skyaware.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -858,7 +858,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = Config/SkyAwareWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 58;
+				CURRENT_PROJECT_VERSION = 80;
 				DEVELOPMENT_TEAM = YVC4WFW94T;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Config/WidgetExtension-Info.plist";
@@ -886,7 +886,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = Config/SkyAwareWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 58;
+				CURRENT_PROJECT_VERSION = 80;
 				DEVELOPMENT_TEAM = YVC4WFW94T;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Config/WidgetExtension-Info.plist";

--- a/Sources/App/HomeRefreshPipeline.swift
+++ b/Sources/App/HomeRefreshPipeline.swift
@@ -12,7 +12,20 @@ import SwiftUI
 import ArcusCore
 
 protocol HomeWeatherQuerying: Sendable {
-    func currentWeather(for location: CLLocation) async -> SummaryWeather?
+    func currentWeather(for location: CLLocation) async -> HomeWeatherRefreshResult
+}
+
+enum HomeWeatherRefreshResult: Sendable, Equatable {
+    case skipped
+    case success(SummaryWeather?)
+    case failure
+
+    var weather: SummaryWeather? {
+        if case .success(let weather) = self {
+            return weather
+        }
+        return nil
+    }
 }
 
 @MainActor
@@ -487,8 +500,11 @@ final class HomeRefreshPipeline {
             )
         }
 
-        if snapshot.weatherWasRefreshed {
-            summaryWeather = snapshot.weather
+        switch snapshot.weatherRefreshResult {
+        case .success(let weather):
+            summaryWeather = weather
+        case .skipped, .failure:
+            break
         }
 
         outlookSnapshot = HomeOutlookSnapshot(

--- a/Sources/App/HomeRefreshPipeline.swift
+++ b/Sources/App/HomeRefreshPipeline.swift
@@ -486,6 +486,10 @@ final class HomeRefreshPipeline {
             return
         }
 
+        let locationChanged = snapshot.locationSnapshot != nil
+            && lastResolvedLocationScopedRefreshKey != nil
+            && snapshot.refreshKey != lastResolvedLocationScopedRefreshKey
+
         if let locationSnapshot = snapshot.locationSnapshot {
             snap = locationSnapshot
             lastResolvedLocationScopedRefreshKey = snapshot.refreshKey
@@ -504,6 +508,9 @@ final class HomeRefreshPipeline {
         case .success(let weather):
             summaryWeather = weather
         case .skipped, .failure:
+            if locationChanged {
+                summaryWeather = nil
+            }
             break
         }
 

--- a/Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift
+++ b/Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift
@@ -65,11 +65,6 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
         let shouldRefreshRiskWidgets: Bool
     }
 
-    private struct WeatherRefreshOutcome: Sendable {
-        let weather: SummaryWeather?
-        let wasRefreshed: Bool
-    }
-
     struct Environment: Sendable {
         let logger: Logger
         let spcSync: any SpcSyncing
@@ -166,7 +161,7 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
             weather: weatherRefresh.weather,
             freshness: freshness
         )
-        snapshot.weatherWasRefreshed = weatherRefresh.wasRefreshed
+        snapshot.weatherRefreshResult = weatherRefresh
 
         if let context {
             let slowProductDecision = slowProductPersistenceDecision(
@@ -177,7 +172,7 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
                 for: plan,
                 context: context,
                 snapshot: snapshot,
-                weather: weatherRefresh.weather,
+                weatherRefreshResult: weatherRefresh,
                 loadedAt: now,
                 slowProductDecision: slowProductDecision
             )
@@ -355,15 +350,15 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
         context: LocationContext?,
         now: Date,
         progress: HomeIngestionRunProgress
-    ) async -> WeatherRefreshOutcome {
+    ) async -> HomeWeatherRefreshResult {
         guard plan.lanes.contains(.weather) else {
             environment.logger.debug("Skipping home ingestion weather refresh reason=lane-not-requested")
-            return .init(weather: nil, wasRefreshed: false)
+            return .skipped
         }
         guard let context else {
             await progress.report(.skipped(.lane(.weather)))
             environment.logger.debug("Skipping home ingestion weather refresh reason=no-location-context")
-            return .init(weather: nil, wasRefreshed: false)
+            return .skipped
         }
         guard weatherKitRefreshPolicy.shouldSync(
             now: now,
@@ -372,7 +367,7 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
         ) else {
             await progress.report(.skipped(.lane(.weather)))
             environment.logger.debug("Skipping home ingestion weather refresh reason=freshness")
-            return .init(weather: nil, wasRefreshed: false)
+            return .skipped
         }
 
         let location = CLLocation(
@@ -381,34 +376,46 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
         )
         await progress.report(.started(.lane(.weather)))
         environment.logger.info("Running home ingestion weather refresh")
-        let weather = await environment.weatherClient.currentWeather(for: location)
-        if weather != nil {
+        let weatherResult = await environment.weatherClient.currentWeather(for: location)
+        switch weatherResult {
+        case .success(let weather):
             freshness.lastWeatherSyncAt = now
-            environment.logger.debug("Finished home ingestion weather refresh result=success")
-        } else {
-            environment.logger.debug("Finished home ingestion weather refresh result=empty")
+            if weather != nil {
+                environment.logger.debug("Finished home ingestion weather refresh result=success")
+            } else {
+                environment.logger.debug("Finished home ingestion weather refresh result=empty")
+            }
+        case .failure:
+            environment.logger.debug("Finished home ingestion weather refresh result=failure")
+        case .skipped:
+            environment.logger.debug("Finished home ingestion weather refresh result=skipped")
         }
         await progress.report(.completed(.lane(.weather)))
-        return .init(weather: weather, wasRefreshed: true)
+        return weatherResult
     }
 
     private func persistProjection(
         for plan: HomeIngestionPlan,
         context: LocationContext,
         snapshot: HomeSnapshot,
-        weather: SummaryWeather?,
+        weatherRefreshResult: HomeWeatherRefreshResult,
         loadedAt: Date,
         slowProductDecision: SlowProductPersistenceDecision
     ) async {
         guard let projectionStore = environment.projectionStore else { return }
 
         do {
-            if plan.lanes.contains(.weather), let weather {
-                _ = try await projectionStore.updateWeather(
-                    weather,
-                    for: context,
-                    loadedAt: loadedAt
-                )
+            if plan.lanes.contains(.weather) {
+                switch weatherRefreshResult {
+                case .success(let weather):
+                    _ = try await projectionStore.updateWeather(
+                        weather,
+                        for: context,
+                        loadedAt: loadedAt
+                    )
+                case .skipped, .failure:
+                    break
+                }
             }
 
             if slowProductDecision.shouldUpdateProjection {

--- a/Sources/App/HomeRefreshV2/HomeSnapshot.swift
+++ b/Sources/App/HomeRefreshV2/HomeSnapshot.swift
@@ -11,7 +11,7 @@ struct HomeSnapshot: Sendable, Equatable {
     var locationSnapshot: LocationSnapshot?
     var refreshKey: LocationContext.RefreshKey?
     var weather: SummaryWeather?
-    var weatherWasRefreshed: Bool
+    var weatherRefreshResult: HomeWeatherRefreshResult
     var stormRisk: StormRiskLevel?
     var severeRisk: SevereWeatherThreat?
     var fireRisk: FireRiskLevel?
@@ -25,7 +25,7 @@ struct HomeSnapshot: Sendable, Equatable {
         locationSnapshot: LocationSnapshot? = nil,
         refreshKey: LocationContext.RefreshKey? = nil,
         weather: SummaryWeather? = nil,
-        weatherWasRefreshed: Bool = false,
+        weatherRefreshResult: HomeWeatherRefreshResult = .skipped,
         stormRisk: StormRiskLevel? = nil,
         severeRisk: SevereWeatherThreat? = nil,
         fireRisk: FireRiskLevel? = nil,
@@ -38,7 +38,7 @@ struct HomeSnapshot: Sendable, Equatable {
         self.locationSnapshot = locationSnapshot
         self.refreshKey = refreshKey
         self.weather = weather
-        self.weatherWasRefreshed = weatherWasRefreshed
+        self.weatherRefreshResult = weatherRefreshResult
         self.stormRisk = stormRisk
         self.severeRisk = severeRisk
         self.fireRisk = fireRisk

--- a/Sources/Clients/WeatherClient.swift
+++ b/Sources/Clients/WeatherClient.swift
@@ -14,13 +14,13 @@ actor WeatherClient {
     private let logger = Logger.providersWeatherKit
     private let service = WeatherService.shared
 
-    func currentWeather(for location: CLLocation) async -> SummaryWeather? {
+    func currentWeather(for location: CLLocation) async -> HomeWeatherRefreshResult {
         do {
             logger.info("WeatherKit request started mode=\(HTTPExecutionMode.current.logName, privacy: .public)")
             let currentWeather = try await self.service.weather(for: location, including: .current)
             logger.info("WeatherKit request completed result=success")
             
-            return .init(
+            return .success(.init(
                 temperature: currentWeather.temperature,
                 symbolName: currentWeather.symbolName,
                 conditionText: currentWeather.condition.description,
@@ -32,10 +32,10 @@ actor WeatherClient {
                 windDirection: currentWeather.wind.compassDirection.abbreviation,
                 pressure: currentWeather.pressure,
                 pressureTrend: currentWeather.pressureTrend.description
-            )
+            ))
         } catch {
             logger.error("WeatherKit request completed result=failure error=\(error, privacy: .public)")
-            return nil
+            return .failure
         }
     }
     

--- a/Sources/Models/Convective/ConvectiveOutlookDTO.swift
+++ b/Sources/Models/Convective/ConvectiveOutlookDTO.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct ConvectiveOutlookDTO: Sendable, Identifiable, Hashable {
-    let id: UUID               // usually the GUID or derived from it
+    let id: String             // stable feed-backed identity for SwiftUI diffing
     let title: String          // e.g., "Day 1 Convective Outlook"
     let link: URL              // link to full outlook page
     let published: Date        // pubDate
@@ -20,7 +20,7 @@ struct ConvectiveOutlookDTO: Sendable, Identifiable, Hashable {
     let validUntil: Date?
     
     init(title: String, link: URL, published: Date, summary: String, fullText: String, day: Int?, riskLevel: String?, issued: Date?, validUntil: Date?) {
-        self.id = UUID()
+        self.id = link.absoluteString
         self.title = title
         self.link = link
         self.published = published

--- a/Tests/UnitTests/BackgroundOrchestratorCadenceTests.swift
+++ b/Tests/UnitTests/BackgroundOrchestratorCadenceTests.swift
@@ -565,8 +565,8 @@ private final class FakeLocationSession: HomeContextPreparing {
 }
 
 private actor FakeWeatherClient: HomeWeatherQuerying {
-    func currentWeather(for location: CLLocation) async -> SummaryWeather? {
-        nil
+    func currentWeather(for location: CLLocation) async -> HomeWeatherRefreshResult {
+        .success(nil)
     }
 }
 

--- a/Tests/UnitTests/HomeRefreshPipelineTests.swift
+++ b/Tests/UnitTests/HomeRefreshPipelineTests.swift
@@ -490,7 +490,7 @@ struct HomeRefreshPipelineTests {
                 locationSnapshot: context.snapshot,
                 refreshKey: context.refreshKey,
                 weather: nil,
-                weatherWasRefreshed: true
+                weatherRefreshResult: .success(nil)
             )
         )
         let locationSession = FakeLocationSession(currentContext: context, preparedContext: context)
@@ -517,7 +517,7 @@ struct HomeRefreshPipelineTests {
                 locationSnapshot: context.snapshot,
                 refreshKey: context.refreshKey,
                 weather: nil,
-                weatherWasRefreshed: false
+                weatherRefreshResult: .skipped
             )
         )
         let locationSession = FakeLocationSession(currentContext: context, preparedContext: context)
@@ -534,6 +534,27 @@ struct HomeRefreshPipelineTests {
         await pipeline.waitForIdle()
 
         #expect(pipeline.summaryWeather == staleWeather)
+    }
+
+    @Test("visible refresh preserves stale weather when weather fetch fails")
+    func visibleRefresh_preservesStaleWeatherWhenWeatherFetchFails() async {
+        let context = makeContext()
+        let staleWeather = sampleWeather()
+        let locationSession = FakeLocationSession(currentContext: context, preparedContext: context)
+        let weather = FakeWeatherClient(result: .failure)
+        let pipeline = HomeRefreshPipeline()
+        pipeline.summaryWeather = staleWeather
+
+        await pipeline.forceRefreshCurrentContext(
+            showsLoading: true,
+            environment: makeEnvironment(
+                weather: weather,
+                locationSession: locationSession
+            )
+        )
+
+        #expect(pipeline.summaryWeather == staleWeather)
+        #expect(await weather.callCount() == 1)
     }
 
     @Test("timer refresh keeps sync work on the hot-alert lane")
@@ -1549,16 +1570,20 @@ private final class FakeLocationSession: HomeLocationContextPreparing, HomeConte
 }
 
 private actor FakeWeatherClient: HomeWeatherQuerying {
-    private let weather: SummaryWeather?
+    private let result: HomeWeatherRefreshResult
     private var calls: [CLLocation] = []
 
     init(weather: SummaryWeather? = nil) {
-        self.weather = weather
+        self.result = .success(weather)
     }
 
-    func currentWeather(for location: CLLocation) async -> SummaryWeather? {
+    init(result: HomeWeatherRefreshResult) {
+        self.result = result
+    }
+
+    func currentWeather(for location: CLLocation) async -> HomeWeatherRefreshResult {
         calls.append(location)
-        return weather
+        return result
     }
 
     func callCount() -> Int {

--- a/Tests/UnitTests/HomeRefreshPipelineTests.swift
+++ b/Tests/UnitTests/HomeRefreshPipelineTests.swift
@@ -557,6 +557,60 @@ struct HomeRefreshPipelineTests {
         #expect(await weather.callCount() == 1)
     }
 
+    @Test("visible refresh clears stale weather after a location change when weather fetch fails")
+    func visibleRefresh_clearsStaleWeatherAfterLocationChangeWhenWeatherFetchFails() async {
+        let oldContext = makeContext()
+        let newContext = makeContext(
+            latitude: 39.93,
+            longitude: -104.61,
+            h3Cell: 222_222,
+            timestamp: 200
+        )
+        let staleWeather = sampleWeather()
+        let coordinator = SequencedHomeIngestionCoordinator(
+            snapshots: [
+                HomeSnapshot(
+                    locationSnapshot: oldContext.snapshot,
+                    refreshKey: oldContext.refreshKey,
+                    weather: staleWeather,
+                    weatherRefreshResult: .success(staleWeather)
+                ),
+                HomeSnapshot(
+                    locationSnapshot: newContext.snapshot,
+                    refreshKey: newContext.refreshKey,
+                    weather: nil,
+                    weatherRefreshResult: .failure
+                )
+            ],
+            gates: []
+        )
+        let locationSession = FakeLocationSession(currentContext: oldContext, preparedContext: oldContext)
+        let pipeline = HomeRefreshPipeline()
+        pipeline.summaryWeather = staleWeather
+
+        await pipeline.forceRefreshCurrentContext(
+            showsLoading: true,
+            environment: makeEnvironment(
+                coordinator: coordinator,
+                locationSession: locationSession
+            )
+        )
+
+        locationSession.currentContext = newContext
+        locationSession.preparedContext = newContext
+
+        await pipeline.forceRefreshCurrentContext(
+            showsLoading: true,
+            environment: makeEnvironment(
+                coordinator: coordinator,
+                locationSession: locationSession
+            )
+        )
+
+        #expect(pipeline.summaryWeather == nil)
+        #expect(await coordinator.requestCount() == 2)
+    }
+
     @Test("timer refresh keeps sync work on the hot-alert lane")
     func timerRefresh_syncsHotFeedsOnly() async {
         let context = makeContext()
@@ -1249,13 +1303,18 @@ struct HomeRefreshPipelineTests {
         return HomeIngestionCoordinator(executor: executor)
     }
 
-    private func makeContext(timestamp: TimeInterval = 100) -> LocationContext {
+    private func makeContext(
+        latitude: Double = 39.75,
+        longitude: Double = -104.44,
+        h3Cell: Int64 = 123_456,
+        timestamp: TimeInterval = 100
+    ) -> LocationContext {
         let snapshot = LocationSnapshot(
-            coordinates: .init(latitude: 39.75, longitude: -104.44),
+            coordinates: .init(latitude: latitude, longitude: longitude),
             timestamp: Date(timeIntervalSince1970: timestamp),
             accuracy: 25,
             placemarkSummary: "Bennett, CO",
-            h3Cell: 123_456
+            h3Cell: h3Cell
         )
         let grid = GridPointSnapshot(
             nwsId: "BOU/10,20",

--- a/docs/audits/weekly-bug-scan.md
+++ b/docs/audits/weekly-bug-scan.md
@@ -78,3 +78,28 @@
   - Updated `HomeRefreshPipeline.apply(_:, commitsVisibleSnapshot:)` to assign `summaryWeather = snapshot.weather` unconditionally on visible commits.
   - Added a regression test proving a successful visible refresh with `weather: nil` clears stale cached weather.
 - out-of-scope repositories intentionally not scanned: arcus-signal, ArcusCore
+
+## 2026-06-25T16:12:18Z
+- date: 2026-06-25T16:12:18Z
+- repository reviewed: project-arcus
+- workflow reviewed: Weekly bug scan (audit-only)
+- commit window inspected: 2026-06-18T16:11:44Z through 2026-06-24T15:36:35Z
+- files inspected:
+  - /Users/justin/Code/project-arcus/Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift
+  - /Users/justin/Code/project-arcus/Sources/App/HomeRefreshPipeline.swift
+  - /Users/justin/Code/project-arcus/Sources/Clients/WeatherClient.swift
+  - /Users/justin/Code/project-arcus/Sources/App/HomeRefreshV2/HomeSnapshot.swift
+  - /Users/justin/Code/project-arcus/Sources/Features/Alert/AlertView.swift
+  - /Users/justin/Code/project-arcus/Sources/Features/Alert/AlertPresentationOrdering.swift
+  - /Users/justin/Code/project-arcus/Sources/App/HomeRefreshV2/HomeSnapshotStore.swift
+  - /Users/justin/Code/project-arcus/docs/codebase/skyaware-app-summary.md
+  - /Users/justin/Code/project-arcus/Tests/UnitTests/HomeRefreshPipelineTests.swift
+- top finding: `WeatherClient.currentWeather(for:)` collapses WeatherKit failures into `nil`, but `HomeIngestionExecutor.refreshWeatherIfNeeded` still marks the lane refreshed and `HomeRefreshPipeline.apply(_:, commitsVisibleSnapshot:)` clears `summaryWeather` on any refreshed nil payload, so a transient WeatherKit error wipes the visible current-conditions card instead of preserving the last known reading.
+- best next fix: Carry explicit weather refresh success/failure state through the ingestion snapshot, and only clear `summaryWeather` when WeatherKit returns a successful empty result; keep the prior value on transport or API failure.
+- implementation is recommended: Yes
+- implementation status: completed on 2026-07-01
+- implementation notes:
+  - Introduced `HomeWeatherRefreshResult` to distinguish skipped, success, and failure outcomes.
+  - Updated the ingestion pipeline and `HomeRefreshPipeline` to preserve stale weather on failure while still clearing on successful empty refreshes.
+  - Added regression coverage for success, skipped, and failure paths.
+- out-of-scope repositories intentionally not scanned: arcus-signal, ArcusCore

--- a/docs/audits/weekly-performance-audit.md
+++ b/docs/audits/weekly-performance-audit.md
@@ -75,3 +75,26 @@
 - implementation notes:
   - Hoisted sorted alerts, sorted mesos, and latest-issued derivation into stored values in `AlertView`.
   - Verified the change with `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" build`.
+
+## 2026-06-28
+- workflow reviewed: Convective Outlooks workflow
+- files inspected:
+  - docs/codebase/skyaware-app-summary.md
+  - Sources/App/HomeView.swift
+  - Sources/App/HomeRefreshPipeline.swift
+  - Sources/App/HomeRefreshV2/HomeSnapshotStore.swift
+  - Sources/Features/ConvectiveOutlookView/ConvectiveOutlookView.swift
+  - Sources/Features/ConvectiveOutlookView/ConvectiveOutlookDetailView.swift
+  - Sources/Features/ConvectiveOutlookView/OutlookRowView.swift
+  - Sources/Features/Summary/OutlookSummaryCard.swift
+  - Sources/Features/Summary/OutlookView.swift
+  - Sources/Models/Convective/ConvectiveOutlookDTO.swift
+  - Sources/Repos/ConvectiveOutlookRepo.swift
+- top finding: `ConvectiveOutlookDTO` assigns a fresh `UUID()` in its initializer, so the same SPC outlook becomes a brand-new identity on every refresh or snapshot load, which forces SwiftUI to treat unchanged rows as replacements instead of updates.
+- best next fix: derive the DTO identity from a stable feed-backed key such as `link` or the canonical outlook title/published tuple, so `ConvectiveOutlookView` and any summary surfaces can preserve row identity across refreshes.
+- measurement gap: profile Outlooks-tab row diff churn and `OutlookRowView` body recomputation count across a manual refresh to confirm how much identity instability is visible in Instruments.
+- implementation recommended: yes
+- implementation status: completed on 2026-07-01
+- implementation notes:
+  - Changed `ConvectiveOutlookDTO.id` to use `link.absoluteString` instead of a fresh `UUID()`.
+  - Verified with `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17" -derivedDataPath /private/tmp/SkyAware-PerformanceAudit build`.


### PR DESCRIPTION
# Summary
This branch updates the home refresh flow so failed WeatherKit refreshes no longer overwrite the last visible current conditions, while preserving the existing behavior for skipped refreshes. It also tightens convective outlook identity and bumps the app and widget marketing versions to 1.1.0.

# What Changed
- Introduced explicit weather refresh results so the pipeline can distinguish success, skip, and failure.
- Kept stale current weather visible when a refresh fails instead of clearing it.
- Updated the weather client and ingestion executor to propagate refresh outcomes through snapshot and projection updates.
- Switched convective outlook DTO identity to the feed-backed URL string to avoid unstable SwiftUI diffing.
- Bumped app and widget marketing versions to 1.1.0 in the project file.

# User Impact
When WeatherKit has a transient failure, users keep seeing the last known current weather instead of the UI dropping back to an empty state. The version bump and identity change are internal maintenance with no direct user-facing impact beyond the stability fix.

# Testing
- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iPhone Simulator,name=iPhone 17" -only-testing:SkyAwareTests/HomeRefreshPipelineTests test`
- `HomeRefreshPipelineTests/visibleRefresh_preservesStaleWeatherWhenWeatherFetchFails()` passed in the focused test run.