### PR TITLE
Fix failed notification scheduling from consuming occurrences

### DIFF
--- a/Sources/Interfaces/Notification/NotificationGating.swift
+++ b/Sources/Interfaces/Notification/NotificationGating.swift
@@ -9,4 +9,92 @@ import Foundation
 
 protocol NotificationGating: Sendable {
     func allow(_ event: NotificationEvent, now: Date) async -> Bool
+    func finish(_ event: NotificationEvent, didSchedule: Bool) async
+}
+
+extension NotificationGating {
+    func finish(_ event: NotificationEvent, didSchedule: Bool) async {}
+}
+
+actor NotificationClaimState {
+    enum Retention: Sendable {
+        case latest
+        case all
+    }
+
+    private let store: NotificationStateStoring
+    private let retention: Retention
+    private var delivered = Set<String>()
+    private var inFlight = Set<String>()
+    private var isLoaded = false
+    private var loadingTask: Task<String?, Never>?
+    private var persistenceTask: Task<Void, Never>?
+
+    init(store: NotificationStateStoring, retention: Retention) {
+        self.store = store
+        self.retention = retention
+    }
+
+    func claim(_ identity: String) async -> Bool {
+        await loadIfNeeded()
+        guard delivered.contains(identity) == false else { return false }
+        return inFlight.insert(identity).inserted
+    }
+
+    func finish(_ identity: String, didSchedule: Bool) async {
+        guard inFlight.remove(identity) != nil, didSchedule else { return }
+
+        switch retention {
+        case .latest:
+            delivered = [identity]
+        case .all:
+            delivered.insert(identity)
+        }
+        await persist()
+    }
+
+    private func loadIfNeeded() async {
+        guard isLoaded == false else { return }
+
+        let task: Task<String?, Never>
+        if let loadingTask {
+            task = loadingTask
+        } else {
+            let store = self.store
+            task = Task { await store.lastStamp() }
+            loadingTask = task
+        }
+
+        let stamp = await task.value
+        guard isLoaded == false else { return }
+        if let stamp, stamp.isEmpty == false {
+            switch retention {
+            case .latest:
+                delivered = [stamp]
+            case .all:
+                delivered = Set(stamp.split(separator: "\n").map(String.init))
+            }
+        }
+        isLoaded = true
+        loadingTask = nil
+    }
+
+    private func persist() async {
+        let stamp: String
+        switch retention {
+        case .latest:
+            stamp = delivered.first ?? ""
+        case .all:
+            stamp = delivered.sorted().joined(separator: "\n")
+        }
+
+        let previousTask = persistenceTask
+        let store = self.store
+        let task = Task {
+            await previousTask?.value
+            await store.setLastStamp(stamp)
+        }
+        persistenceTask = task
+        await task.value
+    }
 }

