### PR TITLE
Refine Storm Setup alert eligibility and refresh behavior

### DIFF
--- a/SkyAware.xcodeproj/project.pbxproj
+++ b/SkyAware.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 				UnitTests/SpcProviderSyncMapProductsTests.swift,
 				UnitTests/SpcRiskTestSupport.swift,
 				UnitTests/StormRiskRepoRefreshCategoricalRiskTests.swift,
+				UnitTests/StormSetupAlertEligibilityTests.swift,
 				UnitTests/StormSetupDetailPresentationTests.swift,
 				UnitTests/StormSetupHTTPClientTests.swift,
 				UnitTests/StormSetupIngestionTests.swift,

--- a/Sources/App/HomeRefreshV2/HomeStormSetupIngestion.swift
+++ b/Sources/App/HomeRefreshV2/HomeStormSetupIngestion.swift
@@ -104,7 +104,10 @@ actor HomeStormSetupIngestion {
             preferences: preferences,
             stormRisk: snapshot.stormRisk,
             severeRisk: snapshot.severeRisk,
-            hasActiveAlert: snapshot.alerts.isEmpty == false,
+            hasQualifyingConvectiveAlert: StormSetupAlertEligibility.hasQualifyingAlert(
+                in: snapshot.alerts,
+                now: now
+            ),
             hasActiveMeso: snapshot.mesos.isEmpty == false,
             assessmentOverall: cachedStormSetup.map { StormSetupAssessment(dto: $0).assessment.overall },
             payloadExpiresAt: cachedStormSetup?.freshness.expiresAt,

--- a/Sources/App/HomeView+PresentationState.swift
+++ b/Sources/App/HomeView+PresentationState.swift
@@ -257,11 +257,24 @@ extension HomeView {
         return projectionValue ?? pipelineValue
     }
 
-    static func shouldRefreshStormSetupSettings(
-        previousPreferences: StormSetupPreferences?,
-        currentPreferences: StormSetupPreferences
+    static func shouldScheduleStormSetupSettingsRefresh(
+        previousPreferences: StormSetupPreferences,
+        currentPreferences: StormSetupPreferences,
+        hasCurrentLocationContext: Bool,
+        isPreviewMode: Bool,
+        isUITestStaticMode: Bool
     ) -> Bool {
-        previousPreferences != currentPreferences
+        guard hasCurrentLocationContext, isPreviewMode == false, isUITestStaticMode == false else {
+            return false
+        }
+
+        let stormSetupWasEnabled = previousPreferences.stormSetupEnabled
+        let stormSetupIsEnabled = currentPreferences.stormSetupEnabled
+        let detailedIngredientsWereEnabled = previousPreferences.detailedIngredientsEnabled
+        let detailedIngredientsAreEnabled = currentPreferences.detailedIngredientsEnabled
+
+        return (stormSetupWasEnabled == false && stormSetupIsEnabled) ||
+            (detailedIngredientsWereEnabled == false && detailedIngredientsAreEnabled && stormSetupIsEnabled)
     }
 
     static func preferredOutlooks(

--- a/Sources/App/HomeView.swift
+++ b/Sources/App/HomeView.swift
@@ -41,8 +41,6 @@ struct HomeView: View {
     @State private var locationReliabilityRailQualifyingDay: String?
     @State private var locationReliabilityRailLastEligibilityReason: LocationReliabilitySummaryRailEligibilityReason?
     @State private var showsLocationReliabilitySheet: Bool = false
-    @State private var lastStormSetupPreferences: StormSetupPreferences?
-
     private var isUITestStaticMode: Bool {
         ProcessInfo.processInfo.environment["UI_TESTS_STATIC_HOME"] == "1"
     }
@@ -402,11 +400,29 @@ struct HomeView: View {
                 )
             }
         }
-        .onChange(of: stormSetupEnabled) { _, _ in
-            scheduleStormSetupSettingsRefreshIfNeeded()
+        .onChange(of: stormSetupEnabled) { oldValue, newValue in
+            scheduleStormSetupSettingsRefreshIfNeeded(
+                previousPreferences: .init(
+                    stormSetupEnabled: oldValue,
+                    detailedIngredientsEnabled: detailedIngredientsEnabled
+                ),
+                currentPreferences: .init(
+                    stormSetupEnabled: newValue,
+                    detailedIngredientsEnabled: detailedIngredientsEnabled
+                )
+            )
         }
-        .onChange(of: detailedIngredientsEnabled) { _, _ in
-            scheduleStormSetupSettingsRefreshIfNeeded()
+        .onChange(of: detailedIngredientsEnabled) { oldValue, newValue in
+            scheduleStormSetupSettingsRefreshIfNeeded(
+                previousPreferences: .init(
+                    stormSetupEnabled: stormSetupEnabled,
+                    detailedIngredientsEnabled: oldValue
+                ),
+                currentPreferences: .init(
+                    stormSetupEnabled: stormSetupEnabled,
+                    detailedIngredientsEnabled: newValue
+                )
+            )
         }
         .onChange(of: remoteAlertPresentationState.focusRequest?.id) { _, newValue in
             guard newValue != nil else { return }
@@ -440,20 +456,20 @@ struct HomeView: View {
         }
     }
 
-    private func scheduleStormSetupSettingsRefreshIfNeeded() {
-        guard isPreviewMode == false, isUITestStaticMode == false else {
-            return
-        }
-
-        let currentPreferences = stormSetupPreferences
-        guard Self.shouldRefreshStormSetupSettings(
-            previousPreferences: lastStormSetupPreferences,
-            currentPreferences: currentPreferences
+    private func scheduleStormSetupSettingsRefreshIfNeeded(
+        previousPreferences: StormSetupPreferences,
+        currentPreferences: StormSetupPreferences
+    ) {
+        guard Self.shouldScheduleStormSetupSettingsRefresh(
+            previousPreferences: previousPreferences,
+            currentPreferences: currentPreferences,
+            hasCurrentLocationContext: locationSession.currentContext != nil,
+            isPreviewMode: isPreviewMode,
+            isUITestStaticMode: isUITestStaticMode
         ) else {
             return
         }
 
-        lastStormSetupPreferences = currentPreferences
         refreshPipeline.updateEnvironment(refreshEnvironment)
         Task {
             await refreshPipeline.enqueueRefresh(.timer, environment: refreshEnvironment)

--- a/Sources/App/SkyAwareApp.swift
+++ b/Sources/App/SkyAwareApp.swift
@@ -341,6 +341,13 @@ private extension SkyAwareApp {
             forKey: "detailedIngredientsEnabled",
             in: sharedDefaults
         )
+#if DEBUG
+        applyUITestBooleanOverride(
+            env["UI_TESTS_STORM_SETUP_FORCE_DISPLAY"],
+            forKey: "stormSetupForceDisplay",
+            in: sharedDefaults
+        )
+#endif
     }
 
     @MainActor

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -651,10 +651,17 @@ struct SummaryView: View {
     }
 
     private func stormSetupSlotState(now: Date) -> StormSetupSlotState {
-        Self.stormSetupSlotState(
+#if DEBUG
+        let isForcedPresentation = stormSetupForceDisplay
+#else
+        let isForcedPresentation = false
+#endif
+
+        return Self.stormSetupSlotState(
             presentation: stormSetupDetailPresentation(now: now),
             hasStormSetup: stormSetup != nil,
             stormSetupEnabled: stormSetupPreferences.stormSetupEnabled,
+            isForcedPresentation: isForcedPresentation,
             isRefreshInFlight: isRefreshInFlight,
             isLocationUnavailable: isLocationUnavailable
         )
@@ -664,15 +671,26 @@ struct SummaryView: View {
         presentation: StormSetupDetailPresentation?,
         hasStormSetup: Bool,
         stormSetupEnabled: Bool,
+        isForcedPresentation: Bool = false,
         isRefreshInFlight: Bool,
         isLocationUnavailable: Bool
     ) -> StormSetupSlotState {
-        guard isLocationUnavailable == false, stormSetupEnabled else {
+        guard isLocationUnavailable == false else {
             return .hidden
         }
 
-        if let presentation {
+        if let presentation,
+           Self.shouldShowStormSetupPresentation(
+               hasPresentation: true,
+               stormSetupEnabled: stormSetupEnabled,
+               isForcedPresentation: isForcedPresentation,
+               isLocationUnavailable: isLocationUnavailable
+           ) {
             return .visible(presentation)
+        }
+
+        guard stormSetupEnabled else {
+            return .hidden
         }
 
         if hasStormSetup == false, isRefreshInFlight {
@@ -680,6 +698,17 @@ struct SummaryView: View {
         }
 
         return .hidden
+    }
+
+    static func shouldShowStormSetupPresentation(
+        hasPresentation: Bool,
+        stormSetupEnabled: Bool,
+        isForcedPresentation: Bool,
+        isLocationUnavailable: Bool
+    ) -> Bool {
+        hasPresentation &&
+        isLocationUnavailable == false &&
+        (stormSetupEnabled || isForcedPresentation)
     }
 
     static func sectionPlan(

--- a/Sources/Features/Summary/SummaryView.swift
+++ b/Sources/Features/Summary/SummaryView.swift
@@ -630,7 +630,7 @@ struct SummaryView: View {
             preferences: stormSetupPreferences,
             stormRisk: stormRisk,
             severeRisk: severeRisk,
-            hasActiveAlert: !alerts.isEmpty,
+            hasQualifyingConvectiveAlert: StormSetupAlertEligibility.hasQualifyingAlert(in: alerts, now: now),
             hasActiveMeso: !mesos.isEmpty,
             assessmentOverall: StormSetupAssessment(dto: stormSetup).assessment.overall,
             payloadExpiresAt: stormSetup.freshness.expiresAt,

--- a/Sources/Models/StormSetup/StormSetupAlertEligibility.swift
+++ b/Sources/Models/StormSetup/StormSetupAlertEligibility.swift
@@ -1,0 +1,29 @@
+//
+//  StormSetupAlertEligibility.swift
+//  SkyAware
+//
+//  Created by OpenAI Codex.
+//
+
+import Foundation
+
+enum StormSetupAlertEligibility {
+    private static let qualifyingEventTitles: Set<String> = [
+        "severe thunderstorm watch",
+        "severe thunderstorm warning",
+        "tornado watch",
+        "tornado warning"
+    ]
+
+    static func hasQualifyingAlert(in alerts: [AlertDTO], now: Date) -> Bool {
+        alerts.contains { qualifies($0, now: now) }
+    }
+
+    static func qualifies(_ alert: AlertDTO, now: Date) -> Bool {
+        let normalizedTitle = alert.title.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        return qualifyingEventTitles.contains(normalizedTitle)
+            && alert.issued <= now
+            && alert.ends > now
+    }
+}

--- a/Sources/Models/StormSetup/StormSetupPreferences.swift
+++ b/Sources/Models/StormSetup/StormSetupPreferences.swift
@@ -18,7 +18,7 @@ struct StormSetupPolicyInput: Sendable, Equatable {
     let preferences: StormSetupPreferences
     let stormRisk: StormRiskLevel?
     let severeRisk: SevereWeatherThreat?
-    let hasActiveAlert: Bool
+    let hasQualifyingConvectiveAlert: Bool
     let hasActiveMeso: Bool
     let assessmentOverall: StormSetupSignal?
     let payloadExpiresAt: Date?
@@ -32,7 +32,7 @@ struct StormSetupFetchPolicy {
 
         return input.stormRisk.map { $0 >= .marginal } ?? false
             || input.severeRisk.map { $0 != .allClear } ?? false
-            || input.hasActiveAlert
+            || input.hasQualifyingConvectiveAlert
             || input.hasActiveMeso
             || input.preferences.effectiveDetailedIngredientsEnabled
     }
@@ -46,7 +46,7 @@ struct StormSetupDisplayPolicy {
 
         return input.assessmentOverall == .supportive
             || input.assessmentOverall == .strong
-            || input.hasActiveAlert
+            || input.hasQualifyingConvectiveAlert
             || input.hasActiveMeso
             || input.preferences.effectiveDetailedIngredientsEnabled
     }

--- a/Tests/UITests/SkyAwareUITests.swift
+++ b/Tests/UITests/SkyAwareUITests.swift
@@ -605,6 +605,33 @@ final class SkyAwareUITests: XCTestCase {
         saveScreenshot(darkApp, named: "storm-setup-detail-dark")
     }
 
+    @MainActor
+    func testStormSetupDiagnosticsForceDisplayOverridesDisabledFeature() throws {
+        let app = launchStormSetupFixtureApp(
+            colorScheme: nil,
+            stormSetupEnabled: false,
+            forceDisplay: true
+        )
+
+        let summaryScrollView = app.scrollViews["summary-scroll"]
+        XCTAssertTrue(summaryScrollView.waitForExistence(timeout: 10), "Expected Summary scroll view to exist.")
+
+        let stormSetupCard = app.buttons["summary-storm-setup-card"]
+        scrollUntilHittable(stormSetupCard, in: summaryScrollView)
+        XCTAssertTrue(stormSetupCard.exists, "Expected forced Storm Setup card while the feature is disabled.")
+
+        stormSetupCard.tap()
+
+        XCTAssertTrue(
+            app.navigationBars["Storm Setup"].waitForExistence(timeout: 10),
+            "Expected forced Storm Setup card to open its detail."
+        )
+        XCTAssertFalse(
+            app.otherElements["storm-setup-advanced-details"].exists,
+            "Force display must not enable Detailed Ingredients while Storm Setup is disabled."
+        )
+    }
+
 //  TODO: This test is broken and have tried to fix it multiple times with 5.4 mini and 5.4.
 //        Spend some time looking at this later, and determine if/how to fix. We may not need
 //        it since I'm debating actually showing atmospheric conditions and storm setup.
@@ -1055,7 +1082,9 @@ final class SkyAwareUITests: XCTestCase {
     @MainActor
     private func launchStormSetupFixtureApp(
         colorScheme: String?,
-        accessibilityTextSize: Bool = false
+        accessibilityTextSize: Bool = false,
+        stormSetupEnabled: Bool = true,
+        forceDisplay: Bool = false
     ) -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["UI_TESTS_FORCE_ONBOARDING_COMPLETE"] = "1"
@@ -1063,8 +1092,9 @@ final class SkyAwareUITests: XCTestCase {
         app.launchEnvironment["UI_TESTS_SUPPRESS_LOCATION_RESTRICTED_SHEET"] = "1"
         app.launchEnvironment["UI_TESTS_STATIC_HOME"] = "1"
         app.launchEnvironment["UI_TESTS_STORM_SETUP_FIXTURE"] = "supportive"
-        app.launchEnvironment["UI_TESTS_STORM_SETUP_ENABLED"] = "1"
+        app.launchEnvironment["UI_TESTS_STORM_SETUP_ENABLED"] = stormSetupEnabled ? "1" : "0"
         app.launchEnvironment["UI_TESTS_DETAILED_INGREDIENTS_ENABLED"] = "1"
+        app.launchEnvironment["UI_TESTS_STORM_SETUP_FORCE_DISPLAY"] = forceDisplay ? "1" : "0"
 
         if let colorScheme {
             app.launchEnvironment["UI_TESTS_COLOR_SCHEME"] = colorScheme

--- a/Tests/UnitTests/HomeViewStateTests.swift
+++ b/Tests/UnitTests/HomeViewStateTests.swift
@@ -482,14 +482,59 @@ struct HomeViewProjectionLaunchTests {
         #expect(fallbackSelected == fallback)
     }
 
-    @Test("storm setup settings use raw values and session tick refresh path")
-    func stormSetupSettings_useRawValuesAndSessionTickRefreshPath() {
+    @Test("storm setup settings schedule only qualifying enablement transitions")
+    func stormSetupSettings_scheduleOnlyQualifyingEnablementTransitions() {
         let preferences = StormSetupPreferences(stormSetupEnabled: false, detailedIngredientsEnabled: true)
         #expect(preferences.effectiveDetailedIngredientsEnabled == false)
 
-        let current = StormSetupPreferences(stormSetupEnabled: true, detailedIngredientsEnabled: true)
-        #expect(HomeView.shouldRefreshStormSetupSettings(previousPreferences: current, currentPreferences: current) == false)
-        #expect(HomeView.shouldRefreshStormSetupSettings(previousPreferences: nil, currentPreferences: current))
+        let cases: [(String, StormSetupPreferences, StormSetupPreferences, Bool, Bool, Bool, Bool)] = [
+            ("Storm Setup enable with context", .init(), .init(stormSetupEnabled: true), true, false, false, true),
+            ("Storm Setup enable without context", .init(), .init(stormSetupEnabled: true), false, false, false, false),
+            ("Storm Setup disable", .init(stormSetupEnabled: true), .init(), true, false, false, false),
+            ("unchanged Storm Setup", .init(stormSetupEnabled: true), .init(stormSetupEnabled: true), true, false, false, false),
+            (
+                "Detailed Ingredients enable with Storm Setup",
+                .init(stormSetupEnabled: true),
+                .init(stormSetupEnabled: true, detailedIngredientsEnabled: true),
+                true,
+                false,
+                false,
+                true
+            ),
+            (
+                "Detailed Ingredients enable without Storm Setup",
+                .init(),
+                .init(detailedIngredientsEnabled: true),
+                true,
+                false,
+                false,
+                false
+            ),
+            (
+                "Detailed Ingredients disable",
+                .init(stormSetupEnabled: true, detailedIngredientsEnabled: true),
+                .init(stormSetupEnabled: true),
+                true,
+                false,
+                false,
+                false
+            ),
+            ("preview mode", .init(), .init(stormSetupEnabled: true), true, true, false, false),
+            ("static UI-test mode", .init(), .init(stormSetupEnabled: true), true, false, true, false)
+        ]
+
+        for (name, previous, current, hasContext, isPreview, isStaticTest, expected) in cases {
+            #expect(
+                HomeView.shouldScheduleStormSetupSettingsRefresh(
+                    previousPreferences: previous,
+                    currentPreferences: current,
+                    hasCurrentLocationContext: hasContext,
+                    isPreviewMode: isPreview,
+                    isUITestStaticMode: isStaticTest
+                ) == expected,
+                "\\(name)"
+            )
+        }
     }
 }
 

--- a/Tests/UnitTests/StormSetupAlertEligibilityTests.swift
+++ b/Tests/UnitTests/StormSetupAlertEligibilityTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+@testable import SkyAware
+
+@Suite("Storm Setup Alert Eligibility")
+struct StormSetupAlertEligibilityTests {
+    private let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
+
+    @Test("only active approved event titles qualify", arguments: [
+        ("Severe Thunderstorm Watch", true),
+        ("Severe Thunderstorm Warning", true),
+        ("Tornado Watch", true),
+        ("Tornado Warning", true),
+        ("  tornado warning  ", true),
+        ("Air Quality Alert", false),
+        ("Flash Flood Warning", false),
+        ("Winter Storm Warning", false),
+        ("Unknown", false),
+        ("", false)
+    ])
+    func exactTitleEligibility(title: String, expected: Bool) {
+        #expect(StormSetupAlertEligibility.qualifies(makeAlert(title: title), now: now) == expected)
+    }
+
+    @Test("validity interval is issued-inclusive and end-exclusive")
+    func validityIntervalEligibility() {
+        #expect(StormSetupAlertEligibility.qualifies(
+            makeAlert(title: "Tornado Warning", issued: now, ends: now.addingTimeInterval(1)),
+            now: now
+        ))
+        #expect(StormSetupAlertEligibility.qualifies(
+            makeAlert(title: "Tornado Warning", issued: now.addingTimeInterval(1), ends: now.addingTimeInterval(2)),
+            now: now
+        ) == false)
+        #expect(StormSetupAlertEligibility.qualifies(
+            makeAlert(title: "Tornado Warning", issued: now.addingTimeInterval(-1), ends: now),
+            now: now
+        ) == false)
+        #expect(StormSetupAlertEligibility.qualifies(
+            makeAlert(title: "Tornado Warning", issued: now.addingTimeInterval(-2), ends: now.addingTimeInterval(-1)),
+            now: now
+        ) == false)
+    }
+
+    private func makeAlert(
+        title: String,
+        issued: Date? = nil,
+        ends: Date? = nil
+    ) -> AlertDTO {
+        let resolvedIssued = issued ?? now.addingTimeInterval(-1)
+        let resolvedEnds = ends ?? now.addingTimeInterval(1)
+
+        return AlertDTO(
+            id: UUID().uuidString,
+            messageId: nil,
+            currentRevisionSent: nil,
+            title: title,
+            headline: title,
+            issued: resolvedIssued,
+            expires: resolvedEnds,
+            ends: resolvedEnds,
+            messageType: "Alert",
+            sender: nil,
+            severity: "Severe",
+            urgency: "Immediate",
+            certainty: "Observed",
+            description: "Alert",
+            instruction: nil,
+            response: nil,
+            areaSummary: "Area",
+            geometryData: nil,
+            tornadoDetection: nil,
+            tornadoDamageThreat: nil,
+            maxWindGust: nil,
+            maxHailSize: nil,
+            windThreat: nil,
+            hailThreat: nil,
+            thunderstormDamageThreat: nil,
+            flashFloodDetection: nil,
+            flashFloodDamageThreat: nil
+        )
+    }
+}

--- a/Tests/UnitTests/StormSetupIngestionTests.swift
+++ b/Tests/UnitTests/StormSetupIngestionTests.swift
@@ -38,6 +38,57 @@ struct StormSetupIngestionTests {
         }
     }
 
+    @Test("Storm Setup classifies alerts before request eligibility")
+    func stormSetupClassifiesAlertsBeforeRequestEligibility() async throws {
+        let cases: [(String, AlertDTO, [MdDTO], Int)] = [
+            (
+                "active tornado warning",
+                makeStormSetupAlert(title: "Tornado Warning", issued: fixedNow, ends: fixedNow.addingTimeInterval(60)),
+                [],
+                1
+            ),
+            (
+                "active air quality alert",
+                makeStormSetupAlert(title: "Air Quality Alert", issued: fixedNow, ends: fixedNow.addingTimeInterval(60)),
+                [],
+                0
+            ),
+            (
+                "expired tornado warning",
+                makeStormSetupAlert(title: "Tornado Warning", issued: fixedNow.addingTimeInterval(-60), ends: fixedNow),
+                [],
+                0
+            ),
+            (
+                "meso remains independently eligible",
+                makeStormSetupAlert(title: "Air Quality Alert", issued: fixedNow, ends: fixedNow.addingTimeInterval(60)),
+                [MD.sampleDiscussionDTOs[0]],
+                1
+            )
+        ]
+
+        for testCase in cases {
+            let context = makeContext()
+            let query = StormSetupQueryingFake(
+                response: .success(makeStormSetupDTO(h3Cell: context.h3Cell, expiresAt: fixedNow.addingTimeInterval(3600)))
+            )
+            let harness = try makeHarness(
+                context: context,
+                query: query,
+                stormRisk: .allClear,
+                severeRisk: .allClear,
+                activeAlerts: [testCase.1],
+                activeMesos: testCase.2
+            )
+
+            _ = try await harness.executor.run(
+                plan: HomeIngestionPlan(request: .init(trigger: .foregroundActivate))
+            )
+
+            #expect(await query.requestCount() == testCase.3, "\(testCase.0)")
+        }
+    }
+
     @Test("eligible triggers request exactly once in the expected HTTP mode")
     func eligibleTriggersRequestExactlyOnceInExpectedHTTPMode() async throws {
         let cases: [(String, HomeRefreshTrigger, HTTPExecutionMode)] = [
@@ -2191,6 +2242,38 @@ private enum TestError: Error {
 }
 
 private let fixedNow = Date(timeIntervalSinceReferenceDate: 1_000_000)
+
+private func makeStormSetupAlert(title: String, issued: Date, ends: Date) -> AlertDTO {
+    AlertDTO(
+        id: UUID().uuidString,
+        messageId: nil,
+        currentRevisionSent: nil,
+        title: title,
+        headline: title,
+        issued: issued,
+        expires: ends,
+        ends: ends,
+        messageType: "Alert",
+        sender: nil,
+        severity: "Severe",
+        urgency: "Immediate",
+        certainty: "Observed",
+        description: "Alert",
+        instruction: nil,
+        response: nil,
+        areaSummary: "Area",
+        geometryData: nil,
+        tornadoDetection: nil,
+        tornadoDamageThreat: nil,
+        maxWindGust: nil,
+        maxHailSize: nil,
+        windThreat: nil,
+        hailThreat: nil,
+        thunderstormDamageThreat: nil,
+        flashFloodDetection: nil,
+        flashFloodDamageThreat: nil
+    )
+}
 
 @MainActor
 private func waitUntil(

--- a/Tests/UnitTests/StormSetupPolicyTests.swift
+++ b/Tests/UnitTests/StormSetupPolicyTests.swift
@@ -10,7 +10,7 @@ struct StormSetupPolicyTests {
             preferences: .init(stormSetupEnabled: false, detailedIngredientsEnabled: true),
             stormRisk: .high,
             severeRisk: .tornado(probability: 0.7),
-            hasActiveAlert: true,
+            hasQualifyingConvectiveAlert: true,
             hasActiveMeso: true,
             assessmentOverall: .strong,
             payloadExpiresAt: future,
@@ -21,7 +21,7 @@ struct StormSetupPolicyTests {
         #expect(StormSetupDisplayPolicy.shouldShow(input) == false)
     }
 
-    @Test("fetch policy respects risk, alert, meso, override, and payload freshness")
+    @Test("fetch policy respects risk, qualifying alerts, meso, detailed ingredients, and payload freshness")
     func fetchPolicyRespectsTriggersAndFreshness() {
         let cases: [(String, StormSetupPolicyInput, Bool)] = [
             ("thunderstorm does not qualify", makeInput(stormRisk: .thunderstorm), false),
@@ -30,7 +30,7 @@ struct StormSetupPolicyTests {
             ("wind qualifies", makeInput(severeRisk: .wind(probability: 0.2)), true),
             ("hail qualifies", makeInput(severeRisk: .hail(probability: 0.2)), true),
             ("tornado qualifies", makeInput(severeRisk: .tornado(probability: 0.2)), true),
-            ("alert qualifies", makeInput(hasActiveAlert: true), true),
+            ("qualifying convective alert qualifies", makeInput(hasQualifyingConvectiveAlert: true), true),
             ("meso qualifies", makeInput(hasActiveMeso: true), true),
             ("detailed ingredients qualifies", makeInput(preferences: .init(stormSetupEnabled: true, detailedIngredientsEnabled: true)), true),
             ("unexpired payload suppresses refetch", makeInput(stormRisk: .high, payloadExpiresAt: future), false),
@@ -52,10 +52,14 @@ struct StormSetupPolicyTests {
             ("weak stays hidden", makeInput(assessmentOverall: .weak, payloadExpiresAt: future), false),
             ("conditional stays hidden", makeInput(assessmentOverall: .conditional, payloadExpiresAt: future), false),
             ("unknown stays hidden", makeInput(assessmentOverall: .unknown, payloadExpiresAt: future), false),
-            ("alert qualifies", makeInput(hasActiveAlert: true, assessmentOverall: .unknown, payloadExpiresAt: future), true),
+            (
+                "qualifying convective alert qualifies unknown assessment",
+                makeInput(hasQualifyingConvectiveAlert: true, assessmentOverall: .unknown, payloadExpiresAt: future),
+                true
+            ),
             ("meso qualifies", makeInput(hasActiveMeso: true, assessmentOverall: .weak, payloadExpiresAt: future), true),
             (
-                "override qualifies",
+                "detailed ingredients qualifies",
                 makeInput(
                     preferences: .init(stormSetupEnabled: true, detailedIngredientsEnabled: true),
                     assessmentOverall: .conditional,
@@ -67,7 +71,7 @@ struct StormSetupPolicyTests {
                 "missing assessment stays hidden",
                 makeInput(
                     preferences: .init(stormSetupEnabled: true, detailedIngredientsEnabled: true),
-                    hasActiveAlert: true,
+                    hasQualifyingConvectiveAlert: true,
                     assessmentOverall: nil,
                     payloadExpiresAt: future
                 ),
@@ -77,7 +81,7 @@ struct StormSetupPolicyTests {
                 "expired assessment stays hidden",
                 makeInput(
                     preferences: .init(stormSetupEnabled: true, detailedIngredientsEnabled: true),
-                    hasActiveAlert: true,
+                    hasQualifyingConvectiveAlert: true,
                     assessmentOverall: .strong,
                     payloadExpiresAt: past
                 ),
@@ -109,7 +113,7 @@ private func makeInput(
     preferences: StormSetupPreferences = .init(stormSetupEnabled: true, detailedIngredientsEnabled: false),
     stormRisk: StormRiskLevel? = nil,
     severeRisk: SevereWeatherThreat? = nil,
-    hasActiveAlert: Bool = false,
+    hasQualifyingConvectiveAlert: Bool = false,
     hasActiveMeso: Bool = false,
     assessmentOverall: StormSetupSignal? = nil,
     payloadExpiresAt: Date? = nil,
@@ -119,7 +123,7 @@ private func makeInput(
         preferences: preferences,
         stormRisk: stormRisk,
         severeRisk: severeRisk,
-        hasActiveAlert: hasActiveAlert,
+        hasQualifyingConvectiveAlert: hasQualifyingConvectiveAlert,
         hasActiveMeso: hasActiveMeso,
         assessmentOverall: assessmentOverall,
         payloadExpiresAt: payloadExpiresAt,

--- a/Tests/UnitTests/SummaryViewLoadingStateTests.swift
+++ b/Tests/UnitTests/SummaryViewLoadingStateTests.swift
@@ -115,6 +115,29 @@ struct SummaryViewRiskPlaceholderPresentationTests {
 @Suite("Summary View Storm Setup Slot State")
 @MainActor
 struct SummaryViewStormSetupSlotStateTests {
+    @Test("forced presentation bypasses the normal Storm Setup feature gate")
+    func forcedPresentation_bypassesNormalFeatureGate() {
+        let cases: [(String, Bool, Bool, Bool, Bool, Bool)] = [
+            ("feature off and force off", true, false, false, false, false),
+            ("feature off and force on", true, false, true, false, true),
+            ("policy-suppressed presentation forced on", true, true, true, false, true),
+            ("force on without payload", false, false, true, false, false),
+            ("location unavailable", true, false, true, true, false)
+        ]
+
+        for (name, hasPresentation, stormSetupEnabled, isForcedPresentation, isLocationUnavailable, expected) in cases {
+            #expect(
+                SummaryView.shouldShowStormSetupPresentation(
+                    hasPresentation: hasPresentation,
+                    stormSetupEnabled: stormSetupEnabled,
+                    isForcedPresentation: isForcedPresentation,
+                    isLocationUnavailable: isLocationUnavailable
+                ) == expected,
+                "\\(name)"
+            )
+        }
+    }
+
     @Test("composed Storm Setup state reserves only loading and visible sections")
     func composedStateAndPlanRespectSlotContract() {
         let cases: [(String, SummaryView.StormSetupSlotState, Bool)] = [
@@ -185,6 +208,7 @@ struct SummaryViewStormSetupSlotStateTests {
                 presentation: nil,
                 hasStormSetup: false,
                 stormSetupEnabled: false,
+                isForcedPresentation: true,
                 isRefreshInFlight: true,
                 isLocationUnavailable: false
             ) == .hidden

--- a/docs/plans/storm-setup-runbook.md
+++ b/docs/plans/storm-setup-runbook.md
@@ -105,8 +105,8 @@ arrays are useful current/cached content.
 
 For Storm Setup fetch eligibility, active severe context includes either:
 
-- at least one `AlertDTO`, or
-- at least one `MdDTO`
+- at least one active Severe Thunderstorm Watch, Severe Thunderstorm Warning, Tornado Watch, or Tornado Warning, or
+- at least one active `MdDTO`
 
 ### Settings and flags
 
@@ -342,7 +342,7 @@ stormSetupEnabled
 AND (
     stormRisk >= marginal
     OR severeRisk != allClear
-    OR active AlertDTO exists
+    OR active qualifying convective AlertDTO exists
     OR active MdDTO exists
     OR effectiveDetailedIngredientsEnabled
 )
@@ -370,7 +370,7 @@ stormSetupEnabled
 AND unexpiredAssessmentExists
 AND (
     assessment.overall is supportive or strong
-    OR active AlertDTO exists
+    OR active qualifying convective AlertDTO exists
     OR active MdDTO exists
     OR effectiveDetailedIngredientsEnabled
 )

--- a/release/CHANGELOG.md
+++ b/release/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.1.0(99)
+## v1.1.0(103)
 
 ### UI / UX
 - Today now publishes core content earlier and centralizes display selection so useful content remains stable while optional enrichment finishes.

--- a/release/RELEASE_NOTES.md
+++ b/release/RELEASE_NOTES.md
@@ -2,11 +2,11 @@
 
 ## v1.1.0(103)
 
-### Overview
+## Overview
 This build makes Today more stable during partial refreshes, preserves useful cached warning and air-quality data,
 and makes background refresh cancellation and pending-upload work more predictable.
 
-### Highlights
+## Highlights
 - Today publishes core content earlier and keeps display selection stable while optional enrichment finishes.
 - Cached map warnings remain visible when a fresh warning lookup cannot provide a replacement.
 - Same-location air-quality data remains visible when an optional refresh has no replacement value.
@@ -14,7 +14,7 @@ and makes background refresh cancellation and pending-upload work more predictab
 - Background refresh now bounds pending-upload work and responds to cancellation before ingestion continues.
 - Regression coverage was expanded across Today refresh, ingestion cancellation, background uploads, location side effects, map warnings, AQI preservation, onboarding, and Storm Setup behavior.
 
-### Maintenance
+## Maintenance
 - Today refresh coordination, Home projection commits, upload side effects, and live Arcus dependencies were simplified and made explicit.
 - Architecture, performance, physical-device validation, release-readiness, and simulator validation documentation were updated.
 

--- a/release/RELEASE_NOTES.md
+++ b/release/RELEASE_NOTES.md
@@ -2,11 +2,11 @@
 
 ## v1.1.0(103)
 
-## Overview
+### Overview
 This build makes Today more stable during partial refreshes, preserves useful cached warning and air-quality data,
 and makes background refresh cancellation and pending-upload work more predictable.
 
-## Highlights
+### Highlights
 - Today publishes core content earlier and keeps display selection stable while optional enrichment finishes.
 - Cached map warnings remain visible when a fresh warning lookup cannot provide a replacement.
 - Same-location air-quality data remains visible when an optional refresh has no replacement value.
@@ -14,7 +14,7 @@ and makes background refresh cancellation and pending-upload work more predictab
 - Background refresh now bounds pending-upload work and responds to cancellation before ingestion continues.
 - Regression coverage was expanded across Today refresh, ingestion cancellation, background uploads, location side effects, map warnings, AQI preservation, onboarding, and Storm Setup behavior.
 
-## Maintenance
+### Maintenance
 - Today refresh coordination, Home projection commits, upload side effects, and live Arcus dependencies were simplified and made explicit.
 - Architecture, performance, physical-device validation, release-readiness, and simulator validation documentation were updated.
 

--- a/release/RELEASE_NOTES.md
+++ b/release/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## v1.1.0(99)
+## v1.1.0(103)
 
 ### Overview
 This build makes Today more stable during partial refreshes, preserves useful cached warning and air-quality data,

--- a/release/TESTFLIGHT_NOTES.md
+++ b/release/TESTFLIGHT_NOTES.md
@@ -1,4 +1,4 @@
-SkyAware v1.1.0(99)
+SkyAware v1.1.0(103)
 
 Highlights:
 - Today should show core content sooner and remain steadier while optional information finishes refreshing.


### PR DESCRIPTION
# Summary
Refine Storm Setup eligibility and presentation behavior so fetches and display decisions respond to active qualifying convective alerts, actionable settings transitions, and a DEBUG-only diagnostic override. The branch also adds focused unit/UI coverage and updates release documentation for build 103.

# What Changed
- Restrict Storm Setup alert eligibility to active Severe Thunderstorm Watch/Warning and Tornado Watch/Warning alerts.
- Trigger settings refreshes only for Storm Setup or Detailed Ingredients enablement transitions with location context.
- Add a DEBUG-only force-display override for diagnostic UI coverage while keeping Detailed Ingredients gated by the feature setting.
- Add unit tests for alert classification, ingestion policy, settings transitions, and summary slot presentation.
- Add a UI test for forced Storm Setup display and update the Storm Setup runbook and release notes.

# User Impact
Users no longer cause Storm Setup fetch/display eligibility from unrelated or expired alerts. Enabling Storm Setup or Detailed Ingredients refreshes the setup when location context is available; disabling settings does not trigger an unnecessary refresh. The diagnostic force-display behavior is DEBUG/test-only and is not user-facing in production.

# Testing
- `git diff --check origin/main...HEAD` passed.
- Focused unit and UI tests were added, but test execution is not evidenced in the branch and was not run for this PR creation.

# Notes
- This PR includes release documentation updates from build 99 to build 103.
- The PR is opened as a draft for review.