### PR TITLE
Coalesce risk profile changes into the morning outlook

### DIFF
--- a/Sources/Features/Background/BackgroundOrchestrator.swift
+++ b/Sources/Features/Background/BackgroundOrchestrator.swift
@@ -182,6 +182,9 @@ actor BackgroundOrchestrator {
                 let coalescedCurrentRiskChange = settings.riskChangeNotificationsEnabled
                     && didMorningNotify
                     && snapshot.riskProfileChange != nil
+                if coalescedCurrentRiskChange, let riskProfileChange = snapshot.riskProfileChange {
+                    await riskChangeEngine.coalesce(change: riskProfileChange)
+                }
                 didRiskChangeNotify = await riskChangeEngine.run(
                     change: coalescedCurrentRiskChange ? nil : snapshot.riskProfileChange,
                     isEnabled: settings.riskChangeNotificationsEnabled

--- a/Sources/Features/Background/BackgroundOrchestrator.swift
+++ b/Sources/Features/Background/BackgroundOrchestrator.swift
@@ -157,7 +157,8 @@ actor BackgroundOrchestrator {
                             stormRisk: stormRisk,
                             severeRisk: severeRisk,
                             fireRisk: fireRisk,
-                            placeMark: locationSnapshot.placemarkSummary ?? "Unknown"
+                            placeMark: locationSnapshot.placemarkSummary ?? "Unknown",
+                            riskProfileChange: settings.riskChangeNotificationsEnabled ? snapshot.riskProfileChange : nil
                         )
                     )
                     if !didMorningNotify { noNotifyReasons.append("Morning summary skipped") }
@@ -178,12 +179,15 @@ actor BackgroundOrchestrator {
                     if !didMesoNotify { noNotifyReasons.append("Meso notification skipped") }
                 } else { noNotifyReasons.append("Meso notification disabled") }
 
+                let coalescedCurrentRiskChange = settings.riskChangeNotificationsEnabled
+                    && didMorningNotify
+                    && snapshot.riskProfileChange != nil
                 didRiskChangeNotify = await riskChangeEngine.run(
-                    change: snapshot.riskProfileChange,
+                    change: coalescedCurrentRiskChange ? nil : snapshot.riskProfileChange,
                     isEnabled: settings.riskChangeNotificationsEnabled
                 )
                 if settings.riskChangeNotificationsEnabled {
-                    if !didRiskChangeNotify {
+                    if !didRiskChangeNotify, !coalescedCurrentRiskChange {
                         if snapshot.riskProfileChange == nil {
                             noNotifyReasons.append("Risk change notification skipped (no change)")
                         } else {

--- a/Sources/Notifications/Morning/AmRangeLocalRule.swift
+++ b/Sources/Notifications/Morning/AmRangeLocalRule.swift
@@ -45,17 +45,22 @@ struct AmRangeLocalRule: NotificationRuleEvaluating {
         let id = "morning:\(stamp)"
         logger.trace("Stamp generated: \(id)")
         
+        var payload: [String: Sendable] = [
+            "localDay": stamp,
+            "issue": ctx.lastConvectiveIssue as Sendable?,
+            "stormRisk": ctx.stormRisk,
+            "severeRisk": ctx.severeRisk,
+            "fireRisk": ctx.fireRisk,
+            "placeMark": ctx.placeMark
+        ]
+        if let riskProfileChange = ctx.riskProfileChange {
+            payload["riskProfileChange"] = riskProfileChange
+        }
+
         return NotificationEvent(
             kind: .morningOutlook,
             key: id,
-            payload: [
-                "localDay": stamp,
-                "issue": ctx.lastConvectiveIssue as Sendable?,
-                "stormRisk": ctx.stormRisk,
-                "severeRisk": ctx.severeRisk,
-                "fireRisk": ctx.fireRisk,
-                "placeMark": ctx.placeMark
-            ]
+            payload: payload
         )
     }
 }

--- a/Sources/Notifications/Morning/MorningComposer.swift
+++ b/Sources/Notifications/Morning/MorningComposer.swift
@@ -20,8 +20,18 @@ struct MorningComposer: NotificationComposing {
         let severeRisk = (event.payload["severeRisk"] as? SevereWeatherThreat) ?? .allClear
         let fireRisk = (event.payload["fireRisk"] as? FireRiskLevel) ?? .clear
         let placemark = (event.payload["placeMark"] as? String) ?? "Unknown"
+        let outlook = "Storm Activity: \(stormRisk.summary)\nSevere Activity: \(severeRisk.summary)\nFire Risk: \(fireRisk.message)"
+
+        let body: String
+        if let riskProfileChange = event.payload["riskProfileChange"] as? RiskProfileChange {
+            let transitions = RiskProfileChangeFormatting.transitionLines(for: riskProfileChange)
+                .joined(separator: "\n")
+            body = "Risk Update\n\(transitions)\n\n\(outlook)"
+        } else {
+            body = outlook
+        }
         
         logger.debug("Summary notification generated")
-        return ("Today's Outlook for \(placemark)", "Storm Activity: \(stormRisk.summary)\nSevere Activity: \(severeRisk.summary)\nFire Risk: \(fireRisk.message)", "\(issue)")
+        return ("Today's Outlook for \(placemark)", body, "\(issue)")
     }
 }

--- a/Sources/Notifications/Morning/MorningContext.swift
+++ b/Sources/Notifications/Morning/MorningContext.swift
@@ -16,6 +16,7 @@ struct MorningContext: Sendable {
     let severeRisk: SevereWeatherThreat
     let fireRisk: FireRiskLevel
     let placeMark: String
+    let riskProfileChange: RiskProfileChange?
     
     init(
         now: Date,
@@ -25,7 +26,8 @@ struct MorningContext: Sendable {
         stormRisk: StormRiskLevel,
         severeRisk: SevereWeatherThreat,
         fireRisk: FireRiskLevel,
-        placeMark: String
+        placeMark: String,
+        riskProfileChange: RiskProfileChange? = nil
     ) {
         self.now = now
         self.lastConvectiveIssue = lastConvectiveIssue
@@ -35,5 +37,6 @@ struct MorningContext: Sendable {
         self.severeRisk = severeRisk
         self.fireRisk = fireRisk
         self.placeMark = placeMark
+        self.riskProfileChange = riskProfileChange
     }
 }

--- a/Sources/Notifications/Morning/SevenAmLocalRule.swift
+++ b/Sources/Notifications/Morning/SevenAmLocalRule.swift
@@ -33,17 +33,22 @@ struct SevenAmLocalRule: NotificationRuleEvaluating {
         let id = "morning:\(stamp)"
         logger.trace("Stamp generated: \(id)")
         
+        var payload: [String: Sendable] = [
+            "localDay": stamp,
+            "issue": ctx.lastConvectiveIssue as Sendable?,
+            "stormRisk": ctx.stormRisk,
+            "severeRisk": ctx.severeRisk,
+            "fireRisk": ctx.fireRisk,
+            "placeMark": ctx.placeMark
+        ]
+        if let riskProfileChange = ctx.riskProfileChange {
+            payload["riskProfileChange"] = riskProfileChange
+        }
+
         return NotificationEvent(
             kind: .morningOutlook,
             key: id,
-            payload: [
-                "localDay": stamp,
-                "issue": ctx.lastConvectiveIssue as Sendable?,
-                "stormRisk": ctx.stormRisk,
-                "severeRisk": ctx.severeRisk,
-                "fireRisk": ctx.fireRisk,
-                "placeMark": ctx.placeMark
-            ]
+            payload: payload
         )
     }
 }

--- a/Sources/Notifications/RiskChange/RiskChangeComposer.swift
+++ b/Sources/Notifications/RiskChange/RiskChangeComposer.swift
@@ -18,19 +18,26 @@ struct RiskChangeComposer: NotificationComposing {
             return ("Your Risk Profile Changed", "", "Updated for your area")
         }
 
-        let lines = change.changedDimensions
-            .sorted(by: Self.dimensionSort)
-            .map { formatTransition(for: $0, change: change) }
+        let lines = RiskProfileChangeFormatting.transitionLines(for: change)
 
         return (
             "Your Risk Profile Changed",
             lines.joined(separator: "\n"),
-            "Updated for \(sanitizedLocation(change.locationSummary))"
+            "Updated for \(RiskProfileChangeFormatting.sanitizedLocation(change.locationSummary))"
         )
     }
 
+}
+
+enum RiskProfileChangeFormatting {
+    static func transitionLines(for change: RiskProfileChange) -> [String] {
+        change.changedDimensions
+            .sorted(by: dimensionSort)
+            .map { formatTransition(for: $0, change: change) }
+    }
+
     private static func dimensionSort(_ lhs: RiskProfileDimension, _ rhs: RiskProfileDimension) -> Bool {
-        Self.sortIndex(for: lhs) < Self.sortIndex(for: rhs)
+        sortIndex(for: lhs) < sortIndex(for: rhs)
     }
 
     private static func sortIndex(for dimension: RiskProfileDimension) -> Int {
@@ -44,7 +51,7 @@ struct RiskChangeComposer: NotificationComposing {
         }
     }
 
-    private func formatTransition(for dimension: RiskProfileDimension, change: RiskProfileChange) -> String {
+    private static func formatTransition(for dimension: RiskProfileDimension, change: RiskProfileChange) -> String {
         switch dimension {
         case .storm:
             return "Storm Risk: \(stormText(change.previous.stormRisk)) → \(stormText(change.current.stormRisk))"
@@ -55,15 +62,15 @@ struct RiskChangeComposer: NotificationComposing {
         }
     }
 
-    private func stormText(_ level: StormRiskLevel) -> String {
+    private static func stormText(_ level: StormRiskLevel) -> String {
         level.message
     }
 
-    private func fireText(_ level: FireRiskLevel) -> String {
+    private static func fireText(_ level: FireRiskLevel) -> String {
         level.status
     }
 
-    private func severeText(_ threat: SevereWeatherThreat) -> String {
+    private static func severeText(_ threat: SevereWeatherThreat) -> String {
         switch threat {
         case .allClear:
             return "All Clear"
@@ -76,7 +83,7 @@ struct RiskChangeComposer: NotificationComposing {
         }
     }
 
-    private func percentText(_ probability: Double) -> String {
+    private static func percentText(_ probability: Double) -> String {
         guard probability.isFinite else {
             return "0%"
         }
@@ -85,7 +92,7 @@ struct RiskChangeComposer: NotificationComposing {
         return "\(wholePercent)%"
     }
 
-    private func sanitizedLocation(_ location: String?) -> String {
+    static func sanitizedLocation(_ location: String?) -> String {
         let trimmed = location?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard trimmed.isEmpty == false, trimmed.localizedCaseInsensitiveCompare("unknown") != .orderedSame else {
             return "your area"

--- a/Sources/Notifications/RiskChange/RiskChangeEngine.swift
+++ b/Sources/Notifications/RiskChange/RiskChangeEngine.swift
@@ -58,4 +58,10 @@ struct RiskChangeEngine: Sendable {
         }
         return didSchedule
     }
+
+    func coalesce(change: RiskProfileChange) async {
+        let context = RiskChangeContext(change: change)
+        guard let event = rule.evaluate(context) else { return }
+        await gate.coalesce(event: event)
+    }
 }

--- a/Sources/Notifications/RiskChange/RiskChangeGate.swift
+++ b/Sources/Notifications/RiskChange/RiskChangeGate.swift
@@ -88,6 +88,28 @@ actor RiskChangeGate {
         await persist()
     }
 
+    /// Records an occurrence that was delivered through a coalesced notification.
+    func coalesce(event: NotificationEvent, now: Date = .now) async {
+        await loadIfNeeded()
+        guard let change = event.payload["change"] as? RiskProfileChange else { return }
+        var didChange = purgeExpired(now: now)
+
+        for key in state.pending.keys where
+            state.pending[key]?.projectionKey == change.projectionKey && inFlightEventKeys.contains(key) == false {
+            state.pending.removeValue(forKey: key)
+            didChange = true
+        }
+
+        guard state.delivered[event.key] == nil else {
+            if didChange { await persist() }
+            return
+        }
+
+        state.delivered[event.key] = Tombstone(deliveredAt: now)
+        trimDeliveredTombstones()
+        await persist()
+    }
+
     /// Claims one pending occurrence. The claim is recorded before the sender is awaited.
     func claim(preferredEventKey: String?, isEnabled: Bool, now: Date = .now) async -> Delivery? {
         await loadIfNeeded()

--- a/Tests/UnitTests/BackgroundOrchestratorCadenceTests.swift
+++ b/Tests/UnitTests/BackgroundOrchestratorCadenceTests.swift
@@ -567,6 +567,50 @@ struct BackgroundOrchestratorCadenceTests {
         #expect((await riskSender.sent()).isEmpty)
     }
 
+    @Test("Coalesced risk change retires an older pending change for the same projection")
+    func coalescedRiskChangeRetiresOlderPendingChangeForSameProjection() async throws {
+        let morningSender = RecordingRiskSender()
+        let riskSender = RecordingRiskSender()
+        let settings = MutableSettingsProvider(
+            settings: .init(
+                morningSummariesEnabled: false,
+                mesoNotificationsEnabled: false,
+                riskChangeNotificationsEnabled: false
+            )
+        )
+        let projectionKey = "projection:alpha"
+        let first = Self.makeRiskSnapshot(
+            change: makeRiskChange(
+                projectionKey: projectionKey,
+                previous: makeRiskProfile(storm: .allClear, severe: .allClear, fire: .clear),
+                current: makeRiskProfile(storm: .marginal, severe: .allClear, fire: .clear)
+            )
+        )
+        let second = Self.makeRiskSnapshot(
+            change: makeRiskChange(
+                projectionKey: projectionKey,
+                previous: makeRiskProfile(storm: .marginal, severe: .allClear, fire: .clear),
+                current: makeRiskProfile(storm: .enhanced, severe: .allClear, fire: .clear)
+            )
+        )
+        let third = Self.makeRiskSnapshot(change: nil)
+        let system = try await makeRiskSystem(
+            snapshots: [first, second, third],
+            morningEngine: makeMorningEngine(sender: morningSender),
+            riskChangeEngine: makeRiskChangeEngine(sender: riskSender),
+            settingsProvider: settings
+        )
+
+        _ = await system.orchestrator.run()
+        await settings.update(.init(morningSummariesEnabled: true, mesoNotificationsEnabled: false))
+        _ = await system.orchestrator.run()
+        await settings.update(.init(morningSummariesEnabled: false, mesoNotificationsEnabled: false))
+        _ = await system.orchestrator.run()
+
+        #expect((await morningSender.sent()).count == 1)
+        #expect((await riskSender.sent()).isEmpty)
+    }
+
     @Test("Morning scheduling failure falls back to the current snapshot risk change")
     func morningSchedulingFailureFallsBackToRiskChange() async throws {
         let riskSender = RecordingRiskSender()

--- a/Tests/UnitTests/BackgroundOrchestratorCadenceTests.swift
+++ b/Tests/UnitTests/BackgroundOrchestratorCadenceTests.swift
@@ -478,12 +478,13 @@ struct BackgroundOrchestratorCadenceTests {
         #expect(health.reasonNoNotify?.contains("Risk change notification skipped (no change)") == true)
     }
 
-    @Test("Background refresh preserves an eligible risk change until enabled")
-    func backgroundRefresh_preservesEligibleRiskChangeUntilEnabled() async throws {
-        let sender = RecordingRiskSender()
+    @Test("Disabled risk changes remain pending after a normal morning summary")
+    func disabledRiskChangeRemainsPendingAfterNormalMorningSummary() async throws {
+        let morningSender = RecordingRiskSender()
+        let riskSender = RecordingRiskSender()
         let settingsProvider = MutableSettingsProvider(
             settings: .init(
-                morningSummariesEnabled: false,
+                morningSummariesEnabled: true,
                 mesoNotificationsEnabled: false,
                 riskChangeNotificationsEnabled: false
             )
@@ -514,13 +515,16 @@ struct BackgroundOrchestratorCadenceTests {
         )
         let system = try await makeRiskSystem(
             snapshots: [snapshot, unchangedSnapshot],
-            riskChangeEngine: makeRiskChangeEngine(sender: sender),
+            morningEngine: makeMorningEngine(sender: morningSender),
+            riskChangeEngine: makeRiskChangeEngine(sender: riskSender),
             settingsProvider: settingsProvider
         )
 
         let firstOutcome = await system.orchestrator.run()
-        #expect(firstOutcome.didNotify == false)
-        #expect(await sender.sent().isEmpty)
+        #expect(firstOutcome.didNotify)
+        let firstMorning = try #require(await morningSender.sent().first)
+        #expect(firstMorning.body.contains("Risk Update") == false)
+        #expect(await riskSender.sent().isEmpty)
 
         await settingsProvider.update(
             .init(
@@ -534,8 +538,122 @@ struct BackgroundOrchestratorCadenceTests {
         let health = try #require(await system.latestHealthRecord())
 
         #expect(secondOutcome.didNotify)
-        #expect(await sender.sent().count == 1)
+        #expect(await riskSender.sent().count == 1)
         #expect(health.didNotify)
+    }
+
+    @Test("Morning success coalesces the current snapshot risk change")
+    func morningSuccessCoalescesCurrentSnapshotRiskChange() async throws {
+        let morningSender = RecordingRiskSender()
+        let riskSender = RecordingRiskSender()
+        let settings = StaticSettingsProvider(
+            settings: .init(morningSummariesEnabled: true, mesoNotificationsEnabled: false)
+        )
+        let snapshot = Self.makeRiskSnapshot(
+            change: makeRiskChange(
+                previous: makeRiskProfile(storm: .marginal, severe: .allClear, fire: .clear),
+                current: makeRiskProfile(storm: .enhanced, severe: .allClear, fire: .clear)
+            )
+        )
+        let system = try await makeRiskSystem(
+            snapshot: snapshot,
+            morningEngine: makeMorningEngine(sender: morningSender),
+            riskChangeEngine: makeRiskChangeEngine(sender: riskSender),
+            settingsProvider: settings
+        )
+
+        #expect((await system.orchestrator.run()).didNotify)
+        #expect((await morningSender.sent()).count == 1)
+        #expect((await riskSender.sent()).isEmpty)
+    }
+
+    @Test("Morning scheduling failure falls back to the current snapshot risk change")
+    func morningSchedulingFailureFallsBackToRiskChange() async throws {
+        let riskSender = RecordingRiskSender()
+        let snapshot = Self.makeRiskSnapshot(
+            change: makeRiskChange(
+                previous: makeRiskProfile(storm: .marginal, severe: .allClear, fire: .clear),
+                current: makeRiskProfile(storm: .enhanced, severe: .allClear, fire: .clear)
+            )
+        )
+        let system = try await makeRiskSystem(
+            snapshot: snapshot,
+            morningEngine: makeMorningEngine(sender: FailingNotificationSender()),
+            riskChangeEngine: makeRiskChangeEngine(sender: riskSender),
+            settingsProvider: StaticSettingsProvider(
+                settings: .init(morningSummariesEnabled: true, mesoNotificationsEnabled: false)
+            )
+        )
+
+        #expect((await system.orchestrator.run()).didNotify)
+        #expect((await riskSender.sent()).count == 1)
+    }
+
+    @Test("Later risk transition remains independent after a coalesced morning")
+    func laterRiskTransitionRemainsIndependentAfterCoalescedMorning() async throws {
+        let morningSender = RecordingRiskSender()
+        let riskSender = RecordingRiskSender()
+        let first = Self.makeRiskSnapshot(
+            change: makeRiskChange(
+                projectionKey: "projection:one",
+                previous: makeRiskProfile(storm: .marginal, severe: .allClear, fire: .clear),
+                current: makeRiskProfile(storm: .enhanced, severe: .allClear, fire: .clear)
+            )
+        )
+        let second = Self.makeRiskSnapshot(
+            change: makeRiskChange(
+                projectionKey: "projection:two",
+                previous: makeRiskProfile(storm: .allClear, severe: .allClear, fire: .clear),
+                current: makeRiskProfile(storm: .slight, severe: .allClear, fire: .clear)
+            )
+        )
+        let system = try await makeRiskSystem(
+            snapshots: [first, second],
+            morningEngine: makeMorningEngine(sender: morningSender, gate: FirstMorningOnlyGate()),
+            riskChangeEngine: makeRiskChangeEngine(sender: riskSender),
+            settingsProvider: StaticSettingsProvider(
+                settings: .init(morningSummariesEnabled: true, mesoNotificationsEnabled: false)
+            )
+        )
+
+        _ = await system.orchestrator.run()
+        _ = await system.orchestrator.run()
+
+        #expect((await morningSender.sent()).count == 1)
+        #expect((await riskSender.sent()).count == 1)
+    }
+
+    @Test("Morning without a current change still delivers an older pending risk change")
+    func morningWithoutCurrentChangeDeliversOlderPendingRiskChange() async throws {
+        let morningSender = RecordingRiskSender()
+        let riskSender = RecordingRiskSender()
+        let settings = MutableSettingsProvider(
+            settings: .init(
+                morningSummariesEnabled: false,
+                mesoNotificationsEnabled: false,
+                riskChangeNotificationsEnabled: false
+            )
+        )
+        let first = Self.makeRiskSnapshot(
+            change: makeRiskChange(
+                previous: makeRiskProfile(storm: .marginal, severe: .allClear, fire: .clear),
+                current: makeRiskProfile(storm: .enhanced, severe: .allClear, fire: .clear)
+            )
+        )
+        let second = Self.makeRiskSnapshot(change: nil)
+        let system = try await makeRiskSystem(
+            snapshots: [first, second],
+            morningEngine: makeMorningEngine(sender: morningSender),
+            riskChangeEngine: makeRiskChangeEngine(sender: riskSender),
+            settingsProvider: settings
+        )
+
+        _ = await system.orchestrator.run()
+        await settings.update(.init(morningSummariesEnabled: true, mesoNotificationsEnabled: false))
+        _ = await system.orchestrator.run()
+
+        #expect((await morningSender.sent()).count == 1)
+        #expect((await riskSender.sent()).count == 1)
     }
 
     @Test("Missing location context records recovery cadence 20")
@@ -1244,6 +1362,7 @@ private extension BackgroundOrchestratorCadenceTests {
 
     func makeRiskSystem<Settings: NotificationSettingsProviding>(
         coordinator: any HomeIngestionCoordinating,
+        morningEngine: MorningEngine? = nil,
         riskChangeEngine: RiskChangeEngine,
         settingsProvider: Settings
     ) async throws -> RiskSystem {
@@ -1254,7 +1373,7 @@ private extension BackgroundOrchestratorCadenceTests {
         let orchestrator = BackgroundOrchestrator(
             coordinator: coordinator,
             policy: RefreshPolicy(),
-            engine: MorningEngine(
+            engine: morningEngine ?? MorningEngine(
                 rule: NoopMorningRule(),
                 gate: AllowAllGate(),
                 composer: NoopComposer(),
@@ -1280,6 +1399,7 @@ private extension BackgroundOrchestratorCadenceTests {
     func makeRiskSystem<Settings: NotificationSettingsProviding>(
         snapshot: HomeSnapshot? = nil,
         snapshots: [HomeSnapshot]? = nil,
+        morningEngine: MorningEngine? = nil,
         riskChangeEngine: RiskChangeEngine,
         settingsProvider: Settings
     ) async throws -> RiskSystem {
@@ -1291,6 +1411,7 @@ private extension BackgroundOrchestratorCadenceTests {
         }
         return try await makeRiskSystem(
             coordinator: coordinator,
+            morningEngine: morningEngine,
             riskChangeEngine: riskChangeEngine,
             settingsProvider: settingsProvider
         )
@@ -1329,6 +1450,34 @@ private extension BackgroundOrchestratorCadenceTests {
     ) -> RiskProfile {
         RiskProfile(stormRisk: storm, severeRisk: severe, fireRisk: fire)
     }
+
+    func makeMorningEngine<Sender: NotificationSending>(
+        sender: Sender,
+        gate: any NotificationGating = AllowAllGate()
+    ) -> MorningEngine {
+        MorningEngine(
+            rule: AmRangeLocalRule(window: 0..<24),
+            gate: gate,
+            composer: MorningComposer(),
+            sender: sender
+        )
+    }
+
+    static func makeRiskSnapshot(change: RiskProfileChange?) -> HomeSnapshot {
+        let context = makeContext(
+            coordinates: CLLocationCoordinate2D(latitude: 39.7392, longitude: -104.9903),
+            timestamp: Date(),
+            placemarkSummary: "Denver, CO"
+        )
+        return HomeSnapshot(
+            locationSnapshot: context.snapshot,
+            refreshKey: context.refreshKey,
+            stormRisk: change?.current.stormRisk ?? .enhanced,
+            severeRisk: change?.current.severeRisk ?? .allClear,
+            fireRisk: change?.current.fireRisk ?? .clear,
+            riskProfileChange: change
+        )
+    }
 }
 
 private struct NoopMorningRule: NotificationRuleEvaluating {
@@ -1357,6 +1506,19 @@ private struct NoopComposer: NotificationComposing {
 
 private struct NoopSender: NotificationSending {
     func send(title: String, body: String, subtitle: String, id: String) async -> Bool { true }
+}
+
+private struct FailingNotificationSender: NotificationSending {
+    func send(title: String, body: String, subtitle: String, id: String) async -> Bool { false }
+}
+
+private actor FirstMorningOnlyGate: NotificationGating {
+    private var hasAllowed = false
+
+    func allow(_ event: NotificationEvent, now: Date) async -> Bool {
+        defer { hasAllowed = true }
+        return hasAllowed == false
+    }
 }
 
 private func waitUntil(

--- a/Tests/UnitTests/MorningNotificationTests.swift
+++ b/Tests/UnitTests/MorningNotificationTests.swift
@@ -99,6 +99,74 @@ struct MorningNotificationTests {
         #expect(secondPass == false)
     }
 
+    @Test("composer preserves the normal morning summary without a risk change")
+    func composerPreservesNormalMorningSummaryWithoutRiskChange() {
+        let message = MorningComposer().compose(
+            NotificationEvent(
+                kind: .morningOutlook,
+                key: "morning:2026-01-02",
+                payload: [
+                    "stormRisk": StormRiskLevel.slight,
+                    "severeRisk": SevereWeatherThreat.tornado(probability: 0.3),
+                    "fireRisk": FireRiskLevel.clear,
+                    "placeMark": "Oklahoma City, OK"
+                ]
+            )
+        )
+
+        #expect(message.title == "Today's Outlook for Oklahoma City, OK")
+        #expect(message.body == """
+        Storm Activity: Chance for a few strong storms
+        Severe Activity: Tornados are possible
+        Fire Risk: No elevated fire weather risk is forecast.
+        """)
+    }
+
+    @Test("composer adds deterministic risk transitions before the morning outlook")
+    func composerAddsRiskTransitionsBeforeMorningOutlook() throws {
+        let change = try #require(
+            RiskProfileChange(
+                previous: .init(
+                    stormRisk: .marginal,
+                    severeRisk: .wind(probability: 0.12),
+                    fireRisk: .clear
+                ),
+                current: .init(
+                    stormRisk: .enhanced,
+                    severeRisk: .tornado(probability: 0.31),
+                    fireRisk: .critical
+                ),
+                projectionKey: "projection:okc",
+                locationSummary: "Oklahoma City, OK",
+                occurrenceID: "morning-transition"
+            )
+        )
+        let message = MorningComposer().compose(
+            NotificationEvent(
+                kind: .morningOutlook,
+                key: "morning:2026-01-02",
+                payload: [
+                    "stormRisk": StormRiskLevel.enhanced,
+                    "severeRisk": SevereWeatherThreat.tornado(probability: 0.31),
+                    "fireRisk": FireRiskLevel.critical,
+                    "placeMark": "Oklahoma City, OK",
+                    "riskProfileChange": change
+                ]
+            )
+        )
+
+        #expect(message.body == """
+        Risk Update
+        Storm Risk: Marginal Risk → Enhanced Risk
+        Severe Risk: Wind 12% → Tornado 31%
+        Fire Risk: Clear → Critical
+
+        Storm Activity: Several severe storms are possible
+        Severe Activity: Tornados are possible
+        Fire Risk: Dry fuels, strong winds, and very low humidity could allow any fire that starts to spread rapidly.
+        """)
+    }
+
     @Test("engine reports scheduling failure")
     func engineReportsSchedulingFailure() async {
         let now = makeDate(year: 2026, month: 1, day: 2, hour: 8, tz: centralTime)

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -53,3 +53,5 @@
   failures retry at 20, but the next successful run must authoritatively restore the condition-appropriate band.
 - When coalescing one notification channel into another, include the source channel's preference in the coalescing
   predicate. A disabled delivery must remain pending rather than becoming unrequested content in the alternate channel.
+- Coalescing a newer occurrence must pass through the delivery gate's supersession logic; otherwise a stale pending
+  occurrence for the same projection can escape immediately after the combined notification.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -51,3 +51,5 @@
 - For background cadence work, preserve the established 20/40/60-minute bands: marginal-or-higher categorical risk,
   active alerts, or active mesos use 20 minutes; thunderstorm-only uses 40; all-clear uses 60. Missing context and
   failures retry at 20, but the next successful run must authoritatively restore the condition-appropriate band.
+- When coalescing one notification channel into another, include the source channel's preference in the coalescing
+  predicate. A disabled delivery must remain pending rather than becoming unrequested content in the alternate channel.


### PR DESCRIPTION
# Summary
This branch makes morning notifications absorb the current risk-profile change when the summary successfully sends, so users get one combined message instead of two back-to-back notifications. It also preserves the standalone risk-change path when morning delivery fails or when the change is unrelated to that morning run.

# What Changed
- Added `riskProfileChange` to the morning notification context and payload when a current change is present.
- Updated the morning composer to prepend deterministic risk-transition lines before the normal outlook body.
- Changed the background orchestrator to skip the standalone risk-change notification when a morning summary already delivered the same current change, while preserving the fallback when morning delivery fails.
- Extracted shared risk-transition formatting so morning and risk-change notifications use the same ordering and wording.
- Expanded unit coverage for morning composition and background cadence edge cases.
- Updated `tasks/lessons.md` with the notification-coalescing lesson.

# User Impact
Users now see one consolidated morning notification when a fresh risk change coincides with the daily outlook, which reduces duplicate alerts and makes the transition more obvious. If the morning notification cannot be sent, the separate risk-change notification still goes out instead.

# Testing
- `xcodebuild -project SkyAware.xcodeproj -scheme SkyAware -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2" -only-testing:SkyAwareTests/MorningNotificationTests -only-testing:SkyAwareTests/BackgroundOrchestratorCadenceTests test`
- Focused unit tests passed, including the new coalescing and fallback cases.

# Notes
- `tasks/lessons.md` was updated alongside the code.