--- a/Sources/Notifications/Meso/MesoEngine.swift
+++ b/Sources/Notifications/Meso/MesoEngine.swift
@@ -62,6 +62,7 @@ struct MesoEngine: Sendable {
 
         logger.info("Sending notification")
         let didSchedule = await sender.send(title: msg.title, body: msg.body, subtitle: msg.subtitle, id: event.key)
+        await gate.finish(event, didSchedule: didSchedule)
 
         if didSchedule { logger.notice("Notification scheduled") }
         return didSchedule

--- a/Sources/Notifications/Meso/MesoGate.swift
+++ b/Sources/Notifications/Meso/MesoGate.swift
@@ -10,10 +10,10 @@ import OSLog
 
 struct MesoGate: NotificationGating {
     private let logger = Logger.notificationsMesoGate
-    private let store: NotificationStateStoring
+    private let claims: NotificationClaimState
     
     init(store: NotificationStateStoring) {
-        self.store = store
+        claims = NotificationClaimState(store: store, retention: .latest)
     }
     
     func allow(_ event: NotificationEvent, now: Date) async -> Bool {
@@ -28,17 +28,18 @@ struct MesoGate: NotificationGating {
             return false
         }
   
-        let last = await store.lastStamp()
-        guard last != event.key else {
-        logger.debug("Already sent a notification for meso \(mesoId, privacy: .public) today")
+        guard await claims.claim(event.key) else {
+            logger.debug("Already sent a notification for meso \(mesoId, privacy: .public) today")
             return false
         }
-        
-        logger.debug("Updating the store stamp")
-        await store.setLastStamp(event.key)
-        
+
         logger.notice("Passed the gate")
         return true
+    }
+
+    func finish(_ event: NotificationEvent, didSchedule: Bool) async {
+        guard event.payload["mesoId"] is Int else { return }
+        await claims.finish(event.key, didSchedule: didSchedule)
     }
 }
 

--- a/Sources/Notifications/Morning/MorningEngine.swift
+++ b/Sources/Notifications/Morning/MorningEngine.swift
@@ -40,6 +40,7 @@ struct MorningEngine: Sendable {
         
         logger.info("Sending notification")
         let didSchedule = await sender.send(title: msg.title, body: msg.body, subtitle: msg.subtitle, id: event.key)
+        await gate.finish(event, didSchedule: didSchedule)
         
         if didSchedule { logger.notice("Notification scheduled") }
         return didSchedule

--- a/Sources/Notifications/Morning/MorningGate.swift
+++ b/Sources/Notifications/Morning/MorningGate.swift
@@ -10,10 +10,10 @@ import OSLog
 
 struct MorningGate: NotificationGating {
     private let logger = Logger.notificationsMorningGate
-    private let store: NotificationStateStoring
+    private let claims: NotificationClaimState
     
     init(store: NotificationStateStoring) {
-        self.store = store
+        claims = NotificationClaimState(store: store, retention: .latest)
     }
     
     func allow(_ event: NotificationEvent, now: Date) async -> Bool {
@@ -23,17 +23,18 @@ struct MorningGate: NotificationGating {
             return false
         }
         
-        let last = await store.lastStamp()
-        guard last != day else {
+        guard await claims.claim(day) else {
             logger.debug("Already sent a notification for today")
             return false
         }
-        
-        logger.debug("Updating the morning store stamp")
-        await store.setLastStamp(day)
-        
+
         logger.notice("Passed the gate")
         return true
+    }
+
+    func finish(_ event: NotificationEvent, didSchedule: Bool) async {
+        guard let day = event.payload["localDay"] as? String else { return }
+        await claims.finish(day, didSchedule: didSchedule)
     }
 }
 

--- a/Sources/Notifications/Watch/WatchEngine.swift
+++ b/Sources/Notifications/Watch/WatchEngine.swift
@@ -48,6 +48,7 @@ struct WatchEngine: Sendable {
 
         logger.info("Sending watch notification")
         let didSchedule = await sender.send(title: message.title, body: message.body, subtitle: message.subtitle, id: event.key)
+        await gate.finish(event, didSchedule: didSchedule)
 
         if didSchedule { logger.notice("Watch notification scheduled") }
         return didSchedule

--- a/Sources/Notifications/Watch/WatchGate.swift
+++ b/Sources/Notifications/Watch/WatchGate.swift
@@ -10,10 +10,10 @@ import OSLog
 
 struct WatchGate: NotificationGating {
     private let logger = Logger.notificationsWatchGate
-    private let store: NotificationStateStoring
+    private let claims: NotificationClaimState
 
     init(store: NotificationStateStoring) {
-        self.store = store
+        claims = NotificationClaimState(store: store, retention: .all)
     }
 
     func allow(_ event: NotificationEvent, now: Date) async -> Bool {
@@ -24,25 +24,18 @@ struct WatchGate: NotificationGating {
             return false
         }
 
-        var notifiedWatchIDs = Self.decode(await store.lastStamp())
-        guard notifiedWatchIDs.contains(watchId) == false else {
+        guard await claims.claim(watchId) else {
             logger.debug("Already sent a notification for watch \(watchId, privacy: .public)")
             return false
         }
 
-        notifiedWatchIDs.insert(watchId)
-        await store.setLastStamp(Self.encode(notifiedWatchIDs))
         logger.notice("Passed the gate")
         return true
     }
 
-    private static func decode(_ stamp: String?) -> Set<String> {
-        guard let stamp, stamp.isEmpty == false else { return [] }
-        return Set(stamp.split(separator: "\n").map(String.init))
-    }
-
-    private static func encode(_ watchIDs: Set<String>) -> String {
-        watchIDs.sorted().joined(separator: "\n")
+    func finish(_ event: NotificationEvent, didSchedule: Bool) async {
+        guard let watchId = event.payload["watchId"] as? String, watchId.isEmpty == false else { return }
+        await claims.finish(watchId, didSchedule: didSchedule)
     }
 }
 

--- a/Tests/UnitTests/AlertNotificationTests.swift
+++ b/Tests/UnitTests/AlertNotificationTests.swift
@@ -39,25 +39,50 @@ struct AlertNotificationTests {
         #expect(event.payload["title"] as? String == newerAlert.title)
     }
 
-    @Test("gate blocks duplicate alert notifications")
-    func gateBlocksDuplicateAlertNotifications() async {
-        let gate = WatchGate(store: InMemoryNotificationStore())
+    @Test("gate claims once, retries failure, and commits success")
+    func gateClaimsOnceRetriesFailureAndCommitsSuccess() async {
+        let store = InMemoryNotificationStore()
+        let gate = WatchGate(store: store)
         let event = NotificationEvent(
             kind: .watchNotification,
             key: "watch:abc123",
             payload: ["watchId": "abc123"]
         )
 
-        let firstPass = await gate.allow(event, now: .now)
-        let secondPass = await gate.allow(event, now: .now)
+        async let firstPass = gate.allow(event, now: .now)
+        async let secondPass = gate.allow(event, now: .now)
+        let claimCount = await [firstPass, secondPass].filter { $0 }.count
 
-        #expect(firstPass)
-        #expect(secondPass == false)
+        #expect(claimCount == 1)
+        await gate.finish(event, didSchedule: false)
+        #expect(await gate.allow(event, now: .now))
+        await gate.finish(event, didSchedule: true)
+        #expect(await gate.allow(event, now: .now) == false)
+        #expect(await WatchGate(store: store).allow(event, now: .now) == false)
+    }
+
+    @Test("gate reads the existing newline-separated watch stamps")
+    func gateReadsExistingWatchStamps() async {
+        let gate = WatchGate(store: InMemoryNotificationStore(stamp: "first\nsecond"))
+        let firstEvent = NotificationEvent(
+            kind: .watchNotification,
+            key: "watch:first",
+            payload: ["watchId": "first"]
+        )
+        let secondEvent = NotificationEvent(
+            kind: .watchNotification,
+            key: "watch:second",
+            payload: ["watchId": "second"]
+        )
+
+        #expect(await gate.allow(firstEvent, now: .now) == false)
+        #expect(await gate.allow(secondEvent, now: .now) == false)
     }
 
     @Test("gate remembers more than the most recent alert id")
     func gateRemembersMoreThanMostRecentAlertID() async {
-        let gate = WatchGate(store: InMemoryNotificationStore())
+        let store = InMemoryNotificationStore()
+        let gate = WatchGate(store: store)
         let firstEvent = NotificationEvent(
             kind: .watchNotification,
             key: "watch:first",
@@ -70,8 +95,14 @@ struct AlertNotificationTests {
         )
 
         #expect(await gate.allow(firstEvent, now: .now))
+        await gate.finish(firstEvent, didSchedule: true)
         #expect(await gate.allow(secondEvent, now: .now))
+        await gate.finish(secondEvent, didSchedule: true)
         #expect(await gate.allow(firstEvent, now: .now) == false)
+
+        let reloadedGate = WatchGate(store: store)
+        #expect(await reloadedGate.allow(firstEvent, now: .now) == false)
+        #expect(await reloadedGate.allow(secondEvent, now: .now) == false)
     }
 
     @Test("engine sends a single notification for a new alert")
@@ -100,24 +131,30 @@ struct AlertNotificationTests {
         #expect(sent[0].id == "watch:abc123")
     }
 
-    @Test("watch engine reports scheduling failure")
-    func watchEngineReportsSchedulingFailure() async {
+    @Test("watch engine retries scheduling failure and suppresses the successful occurrence")
+    func watchEngineRetriesSchedulingFailure() async {
+        let sender = SequencedWatchSender(results: [false, true])
         let engine = WatchEngine(
             rule: WatchRule(),
             gate: WatchGate(store: InMemoryNotificationStore()),
             composer: WatchComposer(),
-            sender: FailingWatchSender()
+            sender: sender
         )
 
-        #expect(await engine.run(
-            ctx: .init(
-                now: .now,
-                localTZ: centralTime,
-                location: CLLocationCoordinate2D(latitude: 35.4676, longitude: -97.5164),
-                placeMark: "Oklahoma City, OK"
-            ),
-            alerts: [makeAlert(id: "failed", issued: .now.addingTimeInterval(-300), ends: .now.addingTimeInterval(3_600))]
-        ) == false)
+        let context = NotificationContext(
+            now: .now,
+            localTZ: centralTime,
+            location: CLLocationCoordinate2D(latitude: 35.4676, longitude: -97.5164),
+            placeMark: "Oklahoma City, OK"
+        )
+        let alerts = [
+            makeAlert(id: "failed", issued: .now.addingTimeInterval(-300), ends: .now.addingTimeInterval(3_600))
+        ]
+
+        #expect(await engine.run(ctx: context, alerts: alerts) == false)
+        #expect(await engine.run(ctx: context, alerts: alerts))
+        #expect(await engine.run(ctx: context, alerts: alerts) == false)
+        #expect(await sender.attemptCount() == 2)
     }
 
     @Test("composer uses server-aligned wording for known alert event types")
@@ -494,8 +531,20 @@ private struct NoopSender: NotificationSending {
     func send(title: String, body: String, subtitle: String, id: String) async -> Bool { true }
 }
 
-private struct FailingWatchSender: NotificationSending {
-    func send(title: String, body: String, subtitle: String, id: String) async -> Bool { false }
+private actor SequencedWatchSender: NotificationSending {
+    private var results: [Bool]
+    private var attempts = 0
+
+    init(results: [Bool]) {
+        self.results = results
+    }
+
+    func send(title: String, body: String, subtitle: String, id: String) async -> Bool {
+        attempts += 1
+        return results.removeFirst()
+    }
+
+    func attemptCount() -> Int { attempts }
 }
 
 private func makeRiskChangeEngine<Sender: NotificationSending>(
@@ -512,6 +561,10 @@ private func makeRiskChangeEngine<Sender: NotificationSending>(
 
 actor InMemoryNotificationStore: NotificationStateStoring {
     private var stamp: String?
+
+    init(stamp: String? = nil) {
+        self.stamp = stamp
+    }
 
     func lastStamp() async -> String? { stamp }
     func setLastStamp(_ stamp: String) async { self.stamp = stamp }

--- a/Tests/UnitTests/MesoNotificationTests.swift
+++ b/Tests/UnitTests/MesoNotificationTests.swift
@@ -91,8 +91,9 @@ struct MesoNotificationTests {
     }
     
     @Test
-    func gateBlocksDuplicateEvents() async {
-        let gate = MesoGate(store: InMemoryMesoStore())
+    func gateClaimsOnceRetriesFailureAndCommitsSuccess() async {
+        let store = InMemoryMesoStore()
+        let gate = MesoGate(store: store)
         let event = NotificationEvent(
             kind: .mesoNotification,
             key: "meso:2026-01-02-1234",
@@ -102,11 +103,28 @@ struct MesoNotificationTests {
             ]
         )
         
-        let firstPass = await gate.allow(event, now: .now)
-        let secondPass = await gate.allow(event, now: .now)
-        
-        #expect(firstPass == true)
-        #expect(secondPass == false)
+        async let firstPass = gate.allow(event, now: .now)
+        async let secondPass = gate.allow(event, now: .now)
+        let claimCount = await [firstPass, secondPass].filter { $0 }.count
+
+        #expect(claimCount == 1)
+        await gate.finish(event, didSchedule: false)
+        #expect(await gate.allow(event, now: .now))
+        await gate.finish(event, didSchedule: true)
+        #expect(await gate.allow(event, now: .now) == false)
+        #expect(await MesoGate(store: store).allow(event, now: .now) == false)
+    }
+
+    @Test("gate reads the existing meso stamp")
+    func gateReadsExistingStamp() async {
+        let event = NotificationEvent(
+            kind: .mesoNotification,
+            key: "meso:2026-01-02-1234",
+            payload: ["mesoId": 1234]
+        )
+        let gate = MesoGate(store: InMemoryMesoStore(stamp: event.key))
+
+        #expect(await gate.allow(event, now: .now) == false)
     }
 
     @Test
@@ -213,15 +231,16 @@ struct MesoNotificationTests {
         #expect(message.body.localizedCaseInsensitiveContains("unknown") == false)
     }
 
-    @Test("engine reports scheduling failure")
-    func engineReportsSchedulingFailure() async {
-        let now = makeDate(year: 2026, month: 1, day: 2, hour: 15, tz: centralTime)
+    @Test("engine retries a scheduling failure and suppresses the successful occurrence")
+    func engineRetriesSchedulingFailure() async {
+        let now = Date.now
         let meso = makeMeso(issued: now.addingTimeInterval(-3_600), validEnd: now.addingTimeInterval(3_600))
+        let sender = SequencedMesoSender(results: [false, true])
         let engine = MesoEngine(
             rule: MesoRule(),
             gate: MesoGate(store: InMemoryMesoStore()),
             composer: MesoComposer(),
-            sender: FailingMesoSender(),
+            sender: sender,
             spc: UnusedMesoQuery()
         )
         let context = NotificationContext(
@@ -232,6 +251,9 @@ struct MesoNotificationTests {
         )
 
         #expect(await engine.run(ctx: context, mesos: [meso]) == false)
+        #expect(await engine.run(ctx: context, mesos: [meso]))
+        #expect(await engine.run(ctx: context, mesos: [meso]) == false)
+        #expect(await sender.attemptCount() == 2)
     }
 }
 
@@ -239,13 +261,29 @@ struct MesoNotificationTests {
 
 actor InMemoryMesoStore: NotificationStateStoring {
     private var stamp: String?
+
+    init(stamp: String? = nil) {
+        self.stamp = stamp
+    }
     
     func lastStamp() async -> String? { stamp }
     func setLastStamp(_ stamp: String) async { self.stamp = stamp }
 }
 
-private struct FailingMesoSender: NotificationSending {
-    func send(title: String, body: String, subtitle: String, id: String) async -> Bool { false }
+private actor SequencedMesoSender: NotificationSending {
+    private var results: [Bool]
+    private var attempts = 0
+
+    init(results: [Bool]) {
+        self.results = results
+    }
+
+    func send(title: String, body: String, subtitle: String, id: String) async -> Bool {
+        attempts += 1
+        return results.removeFirst()
+    }
+
+    func attemptCount() -> Int { attempts }
 }
 
 private struct UnusedMesoQuery: SpcRiskQuerying {

--- a/Tests/UnitTests/MorningNotificationTests.swift
+++ b/Tests/UnitTests/MorningNotificationTests.swift
@@ -82,8 +82,9 @@ struct MorningNotificationTests {
     }
     
     @Test
-    func gateBlocksDuplicateEvents() async {
-        let gate = MorningGate(store: InMemoryMorningStore())
+    func gateClaimsOnceRetriesFailureAndCommitsSuccess() async {
+        let store = InMemoryMorningStore()
+        let gate = MorningGate(store: store)
         let event = NotificationEvent(
             kind: .morningOutlook,
             key: "morning:2026-01-02",
@@ -92,11 +93,29 @@ struct MorningNotificationTests {
             ]
         )
         
-        let firstPass = await gate.allow(event, now: .now)
-        let secondPass = await gate.allow(event, now: .now)
-        
-        #expect(firstPass == true)
-        #expect(secondPass == false)
+        async let firstPass = gate.allow(event, now: .now)
+        async let secondPass = gate.allow(event, now: .now)
+        let claimCount = await [firstPass, secondPass].filter { $0 }.count
+
+        #expect(claimCount == 1)
+        await gate.finish(event, didSchedule: false)
+        #expect(await gate.allow(event, now: .now))
+        await gate.finish(event, didSchedule: true)
+        #expect(await gate.allow(event, now: .now) == false)
+        #expect(await MorningGate(store: store).allow(event, now: .now) == false)
+    }
+
+    @Test("gate reads the existing morning stamp")
+    func gateReadsExistingStamp() async {
+        let store = InMemoryMorningStore(stamp: "2026-01-02")
+        let gate = MorningGate(store: store)
+        let event = NotificationEvent(
+            kind: .morningOutlook,
+            key: "morning:2026-01-02",
+            payload: ["localDay": "2026-01-02"]
+        )
+
+        #expect(await gate.allow(event, now: .now) == false)
     }
 
     @Test("composer preserves the normal morning summary without a risk change")
@@ -167,14 +186,15 @@ struct MorningNotificationTests {
         """)
     }
 
-    @Test("engine reports scheduling failure")
-    func engineReportsSchedulingFailure() async {
+    @Test("engine retries a scheduling failure and suppresses the successful occurrence")
+    func engineRetriesSchedulingFailure() async {
         let now = makeDate(year: 2026, month: 1, day: 2, hour: 8, tz: centralTime)
+        let sender = SequencedMorningSender(results: [false, true])
         let engine = MorningEngine(
             rule: AmRangeLocalRule(window: 7..<11),
             gate: MorningGate(store: InMemoryMorningStore()),
             composer: MorningComposer(),
-            sender: FailingMorningSender()
+            sender: sender
         )
         let context = MorningContext(
             now: now,
@@ -188,6 +208,9 @@ struct MorningNotificationTests {
         )
 
         #expect(await engine.run(ctx: context) == false)
+        #expect(await engine.run(ctx: context))
+        #expect(await engine.run(ctx: context) == false)
+        #expect(await sender.attemptCount() == 2)
     }
 }
 
@@ -195,11 +218,27 @@ struct MorningNotificationTests {
 
 actor InMemoryMorningStore: NotificationStateStoring {
     private var stamp: String?
+
+    init(stamp: String? = nil) {
+        self.stamp = stamp
+    }
     
     func lastStamp() async -> String? { stamp }
     func setLastStamp(_ stamp: String) async { self.stamp = stamp }
 }
 
-private struct FailingMorningSender: NotificationSending {
-    func send(title: String, body: String, subtitle: String, id: String) async -> Bool { false }
+private actor SequencedMorningSender: NotificationSending {
+    private var results: [Bool]
+    private var attempts = 0
+
+    init(results: [Bool]) {
+        self.results = results
+    }
+
+    func send(title: String, body: String, subtitle: String, id: String) async -> Bool {
+        attempts += 1
+        return results.removeFirst()
+    }
+
+    func attemptCount() -> Int { attempts }
 }


### PR DESCRIPTION
# Summary
This branch changes notification gating so a failed scheduling attempt does not permanently consume an occurrence. Morning, meso, and watch notifications now claim eligibility before scheduling and only commit delivered state after the sender reports success; if scheduling fails, the occurrence stays eligible for retry. It also expands unit coverage for retry and duplicate suppression across the affected notification paths.

# What Changed
- Added a shared claim-and-finish helper for notification gating state.
- Updated the morning, meso, and watch gates to claim before sending and finish only after the sender result is known.
- Wired the notification engines to finalize gate state after each scheduling attempt.
- Expanded unit tests to cover failed-then-successful retries, duplicate suppression after success, and reading existing persisted stamps.

# User Impact
Failed local notification scheduling no longer burns the underlying occurrence. Users should get another chance on a later run after a transient authorization or scheduling failure instead of losing a morning, meso, or watch notification permanently.

# Testing
- Not run. This PR was drafted from the committed branch diff only.

# Notes
- Existing persisted stamps remain readable, including the newline-separated watch stamp format.