### PR TITLE
Fix background cadence scheduling and recovery

### DIFF
--- a/Sources/App/SkyAwareApp.swift
+++ b/Sources/App/SkyAwareApp.swift
@@ -115,7 +115,7 @@ struct SkyAwareApp: App {
             logger.notice("Background app refresh completed with result: \(String(describing: result), privacy: .public)")
             
             // Schedule the next run
-            await deps.scheduler.scheduleNextAppRefresh(nextRun: result.next)
+            await deps.scheduler.scheduleEvaluatedNextAppRefresh(nextRun: result.next)
             logger.notice("Scheduled next app refresh at: \(result.next, privacy: .public)")
         }
         .onChange(of: scenePhase) { _, newPhase in
@@ -127,9 +127,8 @@ struct SkyAwareApp: App {
             case .background:
                 Task {
                     let scheduler = BackgroundScheduler(refreshId: deps.appRefreshID)
-                    let next = deps.refreshPolicy.getNextRunTime(for: .normal(60))
-                    logger.notice("App entered background; attempting to schedule next app refresh proactively: \(next.shorten(withDateStyle: .none), privacy: .public)")
-                    await scheduler.scheduleNextAppRefresh(nextRun: next)
+                    logger.notice("App entered background; ensuring background refresh is seeded if needed")
+                    await scheduler.ensureScheduled(using: deps.refreshPolicy)
                 }
             case .inactive: // Swallow inactive state
                 break

--- a/Sources/Features/Background/BackgroundOrchestrator.swift
+++ b/Sources/Features/Background/BackgroundOrchestrator.swift
@@ -84,6 +84,7 @@ actor BackgroundOrchestrator {
         let runInterval = signposter.beginInterval("Background Run")
         let startInstant = clock.now
         let start = Date()
+        let recoveryCadence = Cadence.short.minutes
         await pendingUploadDrainer.drainPendingUploads()
         
         return await withTaskCancellationHandler {
@@ -108,11 +109,11 @@ actor BackgroundOrchestrator {
 
                 guard let locationSnapshot = snapshot.locationSnapshot else {
                     logger.info("No current location snapshot available; rechecking in 20m")
-                    let nextRun = refreshPolicy.getNextRunTime(for: .short(20))
+                    let nextRun = refreshPolicy.getNextRunTime(for: .short)
                     let end = Date()
                     let active = clock.now - startInstant
                     
-                    try? await recordBgRun(start: start, end: end, result: Outcome.BackgroundResult.skipped, didNotify: false, notificationReason: "No location snapshot available. Rechecking in 20m", nextRun: nextRun, cadence: 0, cadenceReason: "Early exit", active: active)
+                    try? await recordBgRun(start: start, end: end, result: Outcome.BackgroundResult.skipped, didNotify: false, notificationReason: "No location snapshot available. Rechecking in 20m", nextRun: nextRun, cadence: recoveryCadence, cadenceReason: "Early exit", active: active)
                     
                     return .init(next: nextRun, result: Outcome.BackgroundResult.skipped, didNotify: false, feedsChanged: feedsChanged)
                 }
@@ -196,9 +197,7 @@ actor BackgroundOrchestrator {
                 // MARK: Cadence decision
                 let cadenceResult = cadence.decide(
                     for: .init(
-                        now: .now,
                         categorical: stormRisk,
-                        recentlyChangedLocation: false,
                         inMeso: inMeso,
                         inAlert: inAlert
                     )
@@ -217,7 +216,7 @@ actor BackgroundOrchestrator {
                     didNotify: didNotify,
                     notificationReason: reasonNoNotify,
                     nextRun: nextRun,
-                    cadence: cadenceResult.cadence.getMinutes(),
+                    cadence: cadenceResult.cadence.minutes,
                     cadenceReason: cadenceResult.reason,
                     active: active
                 )
@@ -227,18 +226,18 @@ actor BackgroundOrchestrator {
                 return .init(next: nextRun, result: Outcome.BackgroundResult.success, didNotify: didNotify, feedsChanged: feedsChanged)
             } catch {
                 signposter.endInterval("Background Run", runInterval)
-                let nextRun = refreshPolicy.getNextRunTime(for: .short(20))
+                let nextRun = refreshPolicy.getNextRunTime(for: .short)
                 let end = Date()
                 let active = clock.now - startInstant
                 
                 if error is CancellationError {
                     logger.notice("Background refresh was cancelled: \(error.localizedDescription, privacy: .public)")
-                    try? await recordBgRun(start: start, end: end, result: Outcome.BackgroundResult.cancelled, didNotify: false, notificationReason: "Cancelled by iOS", nextRun: nextRun, cadence: 0, cadenceReason: "Background refresh cancelled", active: active)
+                    try? await recordBgRun(start: start, end: end, result: Outcome.BackgroundResult.cancelled, didNotify: false, notificationReason: "Cancelled by iOS", nextRun: nextRun, cadence: recoveryCadence, cadenceReason: "Background refresh cancelled", active: active)
                     return .init(next: nextRun, result: Outcome.BackgroundResult.cancelled, didNotify: false, feedsChanged: feedsChanged)
                 } else {
                     logger.error("Error refreshing background data: \(error.localizedDescription, privacy: .public)")
                     
-                    try? await recordBgRun(start: start, end: end, result: Outcome.BackgroundResult.failed, didNotify: false, notificationReason: "Error refreshing background data", nextRun: nextRun, cadence: 0, cadenceReason: "Background refresh failed", active: active)
+                    try? await recordBgRun(start: start, end: end, result: Outcome.BackgroundResult.failed, didNotify: false, notificationReason: "Error refreshing background data", nextRun: nextRun, cadence: recoveryCadence, cadenceReason: "Background refresh failed", active: active)
                         
                     return .init(next: nextRun, result: Outcome.BackgroundResult.failed, didNotify: false, feedsChanged: feedsChanged)
                 }

--- a/Sources/Infrastructure/Scheduling/BackgroundScheduler.swift
+++ b/Sources/Infrastructure/Scheduling/BackgroundScheduler.swift
@@ -12,31 +12,81 @@ import BackgroundTasks
 struct BackgroundScheduler {
     private let logger = Logger.backgroundScheduler
     private let appRefreshID: String
-    private let replacementLeadTime: TimeInterval = 120
+    private let replacementTolerance: TimeInterval = 120
     
     init(refreshId: String) {
         appRefreshID = refreshId
     }
     
+    enum SchedulingIntent {
+        case ensure
+        case authoritative
+    }
+
+    enum PendingRequest: Sendable, Equatable {
+        case none
+        case immediate
+        case at(Date)
+    }
+
+    enum SchedulingDecision: Sendable, Equatable {
+        case submit
+        case keepExisting
+        case keepImmediate
+        case replace(existing: Date)
+    }
+
     // MARK: - Schedule Next App Refresh
-    func scheduleNextAppRefresh(nextRun: Date) async {
+    func scheduleEvaluatedNextAppRefresh(nextRun: Date) async {
+        await schedule(nextRun: nextRun, intent: .authoritative)
+    }
+
+    func ensureScheduled(using policy: RefreshPolicy, now: Date = .now) async {
+        let next = policy.getNextRunTime(for: .short, now: now)
+        await schedule(nextRun: next, intent: .ensure)
+    }
+
+    private func schedule(nextRun: Date, intent: SchedulingIntent) async {
         logger.debug("Checking for any pending app refreshes")
         let pending = await pendingRequest(for: appRefreshID)
-        
-        switch pending {
-        case .none:
+
+        switch Self.decision(for: pending, requested: nextRun, intent: intent, minimumDifference: replacementTolerance) {
+        case .submit:
             submitRequest(nextRun: nextRun)
-        case .at(let existing):
-            guard Self.shouldReplace(existing: existing, requested: nextRun, minimumAdvance: replacementLeadTime) else {
+        case .keepExisting:
+            if case .at(let existing) = pending {
                 logger.debug("Keeping existing refresh task at \(existing, privacy: .public); requested \(nextRun, privacy: .public)")
-                return
             }
-            
+        case .keepImmediate:
+            logger.debug("Keeping existing immediate refresh task; requested \(nextRun, privacy: .public)")
+        case .replace(let existing):
             logger.notice("Replacing refresh task from \(existing, privacy: .public) to \(nextRun, privacy: .public)")
             BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: appRefreshID)
             submitRequest(nextRun: nextRun, restoreOnFailure: existing)
+        }
+    }
+
+    static func decision(
+        for pending: PendingRequest,
+        requested: Date,
+        intent: SchedulingIntent,
+        minimumDifference: TimeInterval = 120
+    ) -> SchedulingDecision {
+        switch pending {
+        case .none:
+            return .submit
         case .immediate:
-            logger.debug("Keeping existing immediate refresh task; requested \(nextRun, privacy: .public)")
+            return .keepImmediate
+        case .at(let existing):
+            guard intent == .authoritative else {
+                return .keepExisting
+            }
+
+            guard shouldReplace(existing: existing, requested: requested, minimumAdvance: minimumDifference) else {
+                return .keepExisting
+            }
+
+            return .replace(existing: existing)
         }
     }
     
@@ -45,7 +95,7 @@ struct BackgroundScheduler {
         requested: Date,
         minimumAdvance: TimeInterval = 120
     ) -> Bool {
-        requested.addingTimeInterval(minimumAdvance) < existing
+        abs(existing.timeIntervalSince(requested)) > minimumAdvance
     }
     
     private func submitRequest(nextRun: Date, restoreOnFailure previousRun: Date? = nil) {
@@ -95,18 +145,5 @@ struct BackgroundScheduler {
                 }
             }
         }
-    }
-    
-    private enum PendingRequest {
-        case none
-        case immediate
-        case at(Date)
-    }
-}
-
-extension BackgroundScheduler {
-    func ensureScheduled(using policy: RefreshPolicy, now: Date = .now) async {
-        let next = policy.getNextRunTime(for: .short(20))
-        await scheduleNextAppRefresh(nextRun: next)
     }
 }

--- a/Sources/Policies/CadencePolicy.swift
+++ b/Sources/Policies/CadencePolicy.swift
@@ -8,40 +8,30 @@
 import Foundation
 import OSLog
 
-enum CadenceAdjust { case tighten, loosen }
-
 enum Cadence: Sendable, Equatable {
-    case short(Int), normal(Int), long(Int)
-    
-    var label: String {
-      switch self { case .short(let m): "short(\(m)m)"; case .normal(let m): "normal(\(m)m)"; case .long(let m): "long(\(m)m)" }
-    }
-}
+    case short
+    case normal
+    case long
 
-extension Cadence {
-    static let defaultShort = 20
-    static let defaultNormal = 40
-    static let defaultLong = 60
-    
-    func adjusted(_ a: CadenceAdjust) -> Cadence {
-        switch (a, self) {
-        case (.tighten, .long):   return .normal(Self.defaultNormal)
-        case (.tighten, .normal): return .short(Self.defaultShort)
-        case (.tighten, .short):  return .short(Self.defaultShort)
-        case (.loosen,  .short):  return .normal(Self.defaultNormal)
-        case (.loosen,  .normal): return .long(Self.defaultLong)
-        case (.loosen,  .long):   return .long(Self.defaultLong)
+    var label: String {
+        switch self {
+        case .short:
+            "short(20m)"
+        case .normal:
+            "normal(40m)"
+        case .long:
+            "long(60m)"
         }
     }
-    
-    
-    /// Convenience function to retrieve the minutes saved with the cadence
-    /// - Returns: minutes as Int
-    func getMinutes() -> Int {
+
+    var minutes: Int {
         switch self {
-        case .short(let m):  m
-        case .normal(let m): m
-        case .long(let m):   m
+        case .short:
+            20
+        case .normal:
+            40
+        case .long:
+            60
         }
     }
 }
@@ -52,9 +42,7 @@ struct CadenceResult: Sendable, Equatable {
 }
 
 struct CadenceContext: Sendable {
-    let now: Date
     let categorical: StormRiskLevel
-    let recentlyChangedLocation: Bool
     let inMeso: Bool
     let inAlert: Bool
 }
@@ -68,50 +56,28 @@ struct CadencePolicy: Sendable {
     /// - Returns: a cadence result
     func decide(for ctx: CadenceContext) -> CadenceResult {
         logger.debug("Deciding cadence from context")
-        // Check in meso or watch return short and short circuit
+        // Check in meso or watch return short and short circuit.
         if ctx.inAlert || ctx.inMeso {
             let sources = [ctx.inAlert ? "watch" : nil, ctx.inMeso ? "meso" : nil].compactMap { $0 }.joined(separator: ",")
-            let r = CadenceResult(cadence: .short(Cadence.defaultShort), reason: "gate=\(sources)")
+            let r = CadenceResult(cadence: .short, reason: "gate=\(sources)")
             logger.notice("cadence=\(r.cadence.label, privacy: .public) reason=\(r.reason, privacy: .public)")
             return r
         }
-        
-        // Only going to check categorical storm risk, as its linked to severe.
-        // Tornado, wind, hail don't happen without elevated categorical risk
-        // This makes rule reading easier. No reason to add complexity when
-        // not necessary.
-        
-        // check categorical evaluate level, short circuit return
+
         logger.debug("Checking categorical risk")
-        var base: CadenceResult
         switch ctx.categorical {
-        case .allClear, .thunderstorm, .marginal: // 60
-            base = .init(
-                cadence: .long(Cadence.defaultLong),
-                reason: "gate=categorical: \(ctx.categorical.abbreviation)"
-            )
-        case .slight, .enhanced: // 40
-            base = .init(
-                cadence: .normal(Cadence.defaultNormal),
-                reason: "gate=categorical: \(ctx.categorical.abbreviation)"
-            )
-        case .moderate, .high: // 20
-            base = .init(
-                cadence: .short(Cadence.defaultShort),
-                reason: "gate=categorical: \(ctx.categorical.abbreviation)"
-            )
+        case .allClear:
+            let r = CadenceResult(cadence: .long, reason: "gate=categorical: \(ctx.categorical.abbreviation)")
+            logger.notice("cadence=\(r.cadence.label, privacy: .public) reason=\(r.reason, privacy: .public)")
+            return r
+        case .thunderstorm:
+            let r = CadenceResult(cadence: .normal, reason: "gate=categorical: \(ctx.categorical.abbreviation)")
+            logger.notice("cadence=\(r.cadence.label, privacy: .public) reason=\(r.reason, privacy: .public)")
+            return r
+        case .marginal, .slight, .enhanced, .moderate, .high:
+            let r = CadenceResult(cadence: .short, reason: "gate=categorical: \(ctx.categorical.abbreviation)")
+            logger.notice("cadence=\(r.cadence.label, privacy: .public) reason=\(r.reason, privacy: .public)")
+            return r
         }
-        
-        // if we make it here, apply any nudges and then return
-        
-        if ctx.recentlyChangedLocation {
-            let from = base.cadence
-            let to = base.cadence.adjusted(.tighten)
-            base.cadence = to
-            base.reason = [base.reason, "nudge=move \(from.label)->\(to.label)"]
-                .compactMap { $0 }.joined(separator: " ")
-        }
-        
-        return base
     }
 }

--- a/Sources/Policies/RefreshPolicy.swift
+++ b/Sources/Policies/RefreshPolicy.swift
@@ -29,7 +29,7 @@ struct RefreshPolicy: Sendable {
         cal.timeZone = TimeZone(secondsFromGMT: 0)! // Zulu
 
         // Extract minutes from the provided cadence
-        let minutes = cadence.getMinutes()
+        let minutes = cadence.minutes
   
         // Exactly N minutes from now (no top-of-hour alignment)
         let target = cal.date(byAdding: .minute, value: minutes, to: now)!

--- a/Tests/UnitTests/BackgroundOrchestratorCadenceTests.swift
+++ b/Tests/UnitTests/BackgroundOrchestratorCadenceTests.swift
@@ -15,47 +15,122 @@ struct BackgroundSchedulerReplacementPolicyTests {
         let requested = base.addingTimeInterval(20 * 60)
         
         #expect(
-            BackgroundScheduler.shouldReplace(
-                existing: existing,
+            BackgroundScheduler.decision(
+                for: .at(existing),
                 requested: requested,
-                minimumAdvance: 120
-            )
+                intent: .authoritative,
+                minimumDifference: 120
+            ) == .replace(existing: existing)
         )
     }
     
-    @Test("Does not replace when requested run is later")
-    func doNotReplaceWhenRequestedIsLater() {
+    @Test("Replaces pending request when requested run is materially later")
+    func replaceWhenRequestedIsLater() {
         let base = Date(timeIntervalSince1970: 0)
         let existing = base.addingTimeInterval(20 * 60)
         let requested = base.addingTimeInterval(60 * 60)
         
         #expect(
-            BackgroundScheduler.shouldReplace(
-                existing: existing,
+            BackgroundScheduler.decision(
+                for: .at(existing),
                 requested: requested,
-                minimumAdvance: 120
-            ) == false
+                intent: .authoritative,
+                minimumDifference: 120
+            ) == .replace(existing: existing)
         )
     }
     
-    @Test("Does not replace when request is only slightly earlier than pending")
-    func doNotReplaceForTinyTimingDifference() {
+    @Test("Ensure-only scheduling preserves an existing request")
+    func ensureOnlyPreservesExistingRequest() {
         let base = Date(timeIntervalSince1970: 0)
-        let existing = base.addingTimeInterval(60 * 60)
-        let requested = base.addingTimeInterval((60 * 60) - 60)
+        let existing = base.addingTimeInterval(20 * 60)
+        let requested = base.addingTimeInterval(60 * 60)
         
         #expect(
-            BackgroundScheduler.shouldReplace(
-                existing: existing,
+            BackgroundScheduler.decision(
+                for: .at(existing),
                 requested: requested,
-                minimumAdvance: 120
-            ) == false
+                intent: .ensure,
+                minimumDifference: 120
+            ) == .keepExisting
+        )
+    }
+
+    @Test("Keeps requests within the two-minute replacement tolerance")
+    func keepsRequestsWithinTwoMinuteTolerance() {
+        let base = Date(timeIntervalSince1970: 0)
+        let existing = base.addingTimeInterval(60 * 60)
+        let requested = existing.addingTimeInterval(-120)
+
+        #expect(
+            BackgroundScheduler.decision(
+                for: .at(existing),
+                requested: requested,
+                intent: .authoritative,
+                minimumDifference: 120
+            ) == .keepExisting
+        )
+    }
+
+    @Test("Preserves immediate pending requests")
+    func preservesImmediatePendingRequests() {
+        let requested = Date(timeIntervalSince1970: 0).addingTimeInterval(20 * 60)
+
+        #expect(
+            BackgroundScheduler.decision(
+                for: .immediate,
+                requested: requested,
+                intent: .authoritative,
+                minimumDifference: 120
+            ) == .keepImmediate
         )
     }
 }
 
 @Suite("BackgroundOrchestrator Cadence", .serialized)
 struct BackgroundOrchestratorCadenceTests {
+    @Test("Every storm risk level maps to the evaluated cadence band")
+    func everyStormRiskLevel_mapsToExpectedCadenceBand() {
+        let policy = CadencePolicy()
+        let cases: [(StormRiskLevel, Cadence)] = [
+            (.allClear, .long),
+            (.thunderstorm, .normal),
+            (.marginal, .short),
+            (.slight, .short),
+            (.enhanced, .short),
+            (.moderate, .short),
+            (.high, .short)
+        ]
+
+        for (risk, expected) in cases {
+            let result = policy.decide(
+                for: .init(
+                    categorical: risk,
+                    inMeso: false,
+                    inAlert: false
+                )
+            )
+
+            #expect(result.cadence == expected)
+            #expect(result.reason.contains(risk.abbreviation))
+        }
+    }
+
+    @Test("Alert and meso precedence wins over categorical cadence")
+    func alertAndMesoPrecedenceWinsOverCategoricalCadence() {
+        let policy = CadencePolicy()
+        let result = policy.decide(
+            for: .init(
+                categorical: .allClear,
+                inMeso: true,
+                inAlert: true
+            )
+        )
+
+        #expect(result.cadence == .short)
+        #expect(result.reason == "gate=watch,meso")
+    }
+
     @Test("Fresh location request updates provider before risk queries")
     func freshLocationRequest_updatesProviderBeforeRiskQueries() async throws {
         let refreshed = CLLocationCoordinate2D(latitude: 39.7392, longitude: -104.9903)
@@ -247,7 +322,7 @@ struct BackgroundOrchestratorCadenceTests {
         _ = await setup.orchestrator.run()
 
         let cadence = try await setup.latestCadence()
-        #expect(cadence == Cadence.defaultShort)
+        #expect(cadence == Cadence.short.minutes)
     }
 
     @Test("Active alert tightens cadence to short")
@@ -260,7 +335,7 @@ struct BackgroundOrchestratorCadenceTests {
         _ = await setup.orchestrator.run()
 
         let cadence = try await setup.latestCadence()
-        #expect(cadence == Cadence.defaultShort)
+        #expect(cadence == Cadence.short.minutes)
     }
 
     @Test("No active meso/alert keeps all-clear cadence long")
@@ -273,7 +348,7 @@ struct BackgroundOrchestratorCadenceTests {
         _ = await setup.orchestrator.run()
 
         let cadence = try await setup.latestCadence()
-        #expect(cadence == Cadence.defaultLong)
+        #expect(cadence == Cadence.long.minutes)
     }
 
     @Test("Background refresh sends one risk notification and marks didNotify")
@@ -461,6 +536,98 @@ struct BackgroundOrchestratorCadenceTests {
         #expect(secondOutcome.didNotify)
         #expect(await sender.sent().count == 1)
         #expect(health.didNotify)
+    }
+
+    @Test("Missing location context records recovery cadence 20")
+    func missingLocationContext_recordsRecoveryCadenceTwenty() async throws {
+        let setup = try await makeSystem(
+            activeMesos: [],
+            activeAlerts: [],
+            refreshedLocation: nil,
+            refreshSucceeds: false,
+            cachedSnapshotTimestamp: Date().addingTimeInterval(-(6 * 60)),
+            settings: .init(morningSummariesEnabled: false, mesoNotificationsEnabled: false)
+        )
+
+        let outcome = await setup.orchestrator.run()
+        let cadence = try await setup.latestCadence()
+
+        #expect(outcome.result == .skipped)
+        #expect(cadence == 20)
+    }
+
+    @Test("Failure to all-clear recovery records 20 then 60")
+    func failureToAllClearRecovery_recordsTwentyThenSixty() async throws {
+        let context = Self.makeContext(
+            coordinates: CLLocationCoordinate2D(latitude: 39.7392, longitude: -104.9903),
+            timestamp: Date(),
+            placemarkSummary: "Denver, CO"
+        )
+        let successSnapshot = HomeSnapshot(
+            locationSnapshot: context.snapshot,
+            refreshKey: context.refreshKey,
+            stormRisk: .allClear,
+            severeRisk: .allClear,
+            fireRisk: .clear
+        )
+        let coordinator = ScriptedHomeIngestionCoordinator(
+            responses: [
+                .failure(.failed),
+                .snapshot(successSnapshot)
+            ]
+        )
+        let system = try await makeRiskSystem(
+            coordinator: coordinator,
+            riskChangeEngine: makeRiskChangeEngine(sender: NoopSender()),
+            settingsProvider: StaticSettingsProvider(
+                settings: .init(morningSummariesEnabled: false, mesoNotificationsEnabled: false)
+            )
+        )
+
+        let firstOutcome = await system.orchestrator.run()
+        let secondOutcome = await system.orchestrator.run()
+        let cadences = try await system.recordedCadences()
+
+        #expect(firstOutcome.result == .failed)
+        #expect(secondOutcome.result == .success)
+        #expect(cadences == [20, 60])
+    }
+
+    @Test("Failure to thunderstorm recovery records 20 then 40")
+    func failureToThunderstormRecovery_recordsTwentyThenForty() async throws {
+        let context = Self.makeContext(
+            coordinates: CLLocationCoordinate2D(latitude: 39.7392, longitude: -104.9903),
+            timestamp: Date(),
+            placemarkSummary: "Denver, CO"
+        )
+        let successSnapshot = HomeSnapshot(
+            locationSnapshot: context.snapshot,
+            refreshKey: context.refreshKey,
+            stormRisk: .thunderstorm,
+            severeRisk: .allClear,
+            fireRisk: .clear
+        )
+        let coordinator = ScriptedHomeIngestionCoordinator(
+            responses: [
+                .failure(.failed),
+                .snapshot(successSnapshot)
+            ]
+        )
+        let system = try await makeRiskSystem(
+            coordinator: coordinator,
+            riskChangeEngine: makeRiskChangeEngine(sender: NoopSender()),
+            settingsProvider: StaticSettingsProvider(
+                settings: .init(morningSummariesEnabled: false, mesoNotificationsEnabled: false)
+            )
+        )
+
+        let firstOutcome = await system.orchestrator.run()
+        let secondOutcome = await system.orchestrator.run()
+        let cadences = try await system.recordedCadences()
+
+        #expect(firstOutcome.result == .failed)
+        #expect(secondOutcome.result == .success)
+        #expect(cadences == [20, 40])
     }
 }
 
@@ -997,6 +1164,49 @@ private actor SequentialHomeIngestionCoordinator: HomeIngestionCoordinating {
     }
 }
 
+private enum ScriptedCoordinatorError: Error {
+    case failed
+}
+
+private actor ScriptedHomeIngestionCoordinator: HomeIngestionCoordinating {
+    enum Response: Sendable {
+        case snapshot(HomeSnapshot)
+        case failure(ScriptedCoordinatorError)
+    }
+
+    private var responses: [Response]
+
+    init(responses: [Response]) {
+        self.responses = responses
+    }
+
+    func enqueue(
+        _ trigger: HomeRefreshTrigger,
+        locationContext: LocationContext? = nil,
+        remoteAlertContext: HomeRemoteAlertContext? = nil
+    ) {}
+
+    func enqueue(_ request: HomeIngestionRequest) {}
+
+    func enqueueAndWait(
+        _ trigger: HomeRefreshTrigger,
+        locationContext: LocationContext? = nil,
+        remoteAlertContext: HomeRemoteAlertContext? = nil
+    ) async throws -> HomeSnapshot {
+        try await enqueueAndWait(.init(trigger: trigger, locationContext: locationContext, remoteAlertContext: remoteAlertContext))
+    }
+
+    func enqueueAndWait(_ request: HomeIngestionRequest) async throws -> HomeSnapshot {
+        guard responses.isEmpty == false else { return .empty }
+        switch responses.removeFirst() {
+        case .snapshot(let snapshot):
+            return snapshot
+        case .failure(let error):
+            throw error
+        }
+    }
+}
+
 private extension BackgroundOrchestratorCadenceTests {
     struct RiskSystem {
         let orchestrator: BackgroundOrchestrator
@@ -1020,11 +1230,20 @@ private extension BackgroundOrchestratorCadenceTests {
                 return HealthRecord(didNotify: health.didNotify, reasonNoNotify: health.reasonNoNotify)
             }
         }
+
+        func recordedCadences() async throws -> [Int] {
+            try await MainActor.run {
+                let context = ModelContext(modelContainer)
+                let descriptor = FetchDescriptor<BgRunSnapshot>(
+                    sortBy: [SortDescriptor(\.endedAt, order: .forward)]
+                )
+                return try context.fetch(descriptor).map(\.cadence)
+            }
+        }
     }
 
     func makeRiskSystem<Settings: NotificationSettingsProviding>(
-        snapshot: HomeSnapshot? = nil,
-        snapshots: [HomeSnapshot]? = nil,
+        coordinator: any HomeIngestionCoordinating,
         riskChangeEngine: RiskChangeEngine,
         settingsProvider: Settings
     ) async throws -> RiskSystem {
@@ -1032,12 +1251,6 @@ private extension BackgroundOrchestratorCadenceTests {
         try await MainActor.run { try TestStore.reset(BgRunSnapshot.self, in: container) }
 
         let healthStore = BgHealthStore(modelContainer: container)
-        let coordinator: any HomeIngestionCoordinating
-        if let snapshots {
-            coordinator = SequentialHomeIngestionCoordinator(snapshots: snapshots)
-        } else {
-            coordinator = RecordingHomeIngestionCoordinator(snapshot: snapshot ?? .empty)
-        }
         let orchestrator = BackgroundOrchestrator(
             coordinator: coordinator,
             policy: RefreshPolicy(),
@@ -1062,6 +1275,25 @@ private extension BackgroundOrchestratorCadenceTests {
         )
 
         return .init(orchestrator: orchestrator, modelContainer: container)
+    }
+
+    func makeRiskSystem<Settings: NotificationSettingsProviding>(
+        snapshot: HomeSnapshot? = nil,
+        snapshots: [HomeSnapshot]? = nil,
+        riskChangeEngine: RiskChangeEngine,
+        settingsProvider: Settings
+    ) async throws -> RiskSystem {
+        let coordinator: any HomeIngestionCoordinating
+        if let snapshots {
+            coordinator = SequentialHomeIngestionCoordinator(snapshots: snapshots)
+        } else {
+            coordinator = RecordingHomeIngestionCoordinator(snapshot: snapshot ?? .empty)
+        }
+        return try await makeRiskSystem(
+            coordinator: coordinator,
+            riskChangeEngine: riskChangeEngine,
+            settingsProvider: settingsProvider
+        )
     }
 
     func makeRiskChangeEngine<Sender: NotificationSending>(

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -45,3 +45,9 @@
 - Do not infer SwiftData Codable storage behavior from JSON Codable behavior. SwiftData may flatten nested values and
   use framework-specific encoders that trap on otherwise valid custom enum conformances. Inspect the SQLite schema and
   reproduce an actual save/reopen path before prescribing a shared-model decoder fix.
+
+## 2026-07-16
+
+- For background cadence work, preserve the established 20/40/60-minute bands: marginal-or-higher categorical risk,
+  active alerts, or active mesos use 20 minutes; thunderstorm-only uses 40; all-clear uses 60. Missing context and
+  failures retry at 20, but the next successful run must authoritatively restore the condition-appropriate band.


### PR DESCRIPTION
# Summary
This branch makes the evaluated background cadence authoritative across scheduling and diagnostics. It canonicalizes cadence bands, removes the old adjustment inputs, and splits scheduler behavior so bootstrap scheduling only seeds an empty slot while post-run scheduling can replace a materially different pending refresh.

# What Changed
- Canonicalized `Cadence` to fixed short, normal, and long bands mapped to 20, 40, and 60 minutes.
- Removed the old cadence adjustment path and unused cadence context inputs tied to `now`, `recentlyChangedLocation`, and `CadenceAdjust`.
- Split background scheduling into ensure-only seeding and authoritative replacement, while preserving the 2-minute tolerance, immediate-request handling, and failed-replacement restoration.
- Routed app activation and scene-background scheduling through ensure-only behavior, and routed completed background orchestration results through authoritative scheduling.
- Recorded recovery diagnostics with cadence 20 on missing context, cancellation, and failure paths.
- Expanded cadence regression coverage for every `StormRiskLevel`, alert and meso precedence, scheduler replacement behavior, and recovery sequences.

# User Impact
Background refresh cadence now follows the evaluated severe-weather state more reliably. After a failed or interrupted run, the next successful run returns to the correct 20, 40, or 60 minute band instead of lingering on the recovery cadence.

# Testing
- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17,OS=26.5" -only-testing:SkyAwareTests/BackgroundSchedulerReplacementPolicyTests -only-testing:SkyAwareTests/BackgroundOrchestratorCadenceTests test`
- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17,OS=26.5" build`
- `git diff --check`
- `xcrun xcresulttool get --path /private/tmp/SkyAware-CadenceTests.xcresult --format json --legacy` reported 23 passing tests and 0 failures.

# Notes
- BGTaskScheduler still only receives an earliest-begin date; execution remains opportunistic.
- The branch also includes the existing lesson note update in `tasks/lessons.md`.
