### PR TITLE
Restrict the in-app web viewer to trusted domains

### DIFF
--- a/Sources/Utilities/Core/WebContentRoute.swift
+++ b/Sources/Utilities/Core/WebContentRoute.swift
@@ -32,6 +32,11 @@ enum WebContentNavigationDecision: Sendable, Equatable {
 
 enum WebContentPolicy {
     private static let inAppSchemes: Set<String> = ["http", "https"]
+    private static let trustedDomains: Set<String> = [
+        "weather.gov",
+        "spc.noaa.gov",
+        "weatherkit.apple.com"
+    ]
     private static let externalSchemes: Set<String> = [
         "mailto", "tel", "sms", "maps", "facetime", "facetime-audio", "itms-apps", "itms-appss"
     ]
@@ -42,10 +47,10 @@ enum WebContentPolicy {
         }
 
         if inAppSchemes.contains(scheme) {
-            guard url.host?.isEmpty == false else {
+            guard let host = url.host?.lowercased(), host.isEmpty == false else {
                 return .unsupported
             }
-            return .inApp
+            return isTrusted(host: host) ? .inApp : .external
         }
 
         if externalSchemes.contains(scheme) {
@@ -57,5 +62,9 @@ enum WebContentPolicy {
 
     static func canOpenInApp(_ url: URL) -> Bool {
         decision(for: url) == .inApp
+    }
+
+    private static func isTrusted(host: String) -> Bool {
+        trustedDomains.contains { host == $0 || host.hasSuffix("." + $0) }
     }
 }

--- a/Tests/UnitTests/WidgetRouteURLTests.swift
+++ b/Tests/UnitTests/WidgetRouteURLTests.swift
@@ -42,20 +42,44 @@ struct WidgetRouteURLTests {
 
 @Suite("Web content policy")
 struct WebContentPolicyTests {
-    @Test("allows https URLs in-app")
-    func allowsHTTPSInApp() throws {
+    @Test("allows an exact trusted host in-app")
+    func allowsExactTrustedHostInApp() throws {
+        let url = try #require(URL(string: "https://weather.gov"))
+
+        #expect(WebContentPolicy.decision(for: url) == .inApp)
+        #expect(WebContentPolicy.canOpenInApp(url))
+    }
+
+    @Test("allows trusted source URLs in-app")
+    func allowsTrustedSourceURLInApp() throws {
         let url = try #require(URL(string: "https://www.spc.noaa.gov/products/outlook/day1otlk.html"))
 
         #expect(WebContentPolicy.decision(for: url) == .inApp)
         #expect(WebContentPolicy.canOpenInApp(url))
     }
 
-    @Test("allows http URLs in-app")
-    func allowsHTTPInApp() throws {
-        let url = try #require(URL(string: "http://example.com/reference"))
+    @Test("allows an intended trusted subdomain in-app")
+    func allowsTrustedSubdomainInApp() throws {
+        let url = try #require(URL(string: "https://api.weather.gov/alerts/123"))
 
         #expect(WebContentPolicy.decision(for: url) == .inApp)
         #expect(WebContentPolicy.canOpenInApp(url))
+    }
+
+    @Test("routes unrelated web hosts externally")
+    func routesUnrelatedWebHostExternally() throws {
+        let url = try #require(URL(string: "https://example.com/reference"))
+
+        #expect(WebContentPolicy.decision(for: url) == .external)
+        #expect(WebContentPolicy.canOpenInApp(url) == false)
+    }
+
+    @Test("rejects deceptive lookalike hosts")
+    func rejectsDeceptiveLookalikeHost() throws {
+        let url = try #require(URL(string: "https://weather.gov.example.com/reference"))
+
+        #expect(WebContentPolicy.decision(for: url) == .external)
+        #expect(WebContentPolicy.canOpenInApp(url) == false)
     }
 
     @Test("rejects malformed web URL")


### PR DESCRIPTION
# Summary
This branch tightens the in-app web content policy so HTTP/HTTPS destinations stay embedded only when the host is in a small trusted set. Untrusted web destinations now route out through the existing external path, which keeps the viewer aligned with its source-content purpose.

# What Changed
- Added an explicit trusted-domain allowlist to the web content policy.
- Kept trusted official source URLs in-app while routing other HTTP/HTTPS hosts externally.
- Preserved existing handling for non-web external schemes and unsupported URLs.
- Expanded unit tests to cover trusted hosts, intended subdomains, unrelated hosts, lookalike hosts, and malformed URLs.

# User Impact
Links opened from trusted source pages are less likely to behave like a general-purpose browser. Users can still view intended source content in-app, while other web destinations now leave the embedded viewer instead of continuing navigation inside SkyAware.

# Testing
- Not run. This PR was drafted from the committed branch diff only.

# Notes
- The allowlist is host-aware and explicitly permits intended subdomains without relying on naive suffix matching.
- The trusted set in this branch covers weather.gov, spc.noaa.gov, and weatherkit.apple.com.