### PR TITLE
Preserve polygon holes in map rendering and storm risk lookup

### DIFF
--- a/Sources/Features/Map/MapPolygonMapper.swift
+++ b/Sources/Features/Map/MapPolygonMapper.swift
@@ -13,10 +13,34 @@ struct MapPolygonEntry: Sendable {
     let title: String?
     let subtitle: String?
     let coordinates: [Coordinate2D]
+    let interiorCoordinates: [[Coordinate2D]]
+
+    init(
+        key: String,
+        title: String?,
+        subtitle: String?,
+        coordinates: [Coordinate2D],
+        interiorCoordinates: [[Coordinate2D]] = []
+    ) {
+        self.key = key
+        self.title = title
+        self.subtitle = subtitle
+        self.coordinates = coordinates
+        self.interiorCoordinates = interiorCoordinates
+    }
 
     var polygon: MKPolygon {
-        let ringCoordinates = coordinates.map(\.location)
-        let polygon = MKPolygon(coordinates: ringCoordinates, count: ringCoordinates.count)
+        let interiorPolygons = interiorCoordinates.compactMap { interiorCoordinates -> MKPolygon? in
+            guard interiorCoordinates.count > 2 else { return nil }
+            var ringCoordinates = interiorCoordinates.map(\.location)
+            return MKPolygon(coordinates: &ringCoordinates, count: ringCoordinates.count)
+        }
+        var ringCoordinates = coordinates.map(\.location)
+        let polygon = MKPolygon(
+            coordinates: &ringCoordinates,
+            count: ringCoordinates.count,
+            interiorPolygons: interiorPolygons
+        )
         polygon.title = title
         polygon.subtitle = subtitle
         return polygon
@@ -61,7 +85,8 @@ struct MapPolygonMapper: Sendable {
                         key: "cat|\(risk.riskLevel.rawValue)|\(Int(risk.issued.timeIntervalSince1970))|\(polygonFingerprint(for: polygon))",
                         title: polygon.title,
                         subtitle: subtitle,
-                        coordinates: polygon.coordinates
+                        coordinates: polygon.coordinates,
+                        interiorCoordinates: polygon.interiorCoordinates
                     )
                 }
             }
@@ -113,7 +138,8 @@ struct MapPolygonMapper: Sendable {
                         key: "fire|\(fire.riskLevel)|\(Int(fire.issued.timeIntervalSince1970))|\(polygonFingerprint(for: polygon))",
                         title: polygon.title,
                         subtitle: subtitle,
-                        coordinates: polygon.coordinates
+                        coordinates: polygon.coordinates,
+                        interiorCoordinates: polygon.interiorCoordinates
                     )
                 }
             }
@@ -193,7 +219,8 @@ struct MapPolygonMapper: Sendable {
                     key: "sev|\(type.rawValue)|\(probabilityKey)|\(labelKey)|\(polygonFingerprint(for: polygon))",
                     title: polygon.title,
                     subtitle: subtitle,
-                    coordinates: polygon.coordinates
+                    coordinates: polygon.coordinates,
+                    interiorCoordinates: polygon.interiorCoordinates
                 )
             }
         }
@@ -207,16 +234,32 @@ struct MapPolygonMapper: Sendable {
     }
 
     private func polygonFingerprint(for polygon: GeoPolygonEntity) -> String {
-        polygonFingerprint(title: polygon.title, coordinates: polygon.coordinates)
+        polygonFingerprint(
+            title: polygon.title,
+            coordinates: polygon.coordinates,
+            interiorCoordinates: polygon.interiorCoordinates
+        )
     }
 
-    private func polygonFingerprint(title: String, coordinates: [Coordinate2D]) -> String {
+    private func polygonFingerprint(
+        title: String,
+        coordinates: [Coordinate2D],
+        interiorCoordinates: [[Coordinate2D]] = []
+    ) -> String {
         var hasher = StableMapHasher()
         hasher.combine(title)
         hasher.combine(coordinates.count)
 
         for coordinate in coordinates {
             hasher.combine(coordinate)
+        }
+
+        hasher.combine(interiorCoordinates.count)
+        for interiorRing in interiorCoordinates {
+            hasher.combine(interiorRing.count)
+            for coordinate in interiorRing {
+                hasher.combine(coordinate)
+            }
         }
 
         return hasher.hexString

--- a/Sources/Features/Map/RiskPolygonRenderer.swift
+++ b/Sources/Features/Map/RiskPolygonRenderer.swift
@@ -53,7 +53,7 @@ final class RiskPolygonRenderer: MKOverlayPathRenderer {
         if riskOverlay.fillColor.cgColor.alpha > 0 {
             context.addPath(path)
             context.setFillColor(riskOverlay.fillColor.cgColor)
-            context.fillPath()
+            context.drawPath(using: .eoFill)
         }
 
         context.addPath(path)
@@ -80,7 +80,7 @@ final class RiskPolygonRenderer: MKOverlayPathRenderer {
         if softFill.cgColor.alpha > 0 {
             context.addPath(path)
             context.setFillColor(softFill.cgColor)
-            context.fillPath()
+            context.drawPath(using: .eoFill)
         }
 
         let outlineColor = riskOverlay.strokeColor.withAlphaComponent(0.45)

--- a/Sources/Infrastructure/Parsing/GeoJSON/GeoJSONModels.swift
+++ b/Sources/Infrastructure/Parsing/GeoJSON/GeoJSONModels.swift
@@ -93,24 +93,51 @@ extension GeoJSONFeatureCollection {
 extension GeoJSONFeature {
     var materialPolygonCount: Int {
         guard geometry.type == "MultiPolygon" else { return 0 }
-        return geometry.coordinates.reduce(into: 0) { count, polygonGroup in
-            count += polygonGroup.count
-        }
+        return geometry.coordinates.count { coordinateRings(from: $0) != nil }
     }
 
-    /// Creates GeoPolygonEntity objects from the polygon rings
+    /// Creates GeoPolygonEntity objects from MultiPolygon members.
     /// - Parameter polyTitle: the title to assign to each GeoPolygonEntity
     /// - Returns: Array of GeoPolygonEntity instances
     func createPolygonEntities(polyTitle: String) -> [GeoPolygonEntity] {
         guard geometry.type == "MultiPolygon" else { return [] }
         
-        return geometry.coordinates.flatMap { polygonGroup in
-            polygonGroup.map { ring in
-                let coords: [Coordinate2D] = ring.map { pair in
-                    Coordinate2D(latitude: pair[1], longitude: pair[0])
-                }
-                return GeoPolygonEntity(title: polyTitle, coordinates: coords)
+        return geometry.coordinates.compactMap { polygonGroup in
+            guard let coordinateRings = coordinateRings(from: polygonGroup) else {
+                return nil
             }
+
+            return GeoPolygonEntity(
+                title: polyTitle,
+                coordinates: coordinateRings[0],
+                interiorCoordinates: Array(coordinateRings.dropFirst())
+            )
         }
+    }
+
+    private func coordinateRings(from polygonGroup: [[[Double]]]) -> [[Coordinate2D]]? {
+        guard !polygonGroup.isEmpty else { return nil }
+
+        let coordinateRings = polygonGroup.compactMap(coordinates(from:))
+        guard coordinateRings.count == polygonGroup.count else { return nil }
+        return coordinateRings
+    }
+
+    private func coordinates(from ring: [[Double]]) -> [Coordinate2D]? {
+        guard ring.count >= 3 else { return nil }
+
+        var coordinates: [Coordinate2D] = []
+        coordinates.reserveCapacity(ring.count)
+
+        for position in ring {
+            guard position.count >= 2,
+                  position[0].isFinite,
+                  position[1].isFinite else {
+                return nil
+            }
+            coordinates.append(Coordinate2D(latitude: position[1], longitude: position[0]))
+        }
+
+        return coordinates
     }
 }

--- a/Sources/Repos/FireRiskRepo.swift
+++ b/Sources/Repos/FireRiskRepo.swift
@@ -33,16 +33,12 @@ actor FireRiskRepo {
             // Sort by descending risk so we can early-exit on first hit.
             let bySeverity = latestRisks.sorted { $0.riskLevel > $1.riskLevel }
     
-            // 3) For each risk, check polygons with optional bbox prefilter, then precise hit test
             for risk in bySeverity {
                 for poly in risk.polygons {
                     // Coarse bbox prefilter if available
                     if let bbox = poly.bbox, bbox.contains(point) == false { continue }
-    
-                    // Precise hit test on ring coordinates
-                    let ring = poly.ringCoordinates
-                    guard !ring.isEmpty else { continue }
-                    if MesoGeometry.contains(point, inRing: ring) {
+
+                    if poly.contains(point) {
                         switch risk.riskLevel {
                         case 5: return .elevated
                         case 8: return .critical

--- a/Sources/Repos/SevereRiskRepo.swift
+++ b/Sources/Repos/SevereRiskRepo.swift
@@ -88,7 +88,6 @@ actor SevereRiskRepo {
             return lhs.key > rhs.key
         }
 
-        // 3) For each risk, check polygons with optional bbox prefilter, then precise hit test
         for risk in bySeverity {
             for poly in risk.polygons {
                 // Coarse bbox prefilter if available
@@ -96,10 +95,7 @@ actor SevereRiskRepo {
                     continue
                 }
 
-                // Precise hit test on ring coordinates
-                let ring = poly.ringCoordinates
-                guard !ring.isEmpty else { continue }
-                if MesoGeometry.contains(point, inRing: ring) {
+                if poly.contains(point) {
                     return risk.threatLevel
                 }
             }

--- a/Sources/Repos/StormRiskRepo.swift
+++ b/Sources/Repos/StormRiskRepo.swift
@@ -35,16 +35,12 @@ actor StormRiskRepo {
         // Sort by descending risk so we can early-exit on first hit.
         let bySeverity = latestRisks.sorted { $0.riskLevel > $1.riskLevel }
     
-//         3) For each risk, check polygons with optional bbox prefilter, then precise hit test
         for risk in bySeverity {
             for poly in risk.polygons {
                 // Coarse bbox prefilter if available
                 if let bbox = poly.bbox, bbox.contains(point) == false { continue }
                 
-                // Precise hit test on ring coordinates
-                let ring = poly.ringCoordinates
-                guard !ring.isEmpty else { continue }
-                if MesoGeometry.contains(point, inRing: ring) {
+                if poly.contains(point) {
                     return risk.riskLevel
                 }
             }

--- a/Sources/Utilities/Geometry/GeoPolygonEntity.swift
+++ b/Sources/Utilities/Geometry/GeoPolygonEntity.swift
@@ -75,4 +75,12 @@ extension GeoPolygonEntity {
     nonisolated var ringCoordinates: [CLLocationCoordinate2D] {
         coordinates.map { $0.location }
     }
+
+    nonisolated func contains(_ point: CLLocationCoordinate2D) -> Bool {
+        guard MesoGeometry.contains(point, inRing: ringCoordinates) else { return false }
+
+        return interiorCoordinates.allSatisfy { interiorRing in
+            MesoGeometry.contains(point, inRing: interiorRing.map(\.location)) == false
+        }
+    }
 }

--- a/Sources/Utilities/Geometry/GeoPolygonEntity.swift
+++ b/Sources/Utilities/Geometry/GeoPolygonEntity.swift
@@ -10,16 +10,22 @@ import CoreLocation
 
 struct GeoPolygonEntity: Sendable, Codable {
     var title: String
-    var coordinates: [Coordinate2D] // Use Coordinate2D from elsewhere in the project
+    var coordinates: [Coordinate2D]
+    var interiorCoordinates: [[Coordinate2D]]
     
     var minLat: Double?
     var maxLat: Double?
     var minLon: Double?
     var maxLon: Double?
     
-    init(title: String, coordinates: [Coordinate2D]) {
+    init(
+        title: String,
+        coordinates: [Coordinate2D],
+        interiorCoordinates: [[Coordinate2D]] = []
+    ) {
         self.title = title
         self.coordinates = coordinates
+        self.interiorCoordinates = interiorCoordinates
         
         if !coordinates.isEmpty {
             let lats = coordinates.map(\.latitude)
@@ -35,6 +41,27 @@ struct GeoPolygonEntity: Sendable, Codable {
             self.minLon = nil
             self.maxLon = nil
         }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case title
+        case coordinates
+        case interiorCoordinates
+        case minLat
+        case maxLat
+        case minLon
+        case maxLon
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        title = try container.decode(String.self, forKey: .title)
+        coordinates = try container.decode([Coordinate2D].self, forKey: .coordinates)
+        interiorCoordinates = try container.decodeIfPresent([[Coordinate2D]].self, forKey: .interiorCoordinates) ?? []
+        minLat = try container.decodeIfPresent(Double.self, forKey: .minLat)
+        maxLat = try container.decodeIfPresent(Double.self, forKey: .maxLat)
+        minLon = try container.decodeIfPresent(Double.self, forKey: .minLon)
+        maxLon = try container.decodeIfPresent(Double.self, forKey: .maxLon)
     }
 }
 

--- a/Tests/UnitTests/GeoJsonParserTests.swift
+++ b/Tests/UnitTests/GeoJsonParserTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftData
 import Testing
 @testable import SkyAware
 
@@ -108,7 +109,7 @@ struct GeoJsonParserTests {
         #expect(decoded.features.isEmpty)
     }
 
-    @Test("createPolygonEntities returns entities for each ring in MultiPolygon")
+    @Test("createPolygonEntities returns entities for each MultiPolygon member")
     func createPolygonEntities_multiPolygon() throws {
         let data = try #require(validGeoJson.data(using: .utf8))
         let decoded: GeoJSONFeatureCollection = try #require(
@@ -124,6 +125,103 @@ struct GeoJsonParserTests {
         #expect(first.coordinates.count == 3)
         #expect(first.coordinates.first?.latitude == 35.0)
         #expect(first.coordinates.first?.longitude == -97.0)
+    }
+
+    @Test("createPolygonEntities preserves interior rings for each MultiPolygon member")
+    func createPolygonEntities_preservesInteriorRings() {
+        let feature = makeFeature(
+            coordinates: [
+                [
+                    ring(longitude: -100, latitude: 40),
+                    ring(longitude: -99.8, latitude: 40.2),
+                    ring(longitude: -99.6, latitude: 40.4)
+                ],
+                [
+                    ring(longitude: -90, latitude: 30)
+                ]
+            ]
+        )
+
+        let entities = feature.createPolygonEntities(polyTitle: "TSTM")
+
+        #expect(entities.count == 2)
+        #expect(entities[0].coordinates.count == 3)
+        #expect(entities[0].interiorCoordinates.count == 2)
+        #expect(entities[0].interiorCoordinates.allSatisfy { $0.count == 3 })
+        #expect(entities[1].interiorCoordinates.isEmpty)
+        #expect(feature.materialPolygonCount == 2)
+    }
+
+    @Test("legacy GeoPolygonEntity data defaults missing interior rings to empty")
+    func geoPolygonEntity_legacyDataDefaultsInteriorRings() throws {
+        let data = try #require(
+            """
+            {
+              "title": "Legacy",
+              "coordinates": [
+                { "latitude": 35.0, "longitude": -97.0 },
+                { "latitude": 35.1, "longitude": -96.9 },
+                { "latitude": 35.2, "longitude": -97.1 }
+              ],
+              "minLat": 35.0,
+              "maxLat": 35.2,
+              "minLon": -97.1,
+              "maxLon": -96.9
+            }
+            """.data(using: .utf8)
+        )
+
+        let polygon = try JSONDecoder().decode(GeoPolygonEntity.self, from: data)
+
+        #expect(polygon.interiorCoordinates.isEmpty)
+    }
+
+    @MainActor
+    @Test("SwiftData save and reopen preserves interior rings")
+    func geoPolygonEntity_swiftDataRoundTripPreservesInteriorRings() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GeoJsonParserTests")
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let schema = Schema([StormRisk.self])
+        let storeURL = root.appendingPathComponent("SkyAware_Data.sqlite")
+        let configuration = ModelConfiguration("SkyAware_Data", schema: schema, url: storeURL)
+        let polygon = GeoPolygonEntity(
+            title: "TSTM",
+            coordinates: ring(longitude: -100, latitude: 40).map { pair in
+                Coordinate2D(latitude: pair[1], longitude: pair[0])
+            },
+            interiorCoordinates: [ring(longitude: -99.8, latitude: 40.2).map { pair in
+                Coordinate2D(latitude: pair[1], longitude: pair[0])
+            }]
+        )
+
+        do {
+            let container = try ModelContainer(for: schema, configurations: configuration)
+            let context = ModelContext(container)
+            context.insert(
+                StormRisk(
+                    riskLevel: .thunderstorm,
+                    issued: .now,
+                    expires: .now.addingTimeInterval(3_600),
+                    valid: .now,
+                    stroke: nil,
+                    fill: nil,
+                    polygons: [polygon]
+                )
+            )
+            try context.save()
+        }
+
+        let reopenedContainer = try ModelContainer(for: schema, configurations: configuration)
+        let persisted = try #require(
+            ModelContext(reopenedContainer).fetch(FetchDescriptor<StormRisk>()).first
+        )
+
+        #expect(persisted.polygons.count == 1)
+        #expect(persisted.polygons[0].interiorCoordinates == polygon.interiorCoordinates)
     }
 
     @Test("createPolygonEntities returns empty for non-MultiPolygon geometry")
@@ -159,5 +257,30 @@ struct GeoJsonParserTests {
         #expect(feature.materialPolygonCount == 0)
         #expect(feature.createPolygonEntities(polyTitle: "No Areas").isEmpty)
         #expect(feature.properties.LABEL == "No Areas")
+    }
+
+    private func makeFeature(coordinates: [[[[Double]]]]) -> GeoJSONFeature {
+        GeoJSONFeature(
+            type: "Feature",
+            geometry: GeoJSONGeometry(type: "MultiPolygon", coordinates: coordinates),
+            properties: GeoJSONProperties(
+                DN: 1,
+                VALID: "2026-01-01T12:00:00Z",
+                EXPIRE: "2026-01-01T18:00:00Z",
+                ISSUE: "2026-01-01T11:55:00Z",
+                LABEL: "TSTM",
+                LABEL2: "General Thunderstorms Risk",
+                stroke: "#000000",
+                fill: "#111111"
+            )
+        )
+    }
+
+    private func ring(longitude: Double, latitude: Double) -> [[Double]] {
+        [
+            [longitude, latitude],
+            [longitude + 0.1, latitude],
+            [longitude, latitude + 0.1]
+        ]
     }
 }

--- a/Tests/UnitTests/MapDataFreshnessRepoTests.swift
+++ b/Tests/UnitTests/MapDataFreshnessRepoTests.swift
@@ -232,6 +232,109 @@ struct MapDataFreshnessRepoTests {
         #expect(active == .allClear)
     }
 
+    @MainActor
+    @Test("Categorical active lookup matches points inside an exterior and outside its holes")
+    func stormActiveMatchesExteriorOutsideHoles() async throws {
+        let container = try TestStore.container(for: [StormRisk.self])
+        let repo = StormRiskRepo(modelContainer: container)
+        let polygon = GeoPolygonEntity(
+            title: "Slight",
+            coordinates: squareRing(longitude: -100, latitude: 40, size: 10),
+            interiorCoordinates: [squareRing(longitude: -96, latitude: 44, size: 2)]
+        )
+
+        try insertActiveStormRisks([makeActiveStormRisk(level: .slight, polygons: [polygon])], in: container)
+
+        let active = try await repo.active(
+            asOf: activeStormRiskAsOf,
+            for: CLLocationCoordinate2D(latitude: 42, longitude: -98)
+        )
+        #expect(active == .slight)
+    }
+
+    @MainActor
+    @Test("Categorical active lookup excludes every interior hole and exterior misses")
+    func stormActiveExcludesInteriorHolesAndExteriorMisses() async throws {
+        let container = try TestStore.container(for: [StormRisk.self])
+        let repo = StormRiskRepo(modelContainer: container)
+        let polygon = GeoPolygonEntity(
+            title: "Enhanced",
+            coordinates: squareRing(longitude: -100, latitude: 40, size: 10),
+            interiorCoordinates: [
+                squareRing(longitude: -98, latitude: 42, size: 2),
+                squareRing(longitude: -94, latitude: 46, size: 2)
+            ]
+        )
+
+        try insertActiveStormRisks([makeActiveStormRisk(level: .enhanced, polygons: [polygon])], in: container)
+
+        let firstHole = try await repo.active(
+            asOf: activeStormRiskAsOf,
+            for: CLLocationCoordinate2D(latitude: 43, longitude: -97)
+        )
+        let secondHole = try await repo.active(
+            asOf: activeStormRiskAsOf,
+            for: CLLocationCoordinate2D(latitude: 47, longitude: -93)
+        )
+        let exteriorMiss = try await repo.active(
+            asOf: activeStormRiskAsOf,
+            for: CLLocationCoordinate2D(latitude: 52, longitude: -98)
+        )
+
+        #expect(firstHole == .allClear)
+        #expect(secondHole == .allClear)
+        #expect(exteriorMiss == .allClear)
+    }
+
+    @MainActor
+    @Test("Categorical active lookup continues after a higher-risk hole")
+    func stormActiveFallsBackToLowerRiskOutsideHigherRiskHole() async throws {
+        let container = try TestStore.container(for: [StormRisk.self])
+        let repo = StormRiskRepo(modelContainer: container)
+        let higherRisk = GeoPolygonEntity(
+            title: "Enhanced",
+            coordinates: squareRing(longitude: -100, latitude: 40, size: 10),
+            interiorCoordinates: [squareRing(longitude: -97, latitude: 43, size: 2)]
+        )
+        let lowerRisk = GeoPolygonEntity(
+            title: "Slight",
+            coordinates: squareRing(longitude: -98, latitude: 42, size: 4)
+        )
+
+        try insertActiveStormRisks(
+            [
+                makeActiveStormRisk(level: .enhanced, polygons: [higherRisk]),
+                makeActiveStormRisk(level: .slight, polygons: [lowerRisk])
+            ],
+            in: container
+        )
+
+        let active = try await repo.active(
+            asOf: activeStormRiskAsOf,
+            for: CLLocationCoordinate2D(latitude: 44, longitude: -96)
+        )
+        #expect(active == .slight)
+    }
+
+    @MainActor
+    @Test("Categorical active lookup preserves single-ring polygon behavior")
+    func stormActiveMatchesSingleRingPolygon() async throws {
+        let container = try TestStore.container(for: [StormRisk.self])
+        let repo = StormRiskRepo(modelContainer: container)
+        let polygon = GeoPolygonEntity(
+            title: "Marginal",
+            coordinates: squareRing(longitude: -100, latitude: 40, size: 10)
+        )
+
+        try insertActiveStormRisks([makeActiveStormRisk(level: .marginal, polygons: [polygon])], in: container)
+
+        let active = try await repo.active(
+            asOf: activeStormRiskAsOf,
+            for: CLLocationCoordinate2D(latitude: 45, longitude: -95)
+        )
+        #expect(active == .marginal)
+    }
+
     @Test("Severe map returns newest issuance per type and probability bucket")
     func severeMapReturnsNewestIssuancePerBucket() async throws {
         let container = try await MainActor.run { try TestStore.container(for: [SevereRisk.self]) }
@@ -492,4 +595,37 @@ private func makePolygon(squareAtLonLat origin: (Double, Double), size: Double) 
             Coordinate2D(latitude: lat, longitude: lon)
         ]
     )
+}
+
+private let activeStormRiskAsOf = makeUTCDate(2026, 3, 1, 12, 0)
+
+private func makeActiveStormRisk(level: StormRiskLevel, polygons: [GeoPolygonEntity]) -> StormRisk {
+    StormRisk(
+        riskLevel: level,
+        issued: makeUTCDate(2026, 3, 1, 11, 0),
+        expires: makeUTCDate(2026, 3, 1, 20, 0),
+        valid: makeUTCDate(2026, 3, 1, 8, 0),
+        stroke: nil,
+        fill: nil,
+        polygons: polygons
+    )
+}
+
+@MainActor
+private func insertActiveStormRisks(_ risks: [StormRisk], in container: ModelContainer) throws {
+    let context = ModelContext(container)
+    for risk in risks {
+        context.insert(risk)
+    }
+    try context.save()
+}
+
+private func squareRing(longitude: Double, latitude: Double, size: Double) -> [Coordinate2D] {
+    [
+        Coordinate2D(latitude: latitude, longitude: longitude),
+        Coordinate2D(latitude: latitude + size, longitude: longitude),
+        Coordinate2D(latitude: latitude + size, longitude: longitude + size),
+        Coordinate2D(latitude: latitude, longitude: longitude + size),
+        Coordinate2D(latitude: latitude, longitude: longitude)
+    ]
 }

--- a/Tests/UnitTests/MapDataFreshnessRepoTests.swift
+++ b/Tests/UnitTests/MapDataFreshnessRepoTests.swift
@@ -102,6 +102,46 @@ struct MapDataFreshnessRepoTests {
         #expect(results.map(\.riskLevel) == [8])
     }
 
+    @MainActor
+    @Test("Fire active lookup excludes interior holes")
+    func fireActiveLookupExcludesInteriorHoles() async throws {
+        let container = try TestStore.container(for: [FireRisk.self])
+        let repo = FireRiskRepo(modelContainer: container)
+        let polygon = GeoPolygonEntity(
+            title: "Critical",
+            coordinates: squareRing(longitude: -100, latitude: 40, size: 4),
+            interiorCoordinates: [squareRing(longitude: -98.5, latitude: 41.5, size: 1)]
+        )
+        let asOf = makeUTCDate(2026, 3, 1, 12, 0)
+        let context = ModelContext(container)
+        context.insert(
+            FireRisk(
+                product: "FireRH",
+                issued: makeUTCDate(2026, 3, 1, 11, 0),
+                expires: makeUTCDate(2026, 3, 1, 20, 0),
+                valid: makeUTCDate(2026, 3, 1, 8, 0),
+                riskLevel: 8,
+                label: "Critical",
+                stroke: nil,
+                fill: nil,
+                polygons: [polygon]
+            )
+        )
+        try context.save()
+
+        let hole = try await repo.active(
+            asOf: asOf,
+            for: CLLocationCoordinate2D(latitude: 42.0, longitude: -98.0)
+        )
+        let exterior = try await repo.active(
+            asOf: asOf,
+            for: CLLocationCoordinate2D(latitude: 40.5, longitude: -99.5)
+        )
+
+        #expect(hole == .clear)
+        #expect(exterior == .critical)
+    }
+
     @Test("Categorical map returns only the newest valid issuance")
     func stormMapReturnsOnlyNewestValidIssuance() async throws {
         let container = try await MainActor.run { try TestStore.container(for: [StormRisk.self]) }

--- a/Tests/UnitTests/MapPolygonMapperTests.swift
+++ b/Tests/UnitTests/MapPolygonMapperTests.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import ArcusCore
+import MapKit
 import Testing
 import UIKit
 @testable import SkyAware
@@ -63,6 +64,70 @@ struct MapPolygonMapperTests {
         let secondKeys = second.keyedPolygons.map(\.key)
         #expect(firstKeys == secondKeys)
         #expect(Set(firstKeys).count == firstKeys.count)
+    }
+
+    @Test("MapPolygonMapper carries interior rings into MKPolygon and its stable key")
+    func polygonMapping_preservesInteriorRingsAndInvalidatesKey() throws {
+        let exterior = [
+            Coordinate2D(latitude: 35.0, longitude: -97.0),
+            Coordinate2D(latitude: 35.3, longitude: -97.0),
+            Coordinate2D(latitude: 35.0, longitude: -96.7)
+        ]
+        let firstHole = [
+            Coordinate2D(latitude: 35.05, longitude: -96.95),
+            Coordinate2D(latitude: 35.10, longitude: -96.95),
+            Coordinate2D(latitude: 35.05, longitude: -96.90)
+        ]
+        let changedHole = [
+            Coordinate2D(latitude: 35.06, longitude: -96.95),
+            Coordinate2D(latitude: 35.10, longitude: -96.95),
+            Coordinate2D(latitude: 35.05, longitude: -96.90)
+        ]
+
+        let baseline = makeStormRisk(
+            level: .thunderstorm,
+            title: "TSTM",
+            polygon: GeoPolygonEntity(
+                title: "TSTM",
+                coordinates: exterior,
+                interiorCoordinates: [firstHole]
+            )
+        )
+        let revised = makeStormRisk(
+            level: .thunderstorm,
+            title: "TSTM",
+            polygon: GeoPolygonEntity(
+                title: "TSTM",
+                coordinates: exterior,
+                interiorCoordinates: [changedHole]
+            )
+        )
+
+        let baselineResult = mapper.polygons(
+            for: .categorical, stormRisk: [baseline], severeRisks: [], mesos: [], fires: []
+        )
+        let revisedResult = mapper.polygons(
+            for: .categorical, stormRisk: [revised], severeRisks: [], mesos: [], fires: []
+        )
+        let polygon = try #require(baselineResult.polygons.first)
+
+        #expect(polygon.interiorPolygons?.count == 1)
+        #expect(polygon.interiorPolygons?.first?.pointCount == firstHole.count)
+        #expect(baselineResult.keyedPolygons.first?.key != revisedResult.keyedPolygons.first?.key)
+    }
+
+    @Test("Single-ring polygons keep an empty interior polygon collection")
+    func polygonMapping_singleRingRemainsUnchanged() throws {
+        let result = mapper.polygons(
+            for: .categorical,
+            stormRisk: [makeStormRisk(level: .thunderstorm, title: "TSTM")],
+            severeRisks: [],
+            mesos: [],
+            fires: []
+        )
+
+        let polygon = try #require(result.polygons.first)
+        #expect(polygon.interiorPolygons?.isEmpty ?? true)
     }
 
     @Test("Meso polygon keys remain stable when source order changes")
@@ -506,7 +571,11 @@ struct MapPolygonMapperTests {
         #expect(baselineKey != revisedKey)
     }
 
-    private func makeStormRisk(level: StormRiskLevel, title: String) -> StormRiskDTO {
+    private func makeStormRisk(
+        level: StormRiskLevel,
+        title: String,
+        polygon: GeoPolygonEntity? = nil
+    ) -> StormRiskDTO {
         StormRiskDTO(
             riskLevel: level,
             issued: now,
@@ -514,7 +583,7 @@ struct MapPolygonMapperTests {
             valid: now,
             stroke: nil,
             fill: nil,
-            polygons: [makeGeoPolygon(title: title)]
+            polygons: [polygon ?? makeGeoPolygon(title: title)]
         )
     }
 

--- a/Tests/UnitTests/RiskPolygonOverlayTests.swift
+++ b/Tests/UnitTests/RiskPolygonOverlayTests.swift
@@ -79,6 +79,36 @@ struct RiskPolygonOverlayTests {
         #expect(abs((overlay.hatchStyle?.spacing ?? 0) - (HatchStyle.default.spacing * 0.82)) < 0.001)
     }
 
+    @Test("Filled polygon paths exclude interior rings regardless of winding")
+    func rendererPath_evenOddFillTreatsInteriorRingAsHole() throws {
+        var exterior = [
+            CLLocationCoordinate2D(latitude: 35.0, longitude: -97.0),
+            CLLocationCoordinate2D(latitude: 35.4, longitude: -97.0),
+            CLLocationCoordinate2D(latitude: 35.0, longitude: -96.6)
+        ]
+        var hole = [
+            CLLocationCoordinate2D(latitude: 35.08, longitude: -96.92),
+            CLLocationCoordinate2D(latitude: 35.08, longitude: -96.80),
+            CLLocationCoordinate2D(latitude: 35.20, longitude: -96.92)
+        ]
+        let interior = MKPolygon(coordinates: &hole, count: hole.count)
+        let polygon = MKPolygon(
+            coordinates: &exterior,
+            count: exterior.count,
+            interiorPolygons: [interior]
+        )
+        let overlay = RiskPolygonOverlay.probability(from: polygon)
+        let renderer = RiskPolygonRenderer(riskOverlay: overlay, differentiateWithoutColor: false)
+        renderer.createPath()
+        let path = try #require(renderer.path)
+
+        let holePoint = renderer.point(for: MKMapPoint(CLLocationCoordinate2D(latitude: 35.11, longitude: -96.88)))
+        let filledPoint = renderer.point(for: MKMapPoint(CLLocationCoordinate2D(latitude: 35.02, longitude: -96.95)))
+
+        #expect(path.contains(holePoint, using: .evenOdd) == false)
+        #expect(path.contains(filledPoint, using: .evenOdd))
+    }
+
     @MainActor
     @Test("MapCoordinator reuses cached overlay when geometry and style are unchanged")
     func mapCoordinator_reusesEquivalentOverlayForSameKey() {

--- a/Tests/UnitTests/SevereRiskRepoActiveSelectionTests.swift
+++ b/Tests/UnitTests/SevereRiskRepoActiveSelectionTests.swift
@@ -21,6 +21,45 @@ private struct MultiProductMockClient: SpcClient {
 
 @Suite("SevereRiskRepo.active", .serialized)
 struct SevereRiskRepoActiveSelectionTests {
+    @Test("Tornado active lookup excludes parsed interior holes")
+    func tornadoActiveLookupExcludesParsedInteriorHoles() async throws {
+        let container = try await MainActor.run { try TestStore.container(for: [SevereRisk.self]) }
+        let repo = SevereRiskRepo(modelContainer: container)
+        let geometry = makeMultiPolygonGeometry(
+            squareAtLonLat: (-100.0, 40.0),
+            size: 4.0,
+            interiorSquares: [((-98.5, 41.5), 1.0)]
+        )
+        let properties = makeProperties(
+            label: "0.05",
+            label2: "5% Tornado Risk",
+            issue: "202509200000",
+            valid: "202509200000",
+            expire: "202509200200",
+            dn: 5
+        )
+        let data = try JSONEncoder().encode(
+            makeFeatureCollection(features: [makeFeature(properties: properties, geometry: geometry)])
+        )
+
+        try await repo.refreshTornadoRisk(
+            using: MultiProductMockClient(geoJsonByProduct: [.tornado: data])
+        )
+
+        let asOf = makeUTCDate(2025, 9, 20, 1, 0)
+        let hole = try await repo.active(
+            asOf: asOf,
+            for: CLLocationCoordinate2D(latitude: 42.0, longitude: -98.0)
+        )
+        let exterior = try await repo.active(
+            asOf: asOf,
+            for: CLLocationCoordinate2D(latitude: 40.5, longitude: -99.5)
+        )
+
+        #expect(hole == .allClear)
+        #expect(exterior == .tornado(probability: 0.05))
+    }
+
     @Test("Newer tornado issuance removes stale older polygon from active lookup")
     func newerTornadoIssuanceRemovesStaleOlderPolygonFromActiveLookup() async throws {
         let container = try await MainActor.run { try TestStore.container(for: [SevereRisk.self]) }
@@ -267,16 +306,27 @@ private func makeProperties(
     )
 }
 
-private func makeMultiPolygonGeometry(squareAtLonLat origin: (Double, Double), size: Double) -> GeoJSONGeometry {
+private func makeMultiPolygonGeometry(
+    squareAtLonLat origin: (Double, Double),
+    size: Double,
+    interiorSquares: [((Double, Double), Double)] = []
+) -> GeoJSONGeometry {
     let (lon, lat) = origin
-    let ring: [[Double]] = [
-        [lon, lat],
-        [lon, lat + size],
-        [lon + size, lat + size],
-        [lon + size, lat],
-        [lon, lat]
+    let exteriorRing = squareRing(longitude: lon, latitude: lat, size: size)
+    let interiorRings = interiorSquares.map { origin, size in
+        squareRing(longitude: origin.0, latitude: origin.1, size: size)
+    }
+    return GeoJSONGeometry(type: "MultiPolygon", coordinates: [[exteriorRing] + interiorRings])
+}
+
+private func squareRing(longitude: Double, latitude: Double, size: Double) -> [[Double]] {
+    [
+        [longitude, latitude],
+        [longitude, latitude + size],
+        [longitude + size, latitude + size],
+        [longitude + size, latitude],
+        [longitude, latitude]
     ]
-    return GeoJSONGeometry(type: "MultiPolygon", coordinates: [[ring]])
 }
 
 private func makeUTCDate(_ year: Int, _ month: Int, _ day: Int, _ hour: Int, _ minute: Int) -> Date {


### PR DESCRIPTION
# Summary
This branch teaches the map and storm-risk geometry pipeline to preserve interior rings instead of flattening them away. That keeps polygon holes intact in rendering and in point-in-polygon lookup so the app can distinguish between an exterior area and excluded interior space.

# What Changed
- Extended GeoJSON parsing and polygon mapping to carry interior rings through as part of each polygon.
- Updated `MKPolygon` creation so MapKit receives interior polygons for overlays.
- Changed storm-risk hit testing to use the full polygon shape, including hole exclusion, instead of only the exterior ring.
- Added compatibility handling so older persisted polygon records without interior-ring data still decode with empty holes.
- Added regression coverage for GeoJSON parsing, polygon mapping, overlay path behavior, and storm-risk lookup across hole and non-hole cases.

# User Impact
Users should see map overlays render polygon holes correctly instead of filling them in, and storm-risk lookup should no longer report points inside a polygon hole as active risk. Existing stored data remains readable.

# Testing
- Not run in this session.

# Notes
- The branch includes compatibility handling for legacy `GeoPolygonEntity` records that do not yet have interior-ring data.
- The map key/fingerprint logic now includes interior-ring geometry so hole changes invalidate cached overlays.