### PR TITLE
Prevent false risk-change notifications from partial syncs and movement

### DIFF
--- a/Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift
+++ b/Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift
@@ -172,6 +172,8 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
     private struct SlowProductPersistenceDecision: Sendable {
         let updatesConvective: Bool
         let updatesFire: Bool
+        let convectiveSource: SpcMapSourceIdentity?
+        let fireSource: SpcMapSourceIdentity?
         let reconcilesRejectedDomains: Bool
         let shouldRefreshRiskWidgets: Bool
 
@@ -331,6 +333,7 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
         )
         snapshot.weatherRefreshResult = weatherRefresh
         if let context {
+            snapshot.riskComparisonLocationKey = HomeProjection.riskComparisonLocationKey(for: context)
             let slowProductDecision = slowProductPersistenceDecision(
                 plan: plan,
                 mapSyncOutcome: slowProductMapSyncOutcome
@@ -682,6 +685,8 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
                         slowProducts: slowProducts,
                         updatesConvectiveRisk: slowProductDecision.updatesConvective,
                         updatesFireRisk: slowProductDecision.updatesFire,
+                        convectiveSource: slowProductDecision.convectiveSource,
+                        fireSource: slowProductDecision.fireSource,
                         hotAlerts: hotAlerts
                     ),
                     for: context,
@@ -791,6 +796,8 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
             let decision = SlowProductPersistenceDecision(
                 updatesConvective: false,
                 updatesFire: false,
+                convectiveSource: nil,
+                fireSource: nil,
                 reconcilesRejectedDomains: false,
                 shouldRefreshRiskWidgets: true
             )
@@ -806,6 +813,8 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
             let decision = SlowProductPersistenceDecision(
                 updatesConvective: true,
                 updatesFire: true,
+                convectiveSource: nil,
+                fireSource: nil,
                 reconcilesRejectedDomains: false,
                 shouldRefreshRiskWidgets: true
             )
@@ -821,6 +830,8 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
             let decision = SlowProductPersistenceDecision(
                 updatesConvective: true,
                 updatesFire: true,
+                convectiveSource: nil,
+                fireSource: nil,
                 reconcilesRejectedDomains: false,
                 shouldRefreshRiskWidgets: true
             )
@@ -837,6 +848,8 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
         let decision = SlowProductPersistenceDecision(
             updatesConvective: updatesConvective,
             updatesFire: updatesFire,
+            convectiveSource: mapSyncOutcome.convective == .accepted ? mapSyncOutcome.convectiveSource : nil,
+            fireSource: mapSyncOutcome.fire == .accepted ? mapSyncOutcome.fireSource : nil,
             reconcilesRejectedDomains: updatesConvective == false || updatesFire == false,
             shouldRefreshRiskWidgets: updatesConvective || updatesFire
         )

--- a/Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift
+++ b/Sources/App/HomeRefreshV2/HomeIngestionExecutor.swift
@@ -170,8 +170,14 @@ protocol HomeIngestionExecuting: Sendable {
 
 actor HomeIngestionExecutor: HomeIngestionExecuting {
     private struct SlowProductPersistenceDecision: Sendable {
-        let shouldUpdateProjection: Bool
+        let updatesConvective: Bool
+        let updatesFire: Bool
+        let reconcilesRejectedDomains: Bool
         let shouldRefreshRiskWidgets: Bool
+
+        var shouldUpdateProjection: Bool {
+            updatesConvective || updatesFire
+        }
     }
 
     struct Environment: Sendable {
@@ -297,8 +303,10 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
                 environment.logger.info("Running home ingestion slow-product sync mode=\(executionMode.logName, privacy: .public)")
                 slowProductMapSyncOutcome = await syncSlowFeeds(executionMode: executionMode)
                 try await throwIfBackgroundDeadlineExceeded()
-                if slowProductMapSyncOutcome == .accepted {
+                if slowProductMapSyncOutcome?.isFullyAccepted == true {
                     freshness.lastSlowFeedSyncAt = now
+                } else if slowProductMapSyncOutcome != .skipped {
+                    freshness.lastSlowFeedSyncAt = nil
                 }
                 await progress.report(.completed(.lane(.slowProducts)))
                 environment.logger.debug("Finished home ingestion slow-product sync")
@@ -326,6 +334,11 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
             let slowProductDecision = slowProductPersistenceDecision(
                 plan: plan,
                 mapSyncOutcome: slowProductMapSyncOutcome
+            )
+            snapshot = await reconcilingRejectedRiskDomains(
+                in: snapshot,
+                for: context,
+                decision: slowProductDecision
             )
             let riskProfileChange = await persistProjection(
                 for: plan,
@@ -664,7 +677,13 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
 
             if weather != nil || slowProducts != nil || hotAlerts != nil {
                 riskProfileChange = try await projectionStore.commitCore(
-                    .init(weather: weather, slowProducts: slowProducts, hotAlerts: hotAlerts),
+                    .init(
+                        weather: weather,
+                        slowProducts: slowProducts,
+                        updatesConvectiveRisk: slowProductDecision.updatesConvective,
+                        updatesFireRisk: slowProductDecision.updatesFire,
+                        hotAlerts: hotAlerts
+                    ),
                     for: context,
                     loadedAt: loadedAt
                 )
@@ -696,6 +715,34 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
         }
 
         return riskProfileChange
+    }
+
+    private func reconcilingRejectedRiskDomains(
+        in snapshot: HomeSnapshot,
+        for context: LocationContext,
+        decision: SlowProductPersistenceDecision
+    ) async -> HomeSnapshot {
+        guard decision.reconcilesRejectedDomains else { return snapshot }
+
+        var reconciled = snapshot
+        let projection: HomeProjectionRecord?
+        do {
+            projection = try await environment.projectionStore?.projection(for: context)
+        } catch {
+            projection = nil
+            environment.logger.error(
+                "Failed to load prior home projection while preserving rejected SPC domains: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+
+        if decision.updatesConvective == false {
+            reconciled.stormRisk = projection?.stormRisk
+            reconciled.severeRisk = projection?.severeRisk
+        }
+        if decision.updatesFire == false {
+            reconciled.fireRisk = projection?.fireRisk
+        }
+        return reconciled
     }
 
     private func httpExecutionMode(for plan: HomeIngestionPlan) -> HTTPExecutionMode {
@@ -742,7 +789,9 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
         let shouldUpdateSlowProjection = plan.lanes.contains(.slowProducts) || plan.isLocationBearing
         guard shouldUpdateSlowProjection else {
             let decision = SlowProductPersistenceDecision(
-                shouldUpdateProjection: false,
+                updatesConvective: false,
+                updatesFire: false,
+                reconcilesRejectedDomains: false,
                 shouldRefreshRiskWidgets: true
             )
             logSlowProductPersistenceDecision(
@@ -755,7 +804,9 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
 
         guard plan.lanes.contains(.slowProducts) else {
             let decision = SlowProductPersistenceDecision(
-                shouldUpdateProjection: true,
+                updatesConvective: true,
+                updatesFire: true,
+                reconcilesRejectedDomains: false,
                 shouldRefreshRiskWidgets: true
             )
             logSlowProductPersistenceDecision(
@@ -768,7 +819,9 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
 
         guard let mapSyncOutcome else {
             let decision = SlowProductPersistenceDecision(
-                shouldUpdateProjection: true,
+                updatesConvective: true,
+                updatesFire: true,
+                reconcilesRejectedDomains: false,
                 shouldRefreshRiskWidgets: true
             )
             logSlowProductPersistenceDecision(
@@ -779,20 +832,18 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
             return decision
         }
 
-        let decision: SlowProductPersistenceDecision
-        let reason: String
-        switch mapSyncOutcome {
-        case .accepted, .skipped:
-            decision = .init(shouldUpdateProjection: true, shouldRefreshRiskWidgets: true)
-            reason = mapSyncOutcome == .accepted ? "map_sync_accepted" : "map_sync_skipped"
-        case .rejected, .failed:
-            decision = .init(shouldUpdateProjection: false, shouldRefreshRiskWidgets: false)
-            reason = mapSyncOutcome == .rejected ? "map_sync_rejected" : "map_sync_failed"
-        }
+        let updatesConvective = mapSyncOutcome.convective.authorizesProjection
+        let updatesFire = mapSyncOutcome.fire.authorizesProjection
+        let decision = SlowProductPersistenceDecision(
+            updatesConvective: updatesConvective,
+            updatesFire: updatesFire,
+            reconcilesRejectedDomains: updatesConvective == false || updatesFire == false,
+            shouldRefreshRiskWidgets: updatesConvective || updatesFire
+        )
         logSlowProductPersistenceDecision(
             mapSyncOutcome: mapSyncOutcome,
             decision: decision,
-            reason: reason
+            reason: "map_sync_domain_authority"
         )
         return decision
     }
@@ -804,11 +855,15 @@ actor HomeIngestionExecutor: HomeIngestionExecuting {
     ) {
         let outcome = mapSyncOutcome.map(Self.logName(for:)) ?? "none"
         environment.logger.info(
-            "spc_map_persistence_projection_decision mapSyncOutcome=\(outcome, privacy: .public) reason=\(reason, privacy: .public) projection=\(decision.shouldUpdateProjection ? "updated" : "preserved", privacy: .public) widgets=\(decision.shouldRefreshRiskWidgets ? "updated" : "preserved", privacy: .public)"
+            "spc_map_persistence_projection_decision mapSyncOutcome=\(outcome, privacy: .public) reason=\(reason, privacy: .public) convective=\(decision.updatesConvective ? "updated" : "preserved", privacy: .public) fire=\(decision.updatesFire ? "updated" : "preserved", privacy: .public) widgets=\(decision.shouldRefreshRiskWidgets ? "updated" : "preserved", privacy: .public)"
         )
     }
 
     private static func logName(for outcome: SpcMapSyncOutcome) -> String {
+        "convective=\(logName(for: outcome.convective)),fire=\(logName(for: outcome.fire))"
+    }
+
+    private static func logName(for outcome: SpcMapSyncDomainOutcome) -> String {
         switch outcome {
         case .accepted:
             return "accepted"

--- a/Sources/App/HomeRefreshV2/HomeSnapshot.swift
+++ b/Sources/App/HomeRefreshV2/HomeSnapshot.swift
@@ -30,6 +30,7 @@ struct HomeSnapshot: Sendable, Equatable {
     var severeRisk: SevereWeatherThreat?
     var fireRisk: FireRiskLevel?
     var riskProfileChange: RiskProfileChange?
+    var riskComparisonLocationKey: String?
     var mesos: [MdDTO]
     var alerts: [AlertDTO]
     var outlooks: [ConvectiveOutlookDTO]
@@ -49,6 +50,7 @@ struct HomeSnapshot: Sendable, Equatable {
         severeRisk: SevereWeatherThreat? = nil,
         fireRisk: FireRiskLevel? = nil,
         riskProfileChange: RiskProfileChange? = nil,
+        riskComparisonLocationKey: String? = nil,
         mesos: [MdDTO] = [],
         alerts: [AlertDTO] = [],
         outlooks: [ConvectiveOutlookDTO] = [],
@@ -67,6 +69,7 @@ struct HomeSnapshot: Sendable, Equatable {
         self.severeRisk = severeRisk
         self.fireRisk = fireRisk
         self.riskProfileChange = riskProfileChange
+        self.riskComparisonLocationKey = riskComparisonLocationKey
         self.mesos = mesos
         self.alerts = alerts
         self.outlooks = outlooks

--- a/Sources/Features/Background/BackgroundLocationChangeHandler.swift
+++ b/Sources/Features/Background/BackgroundLocationChangeHandler.swift
@@ -66,7 +66,8 @@ actor BackgroundLocationChangeHandler {
                 let settings = await notificationSettingsProvider.current()
                 _ = await riskChangeEngine.run(
                     change: snapshot.riskProfileChange,
-                    isEnabled: settings.riskChangeNotificationsEnabled
+                    isEnabled: settings.riskChangeNotificationsEnabled,
+                    activeLocationKey: snapshot.riskComparisonLocationKey
                 )
             } catch {
                 logger.error(

--- a/Sources/Features/Background/BackgroundOrchestrator.swift
+++ b/Sources/Features/Background/BackgroundOrchestrator.swift
@@ -412,7 +412,8 @@ actor BackgroundOrchestrator {
 
                     didRiskChangeNotify = await riskChangeEngine.run(
                         change: coalescedCurrentRiskChange ? nil : snapshot.riskProfileChange,
-                        isEnabled: settings.riskChangeNotificationsEnabled
+                        isEnabled: settings.riskChangeNotificationsEnabled,
+                        activeLocationKey: snapshot.riskComparisonLocationKey
                     )
                     try Task.checkCancellation()
                     if settings.riskChangeNotificationsEnabled {

--- a/Sources/Interfaces/SPC/SpcSyncing.swift
+++ b/Sources/Interfaces/SPC/SpcSyncing.swift
@@ -7,6 +7,24 @@
 
 import Foundation
 
+enum SpcMapSourceIdentity: Sendable, Equatable {
+    case forecast(issued: Date, valid: Date, expires: Date)
+    case acceptedAllClear(at: Date)
+
+    var persistenceToken: String {
+        switch self {
+        case .forecast(let issued, let valid, let expires):
+            return "forecast:\(Self.token(for: issued)):\(Self.token(for: valid)):\(Self.token(for: expires))"
+        case .acceptedAllClear(let date):
+            return "all-clear:\(Self.token(for: date))"
+        }
+    }
+
+    private static func token(for date: Date) -> String {
+        String(date.timeIntervalSinceReferenceDate.bitPattern, radix: 16)
+    }
+}
+
 enum SpcMapSyncDomainOutcome: Sendable, Equatable {
     case accepted
     case rejected
@@ -21,6 +39,20 @@ enum SpcMapSyncDomainOutcome: Sendable, Equatable {
 struct SpcMapSyncOutcome: Sendable, Equatable {
     let convective: SpcMapSyncDomainOutcome
     let fire: SpcMapSyncDomainOutcome
+    let convectiveSource: SpcMapSourceIdentity?
+    let fireSource: SpcMapSourceIdentity?
+
+    init(
+        convective: SpcMapSyncDomainOutcome,
+        fire: SpcMapSyncDomainOutcome,
+        convectiveSource: SpcMapSourceIdentity? = nil,
+        fireSource: SpcMapSourceIdentity? = nil
+    ) {
+        self.convective = convective
+        self.fire = fire
+        self.convectiveSource = convectiveSource
+        self.fireSource = fireSource
+    }
 
     static let accepted = SpcMapSyncOutcome(convective: .accepted, fire: .accepted)
     static let rejected = SpcMapSyncOutcome(convective: .rejected, fire: .rejected)

--- a/Sources/Interfaces/SPC/SpcSyncing.swift
+++ b/Sources/Interfaces/SPC/SpcSyncing.swift
@@ -7,11 +7,29 @@
 
 import Foundation
 
-enum SpcMapSyncOutcome: Sendable, Equatable {
+enum SpcMapSyncDomainOutcome: Sendable, Equatable {
     case accepted
     case rejected
     case skipped
     case failed
+
+    var authorizesProjection: Bool {
+        self == .accepted || self == .skipped
+    }
+}
+
+struct SpcMapSyncOutcome: Sendable, Equatable {
+    let convective: SpcMapSyncDomainOutcome
+    let fire: SpcMapSyncDomainOutcome
+
+    static let accepted = SpcMapSyncOutcome(convective: .accepted, fire: .accepted)
+    static let rejected = SpcMapSyncOutcome(convective: .rejected, fire: .rejected)
+    static let skipped = SpcMapSyncOutcome(convective: .skipped, fire: .skipped)
+    static let failed = SpcMapSyncOutcome(convective: .failed, fire: .failed)
+
+    var isFullyAccepted: Bool {
+        convective == .accepted && fire == .accepted
+    }
 }
 
 protocol SpcSyncing: Sendable {//where Self: Actor {

--- a/Sources/Models/Home/HomeProjection.swift
+++ b/Sources/Models/Home/HomeProjection.swift
@@ -174,6 +174,10 @@ final class HomeProjection {
     var stormRisk: StormRiskLevel?
     var severeRisk: SevereWeatherThreat?
     var fireRisk: FireRiskLevel?
+    var convectiveRiskComparisonLocationKey: String?
+    var convectiveRiskComparisonSourceKey: String?
+    var fireRiskComparisonLocationKey: String?
+    var fireRiskComparisonSourceKey: String?
     var activeAlerts: [AlertDTO]
     var activeMesos: [MdDTO]
 
@@ -206,6 +210,10 @@ final class HomeProjection {
         stormRisk = nil
         severeRisk = nil
         fireRisk = nil
+        convectiveRiskComparisonLocationKey = nil
+        convectiveRiskComparisonSourceKey = nil
+        fireRiskComparisonLocationKey = nil
+        fireRiskComparisonSourceKey = nil
         activeAlerts = []
         activeMesos = []
         lastHotAlertsLoadAt = nil
@@ -224,6 +232,17 @@ extension HomeProjection {
             "fire:\(normalizedKeyComponent(context.grid.fireZone))"
         ]
         return components.joined(separator: "|")
+    }
+
+    /// Risk comparisons require both the coarse projection and the existing E4 coordinate bucket.
+    /// A different identity seeds a baseline instead of treating movement as a forecast change.
+    static func riskComparisonLocationKey(for context: LocationContext) -> String {
+        let gridKey = context.refreshKey.gridKey
+        return [
+            projectionKey(for: context),
+            "latitudeE4:\(gridKey.latitudeE4)",
+            "longitudeE4:\(gridKey.longitudeE4)"
+        ].joined(separator: "|")
     }
 
     var record: HomeProjectionRecord {

--- a/Sources/Notifications/RiskChange/RiskChangeComposer.swift
+++ b/Sources/Notifications/RiskChange/RiskChangeComposer.swift
@@ -33,7 +33,7 @@ enum RiskProfileChangeFormatting {
     static func transitionLines(for change: RiskProfileChange) -> [String] {
         change.changedDimensions
             .sorted(by: dimensionSort)
-            .map { formatTransition(for: $0, change: change) }
+            .compactMap { formatTransition(for: $0, change: change) }
     }
 
     private static func dimensionSort(_ lhs: RiskProfileDimension, _ rhs: RiskProfileDimension) -> Bool {
@@ -51,14 +51,17 @@ enum RiskProfileChangeFormatting {
         }
     }
 
-    private static func formatTransition(for dimension: RiskProfileDimension, change: RiskProfileChange) -> String {
+    private static func formatTransition(for dimension: RiskProfileDimension, change: RiskProfileChange) -> String? {
         switch dimension {
         case .storm:
-            return "Storm Risk: \(stormText(change.previous.stormRisk)) → \(stormText(change.current.stormRisk))"
+            guard let previous = change.previous.stormRisk, let current = change.current.stormRisk else { return nil }
+            return "Storm Risk: \(stormText(previous)) → \(stormText(current))"
         case .severe:
-            return "Severe Risk: \(severeText(change.previous.severeRisk)) → \(severeText(change.current.severeRisk))"
+            guard let previous = change.previous.severeRisk, let current = change.current.severeRisk else { return nil }
+            return "Severe Risk: \(severeText(previous)) → \(severeText(current))"
         case .fire:
-            return "Fire Risk: \(fireText(change.previous.fireRisk)) → \(fireText(change.current.fireRisk))"
+            guard let previous = change.previous.fireRisk, let current = change.current.fireRisk else { return nil }
+            return "Fire Risk: \(fireText(previous)) → \(fireText(current))"
         }
     }
 

--- a/Sources/Notifications/RiskChange/RiskChangeEngine.swift
+++ b/Sources/Notifications/RiskChange/RiskChangeEngine.swift
@@ -28,7 +28,11 @@ struct RiskChangeEngine: Sendable {
         self.sender = sender
     }
 
-    func run(change: RiskProfileChange?, isEnabled: Bool = true) async -> Bool {
+    func run(
+        change: RiskProfileChange?,
+        isEnabled: Bool = true,
+        activeLocationKey: String? = nil
+    ) async -> Bool {
         var preferredEventKey: String?
         if let change {
             let context = RiskChangeContext(change: change)
@@ -40,7 +44,11 @@ struct RiskChangeEngine: Sendable {
             }
         }
 
-        guard let delivery = await gate.claim(preferredEventKey: preferredEventKey, isEnabled: isEnabled) else {
+        guard let delivery = await gate.claim(
+            preferredEventKey: preferredEventKey,
+            isEnabled: isEnabled,
+            activeLocationKey: activeLocationKey
+        ) else {
             return false
         }
 

--- a/Sources/Notifications/RiskChange/RiskChangeGate.swift
+++ b/Sources/Notifications/RiskChange/RiskChangeGate.swift
@@ -20,6 +20,7 @@ actor RiskChangeGate {
     private struct Pending: Codable {
         let delivery: Delivery
         let projectionKey: String
+        let comparisonLocationKey: String?
         let registrationOrder: Int64
         let registeredAt: Date
     }
@@ -67,6 +68,9 @@ actor RiskChangeGate {
         await loadIfNeeded()
         guard let change = event.payload["change"] as? RiskProfileChange else { return }
         var didChange = purgeExpired(now: now)
+        if let comparisonLocationKey = change.comparisonLocationKey {
+            didChange = discardPending(outside: comparisonLocationKey) || didChange
+        }
         guard state.pending[event.key] == nil, state.delivered[event.key] == nil else {
             if didChange { await persist() }
             return
@@ -82,6 +86,7 @@ actor RiskChangeGate {
         state.pending[event.key] = Pending(
             delivery: Delivery(eventKey: event.key, title: message.title, body: message.body, subtitle: message.subtitle),
             projectionKey: change.projectionKey,
+            comparisonLocationKey: change.comparisonLocationKey,
             registrationOrder: state.nextRegistrationOrder,
             registeredAt: now
         )
@@ -93,6 +98,9 @@ actor RiskChangeGate {
         await loadIfNeeded()
         guard let change = event.payload["change"] as? RiskProfileChange else { return }
         var didChange = purgeExpired(now: now)
+        if let comparisonLocationKey = change.comparisonLocationKey {
+            didChange = discardPending(outside: comparisonLocationKey) || didChange
+        }
 
         for key in state.pending.keys where
             state.pending[key]?.projectionKey == change.projectionKey && inFlightEventKeys.contains(key) == false {
@@ -111,9 +119,18 @@ actor RiskChangeGate {
     }
 
     /// Claims one pending occurrence. The claim is recorded before the sender is awaited.
-    func claim(preferredEventKey: String?, isEnabled: Bool, now: Date = .now) async -> Delivery? {
+    func claim(
+        preferredEventKey: String?,
+        isEnabled: Bool,
+        activeLocationKey: String? = nil,
+        now: Date = .now
+    ) async -> Delivery? {
         await loadIfNeeded()
-        if purgeExpired(now: now) { await persist() }
+        var didChange = purgeExpired(now: now)
+        if let activeLocationKey {
+            didChange = discardPending(outside: activeLocationKey) || didChange
+        }
+        if didChange { await persist() }
         guard isEnabled else { return nil }
 
         let eventKey: String?
@@ -167,6 +184,17 @@ actor RiskChangeGate {
         }
         expiredKeys.forEach { state.pending.removeValue(forKey: $0) }
         return expiredKeys.isEmpty == false
+    }
+
+    private func discardPending(outside activeLocationKey: String) -> Bool {
+        let staleKeys: [String] = state.pending.compactMap { entry in
+            let (key, pending) = entry
+            guard inFlightEventKeys.contains(key) == false,
+                  pending.comparisonLocationKey != activeLocationKey else { return nil }
+            return key
+        }
+        staleKeys.forEach { state.pending.removeValue(forKey: $0) }
+        return staleKeys.isEmpty == false
     }
 
     private func trimDeliveredTombstones() {

--- a/Sources/Providers/SPC/SpcProvider+Syncing.swift
+++ b/Sources/Providers/SPC/SpcProvider+Syncing.swift
@@ -52,7 +52,7 @@ extension SpcProvider: SpcSyncing {
         defer {
             signposter.endInterval("Spc Sync Map Products", runInterval)
             mapSyncTask = nil
-            if !Task.isCancelled && mapSyncOutcome == .accepted {
+            if !Task.isCancelled && mapSyncOutcome.isFullyAccepted {
                 lastMapSyncFinishedAt = Date()
             }
             logger.info(
@@ -63,13 +63,7 @@ extension SpcProvider: SpcSyncing {
         if Task.isCancelled { return .failed }
 
         let stagedBatch = await stageMapProducts(now: Date())
-        let allSucceeded = await persistStagedMapProducts(stagedBatch)
-
-        if stagedBatch.validation.convective.isRejected && stagedBatch.validation.fire.isRejected {
-            mapSyncOutcome = .rejected
-        } else {
-            mapSyncOutcome = allSucceeded ? .accepted : .failed
-        }
+        mapSyncOutcome = await persistStagedMapProducts(stagedBatch)
         return mapSyncOutcome
     }
     
@@ -162,6 +156,10 @@ extension SpcProvider: SpcSyncing {
     }
 
     private static func mapSyncOutcomeLogName(_ outcome: SpcMapSyncOutcome) -> String {
+        "convective=\(mapSyncDomainOutcomeLogName(outcome.convective)),fire=\(mapSyncDomainOutcomeLogName(outcome.fire))"
+    }
+
+    private static func mapSyncDomainOutcomeLogName(_ outcome: SpcMapSyncDomainOutcome) -> String {
         switch outcome {
         case .accepted:
             return "accepted"
@@ -248,9 +246,8 @@ extension SpcProvider: SpcSyncing {
         return StagedSpcMapProductBatch(products: stagedProducts, validation: validation)
     }
 
-    private func persistStagedMapProducts(_ batch: StagedSpcMapProductBatch) async -> Bool {
-        var allSucceeded = true
-
+    private func persistStagedMapProducts(_ batch: StagedSpcMapProductBatch) async -> SpcMapSyncOutcome {
+        let convectiveOutcome: SpcMapSyncDomainOutcome
         switch batch.validation.convective {
         case .accepted(let anchorIssued, let anchorValid, let anchorExpires):
             let stagedClient = StagedMapSyncClient(stagedProducts: batch.products)
@@ -270,7 +267,7 @@ extension SpcProvider: SpcSyncing {
             logger.info(
                 "spc_map_convective_persistence result=\(succeeded ? "committed" : "failed", privacy: .public) committed=\(succeeded, privacy: .public) anchorIssued=\(Self.isoTimestamp(anchorIssued), privacy: .public) anchorValid=\(Self.isoTimestamp(anchorValid), privacy: .public) anchorExpires=\(Self.isoTimestamp(anchorExpires), privacy: .public)"
             )
-            allSucceeded = allSucceeded && succeeded
+            convectiveOutcome = succeeded ? .accepted : .failed
         case .acceptedAllClear(let syncTime):
             let succeeded = await Self.runMapProductSync(
                 named: "accepted_all_clear_convective_batch_transaction",
@@ -285,13 +282,15 @@ extension SpcProvider: SpcSyncing {
             logger.info(
                 "spc_map_convective_persistence result=\(succeeded ? "committed_all_clear" : "failed", privacy: .public) committed=\(succeeded, privacy: .public) syncTime=\(Self.isoTimestamp(syncTime), privacy: .public)"
             )
-            allSucceeded = allSucceeded && succeeded
+            convectiveOutcome = succeeded ? .accepted : .failed
         case .rejected(let reason):
             logger.info(
                 "spc_map_convective_persistence result=skipped reason=\(reason, privacy: .public) committed=false"
             )
+            convectiveOutcome = .rejected
         }
 
+        let fireOutcome: SpcMapSyncDomainOutcome
         switch batch.validation.fire {
         case .accepted(let anchorIssued, let anchorValid, let anchorExpires):
             let stagedClient = StagedMapSyncClient(stagedProducts: batch.products)
@@ -310,7 +309,7 @@ extension SpcProvider: SpcSyncing {
             logger.info(
                 "spc_map_fire_persistence result=\(succeeded ? "committed" : "failed", privacy: .public) committed=\(succeeded, privacy: .public) anchorIssued=\(Self.isoTimestamp(anchorIssued), privacy: .public) anchorValid=\(Self.isoTimestamp(anchorValid), privacy: .public) anchorExpires=\(Self.isoTimestamp(anchorExpires), privacy: .public)"
             )
-            allSucceeded = allSucceeded && succeeded
+            fireOutcome = succeeded ? .accepted : .failed
         case .acceptedAllClear(let syncTime):
             let succeeded = await Self.runMapProductSync(
                 named: "accepted_all_clear_fire_batch_transaction",
@@ -322,14 +321,15 @@ extension SpcProvider: SpcSyncing {
             logger.info(
                 "spc_map_fire_persistence result=\(succeeded ? "committed_all_clear" : "failed", privacy: .public) committed=\(succeeded, privacy: .public) syncTime=\(Self.isoTimestamp(syncTime), privacy: .public)"
             )
-            allSucceeded = allSucceeded && succeeded
+            fireOutcome = succeeded ? .accepted : .failed
         case .rejected(let reason):
             logger.info(
                 "spc_map_fire_persistence result=skipped reason=\(reason, privacy: .public) committed=false"
             )
+            fireOutcome = .rejected
         }
 
-        return allSucceeded
+        return SpcMapSyncOutcome(convective: convectiveOutcome, fire: fireOutcome)
     }
 
     private func fetchStagedMapProduct(
@@ -687,13 +687,6 @@ private enum StagedSpcMapDomainValidation: Sendable {
     case accepted(anchorIssued: Date, anchorValid: Date, anchorExpires: Date)
     case acceptedAllClear(syncTime: Date)
     case rejected(reason: String)
-
-    var isRejected: Bool {
-        if case .rejected = self {
-            return true
-        }
-        return false
-    }
 }
 
 private struct StagedProductWindowMetadata: Sendable, Equatable {

--- a/Sources/Providers/SPC/SpcProvider+Syncing.swift
+++ b/Sources/Providers/SPC/SpcProvider+Syncing.swift
@@ -248,6 +248,7 @@ extension SpcProvider: SpcSyncing {
 
     private func persistStagedMapProducts(_ batch: StagedSpcMapProductBatch) async -> SpcMapSyncOutcome {
         let convectiveOutcome: SpcMapSyncDomainOutcome
+        let convectiveSource: SpcMapSourceIdentity?
         switch batch.validation.convective {
         case .accepted(let anchorIssued, let anchorValid, let anchorExpires):
             let stagedClient = StagedMapSyncClient(stagedProducts: batch.products)
@@ -268,6 +269,9 @@ extension SpcProvider: SpcSyncing {
                 "spc_map_convective_persistence result=\(succeeded ? "committed" : "failed", privacy: .public) committed=\(succeeded, privacy: .public) anchorIssued=\(Self.isoTimestamp(anchorIssued), privacy: .public) anchorValid=\(Self.isoTimestamp(anchorValid), privacy: .public) anchorExpires=\(Self.isoTimestamp(anchorExpires), privacy: .public)"
             )
             convectiveOutcome = succeeded ? .accepted : .failed
+            convectiveSource = succeeded
+                ? .forecast(issued: anchorIssued, valid: anchorValid, expires: anchorExpires)
+                : nil
         case .acceptedAllClear(let syncTime):
             let succeeded = await Self.runMapProductSync(
                 named: "accepted_all_clear_convective_batch_transaction",
@@ -283,14 +287,17 @@ extension SpcProvider: SpcSyncing {
                 "spc_map_convective_persistence result=\(succeeded ? "committed_all_clear" : "failed", privacy: .public) committed=\(succeeded, privacy: .public) syncTime=\(Self.isoTimestamp(syncTime), privacy: .public)"
             )
             convectiveOutcome = succeeded ? .accepted : .failed
+            convectiveSource = succeeded ? .acceptedAllClear(at: syncTime) : nil
         case .rejected(let reason):
             logger.info(
                 "spc_map_convective_persistence result=skipped reason=\(reason, privacy: .public) committed=false"
             )
             convectiveOutcome = .rejected
+            convectiveSource = nil
         }
 
         let fireOutcome: SpcMapSyncDomainOutcome
+        let fireSource: SpcMapSourceIdentity?
         switch batch.validation.fire {
         case .accepted(let anchorIssued, let anchorValid, let anchorExpires):
             let stagedClient = StagedMapSyncClient(stagedProducts: batch.products)
@@ -310,6 +317,9 @@ extension SpcProvider: SpcSyncing {
                 "spc_map_fire_persistence result=\(succeeded ? "committed" : "failed", privacy: .public) committed=\(succeeded, privacy: .public) anchorIssued=\(Self.isoTimestamp(anchorIssued), privacy: .public) anchorValid=\(Self.isoTimestamp(anchorValid), privacy: .public) anchorExpires=\(Self.isoTimestamp(anchorExpires), privacy: .public)"
             )
             fireOutcome = succeeded ? .accepted : .failed
+            fireSource = succeeded
+                ? .forecast(issued: anchorIssued, valid: anchorValid, expires: anchorExpires)
+                : nil
         case .acceptedAllClear(let syncTime):
             let succeeded = await Self.runMapProductSync(
                 named: "accepted_all_clear_fire_batch_transaction",
@@ -322,14 +332,21 @@ extension SpcProvider: SpcSyncing {
                 "spc_map_fire_persistence result=\(succeeded ? "committed_all_clear" : "failed", privacy: .public) committed=\(succeeded, privacy: .public) syncTime=\(Self.isoTimestamp(syncTime), privacy: .public)"
             )
             fireOutcome = succeeded ? .accepted : .failed
+            fireSource = succeeded ? .acceptedAllClear(at: syncTime) : nil
         case .rejected(let reason):
             logger.info(
                 "spc_map_fire_persistence result=skipped reason=\(reason, privacy: .public) committed=false"
             )
             fireOutcome = .rejected
+            fireSource = nil
         }
 
-        return SpcMapSyncOutcome(convective: convectiveOutcome, fire: fireOutcome)
+        return SpcMapSyncOutcome(
+            convective: convectiveOutcome,
+            fire: fireOutcome,
+            convectiveSource: convectiveSource,
+            fireSource: fireSource
+        )
     }
 
     private func fetchStagedMapProduct(

--- a/Sources/Repos/HomeProjectionStore.swift
+++ b/Sources/Repos/HomeProjectionStore.swift
@@ -152,15 +152,21 @@ struct RiskProfileChange: Sendable, Equatable {
 struct HomeProjectionCoreCommit: Sendable {
     let weather: SummaryWeather??
     let slowProducts: (stormRisk: StormRiskLevel?, severeRisk: SevereWeatherThreat?, fireRisk: FireRiskLevel?)?
+    let updatesConvectiveRisk: Bool
+    let updatesFireRisk: Bool
     let hotAlerts: (alerts: [AlertDTO], mesos: [MdDTO])?
 
     init(
         weather: SummaryWeather?? = nil,
         slowProducts: (stormRisk: StormRiskLevel?, severeRisk: SevereWeatherThreat?, fireRisk: FireRiskLevel?)? = nil,
+        updatesConvectiveRisk: Bool = true,
+        updatesFireRisk: Bool = true,
         hotAlerts: (alerts: [AlertDTO], mesos: [MdDTO])? = nil
     ) {
         self.weather = weather
         self.slowProducts = slowProducts
+        self.updatesConvectiveRisk = updatesConvectiveRisk
+        self.updatesFireRisk = updatesFireRisk
         self.hotAlerts = hotAlerts
     }
 }
@@ -320,10 +326,16 @@ actor HomeProjectionStore {
             projection.lastWeatherLoadAt = loadedAt
         }
         if let slowProducts = commit.slowProducts {
-            projection.stormRisk = slowProducts.stormRisk
-            projection.severeRisk = slowProducts.severeRisk
-            projection.fireRisk = slowProducts.fireRisk
-            projection.lastSlowProductsLoadAt = loadedAt
+            if commit.updatesConvectiveRisk {
+                projection.stormRisk = slowProducts.stormRisk
+                projection.severeRisk = slowProducts.severeRisk
+            }
+            if commit.updatesFireRisk {
+                projection.fireRisk = slowProducts.fireRisk
+            }
+            if commit.updatesConvectiveRisk && commit.updatesFireRisk {
+                projection.lastSlowProductsLoadAt = loadedAt
+            }
         }
         if let hotAlerts = commit.hotAlerts {
             projection.activeAlerts = hotAlerts.alerts
@@ -335,11 +347,11 @@ actor HomeProjectionStore {
         try saveProjection(named: "Projection Core Save")
         return RiskProfileChange(
             previous: previousProfile,
-            current: commit.slowProducts.flatMap {
+            current: commit.slowProducts.flatMap { _ in
                 RiskProfile(
-                    stormRisk: $0.stormRisk,
-                    severeRisk: $0.severeRisk,
-                    fireRisk: $0.fireRisk
+                    stormRisk: projection.stormRisk,
+                    severeRisk: projection.severeRisk,
+                    fireRisk: projection.fireRisk
                 )
             },
             projectionKey: projection.projectionKey,

--- a/Sources/Repos/HomeProjectionStore.swift
+++ b/Sources/Repos/HomeProjectionStore.swift
@@ -38,9 +38,9 @@ private struct SevereRiskSignature: Sendable, Equatable {
 }
 
 struct RiskProfile: Sendable, Equatable {
-    let stormRisk: StormRiskLevel
-    let severeRisk: SevereWeatherThreat
-    let fireRisk: FireRiskLevel
+    let stormRisk: StormRiskLevel?
+    let severeRisk: SevereWeatherThreat?
+    let fireRisk: FireRiskLevel?
 
     init(
         stormRisk: StormRiskLevel,
@@ -52,12 +52,10 @@ struct RiskProfile: Sendable, Equatable {
         self.fireRisk = fireRisk
     }
 
-    init?(stormRisk: StormRiskLevel?, severeRisk: SevereWeatherThreat?, fireRisk: FireRiskLevel?) {
-        guard let stormRisk, let severeRisk, let fireRisk else {
-            return nil
-        }
-
-        self.init(stormRisk: stormRisk, severeRisk: severeRisk, fireRisk: fireRisk)
+    init(stormRisk: StormRiskLevel?, severeRisk: SevereWeatherThreat?, fireRisk: FireRiskLevel?) {
+        self.stormRisk = stormRisk
+        self.severeRisk = severeRisk
+        self.fireRisk = fireRisk
     }
 
     static func == (lhs: RiskProfile, rhs: RiskProfile) -> Bool {
@@ -68,29 +66,32 @@ struct RiskProfile: Sendable, Equatable {
 
     var fingerprint: String {
         [
-            "storm=\(stormRisk.rawValue)",
-            "severe=\(severeSignature.fingerprintComponent)",
-            "fire=\(fireRisk.rawValue)"
+            "storm=\(stormRisk.map { String($0.rawValue) } ?? "unavailable")",
+            "severe=\(severeSignature?.fingerprintComponent ?? "unavailable")",
+            "fire=\(fireRisk.map { String($0.rawValue) } ?? "unavailable")"
         ].joined(separator: "|")
     }
 
     func changedDimensions(from previous: RiskProfile) -> [RiskProfileDimension] {
         var dimensions: [RiskProfileDimension] = []
 
-        if previous.stormRisk != stormRisk {
+        if let previousStorm = previous.stormRisk, let stormRisk, previousStorm != stormRisk {
             dimensions.append(.storm)
         }
-        if previous.severeSignature != severeSignature {
+        if let previousSevere = previous.severeSignature,
+           let severeSignature,
+           previousSevere != severeSignature {
             dimensions.append(.severe)
         }
-        if previous.fireRisk != fireRisk {
+        if let previousFire = previous.fireRisk, let fireRisk, previousFire != fireRisk {
             dimensions.append(.fire)
         }
 
         return dimensions
     }
 
-    private var severeSignature: SevereRiskSignature {
+    private var severeSignature: SevereRiskSignature? {
+        guard let severeRisk else { return nil }
         switch severeRisk {
         case .allClear:
             return SevereRiskSignature(kind: .allClear, probabilityPercent: nil)
@@ -115,6 +116,7 @@ struct RiskProfileChange: Sendable, Equatable {
     /// Identifies one accepted persistence transition, rather than its destination profile.
     let occurrenceID: String
     let projectionKey: String
+    let comparisonLocationKey: String?
     let locationSummary: String?
     let previous: RiskProfile
     let current: RiskProfile
@@ -126,20 +128,26 @@ struct RiskProfileChange: Sendable, Equatable {
         previous: RiskProfile?,
         current: RiskProfile?,
         projectionKey: String,
+        comparisonLocationKey: String? = nil,
         locationSummary: String?,
+        eligibleDimensions: [RiskProfileDimension]? = nil,
         occurrenceID: String = UUID().uuidString
     ) {
         guard let previous, let current else {
             return nil
         }
 
-        let changedDimensions = current.changedDimensions(from: previous)
+        let detectedDimensions = current.changedDimensions(from: previous)
+        let changedDimensions = eligibleDimensions.map { eligible in
+            detectedDimensions.filter(eligible.contains)
+        } ?? detectedDimensions
         guard changedDimensions.isEmpty == false else {
             return nil
         }
 
         self.occurrenceID = occurrenceID
         self.projectionKey = projectionKey
+        self.comparisonLocationKey = comparisonLocationKey
         self.locationSummary = locationSummary
         self.previous = previous
         self.current = current
@@ -154,6 +162,8 @@ struct HomeProjectionCoreCommit: Sendable {
     let slowProducts: (stormRisk: StormRiskLevel?, severeRisk: SevereWeatherThreat?, fireRisk: FireRiskLevel?)?
     let updatesConvectiveRisk: Bool
     let updatesFireRisk: Bool
+    let convectiveSource: SpcMapSourceIdentity?
+    let fireSource: SpcMapSourceIdentity?
     let hotAlerts: (alerts: [AlertDTO], mesos: [MdDTO])?
 
     init(
@@ -161,12 +171,16 @@ struct HomeProjectionCoreCommit: Sendable {
         slowProducts: (stormRisk: StormRiskLevel?, severeRisk: SevereWeatherThreat?, fireRisk: FireRiskLevel?)? = nil,
         updatesConvectiveRisk: Bool = true,
         updatesFireRisk: Bool = true,
+        convectiveSource: SpcMapSourceIdentity? = nil,
+        fireSource: SpcMapSourceIdentity? = nil,
         hotAlerts: (alerts: [AlertDTO], mesos: [MdDTO])? = nil
     ) {
         self.weather = weather
         self.slowProducts = slowProducts
         self.updatesConvectiveRisk = updatesConvectiveRisk
         self.updatesFireRisk = updatesFireRisk
+        self.convectiveSource = convectiveSource
+        self.fireSource = fireSource
         self.hotAlerts = hotAlerts
     }
 }
@@ -190,6 +204,8 @@ protocol HomeProjectionPersisting: Sendable {
         stormRisk: StormRiskLevel?,
         severeRisk: SevereWeatherThreat?,
         fireRisk: FireRiskLevel?,
+        convectiveSource: SpcMapSourceIdentity?,
+        fireSource: SpcMapSourceIdentity?,
         for context: LocationContext,
         loadedAt: Date
     ) async throws -> RiskProfileChange?
@@ -208,9 +224,36 @@ protocol HomeProjectionPersisting: Sendable {
     ) async throws -> RiskProfileChange?
 }
 
+extension HomeProjectionPersisting {
+    func updateSlowProducts(
+        stormRisk: StormRiskLevel?,
+        severeRisk: SevereWeatherThreat?,
+        fireRisk: FireRiskLevel?,
+        for context: LocationContext,
+        loadedAt: Date
+    ) async throws -> RiskProfileChange? {
+        try await updateSlowProducts(
+            stormRisk: stormRisk,
+            severeRisk: severeRisk,
+            fireRisk: fireRisk,
+            convectiveSource: nil,
+            fireSource: nil,
+            for: context,
+            loadedAt: loadedAt
+        )
+    }
+}
+
 @ModelActor
 actor HomeProjectionStore {
     private let performanceSignposter = OSSignposter(logger: Logger.appHomeRefresh)
+#if DEBUG
+    private var failsNextSaveForTesting = false
+
+    func failNextSaveForTesting() {
+        failsNextSaveForTesting = true
+    }
+#endif
 
     func projection(for context: LocationContext) throws -> HomeProjectionRecord? {
         try fetchProjection(withKey: HomeProjection.projectionKey(for: context))?.record
@@ -264,34 +307,20 @@ actor HomeProjectionStore {
         stormRisk: StormRiskLevel?,
         severeRisk: SevereWeatherThreat?,
         fireRisk: FireRiskLevel?,
+        convectiveSource: SpcMapSourceIdentity? = nil,
+        fireSource: SpcMapSourceIdentity? = nil,
         for context: LocationContext,
         loadedAt: Date = .now
     ) throws -> RiskProfileChange? {
-        let projection = try fetchOrCreateModel(for: context, touchedAt: loadedAt)
-        let previousProfile = RiskProfile(
-            stormRisk: projection.stormRisk,
-            severeRisk: projection.severeRisk,
-            fireRisk: projection.fireRisk
+        try commitCore(
+            .init(
+                slowProducts: (stormRisk, severeRisk, fireRisk),
+                convectiveSource: convectiveSource,
+                fireSource: fireSource
+            ),
+            for: context,
+            loadedAt: loadedAt
         )
-        let currentProfile = RiskProfile(
-            stormRisk: stormRisk,
-            severeRisk: severeRisk,
-            fireRisk: fireRisk
-        )
-        let change = RiskProfileChange(
-            previous: previousProfile,
-            current: currentProfile,
-            projectionKey: projection.projectionKey,
-            locationSummary: projection.placemarkSummary
-        )
-
-        projection.stormRisk = stormRisk
-        projection.severeRisk = severeRisk
-        projection.fireRisk = fireRisk
-        projection.lastSlowProductsLoadAt = loadedAt
-        projection.updatedAt = loadedAt
-        try saveProjection(named: "Projection Slow Products Save")
-        return change
     }
 
     func updateHotAlerts(
@@ -320,6 +349,7 @@ actor HomeProjectionStore {
             severeRisk: projection.severeRisk,
             fireRisk: projection.fireRisk
         )
+        var eligibleDimensions: [RiskProfileDimension] = []
 
         if let weather = commit.weather {
             projection.weatherPayload = weather.map(HomeProjectionWeatherPayload.init(summary:))
@@ -327,10 +357,26 @@ actor HomeProjectionStore {
         }
         if let slowProducts = commit.slowProducts {
             if commit.updatesConvectiveRisk {
+                if try advancesComparisonBaseline(
+                    for: .convective,
+                    projection: projection,
+                    context: context,
+                    acceptedSource: commit.convectiveSource
+                ) {
+                    eligibleDimensions.append(contentsOf: [.storm, .severe])
+                }
                 projection.stormRisk = slowProducts.stormRisk
                 projection.severeRisk = slowProducts.severeRisk
             }
             if commit.updatesFireRisk {
+                if try advancesComparisonBaseline(
+                    for: .fire,
+                    projection: projection,
+                    context: context,
+                    acceptedSource: commit.fireSource
+                ) {
+                    eligibleDimensions.append(.fire)
+                }
                 projection.fireRisk = slowProducts.fireRisk
             }
             if commit.updatesConvectiveRisk && commit.updatesFireRisk {
@@ -355,8 +401,97 @@ actor HomeProjectionStore {
                 )
             },
             projectionKey: projection.projectionKey,
-            locationSummary: projection.placemarkSummary
+            comparisonLocationKey: HomeProjection.riskComparisonLocationKey(for: context),
+            locationSummary: projection.placemarkSummary,
+            eligibleDimensions: eligibleDimensions
         )
+    }
+
+    private enum RiskComparisonDomain {
+        case convective
+        case fire
+    }
+
+    /// A domain can notify only when a newly accepted SPC source replaces the source sampled at the same
+    /// projection-plus-E4 location identity. All other writes rebase the active domain baseline silently.
+    private func advancesComparisonBaseline(
+        for domain: RiskComparisonDomain,
+        projection: HomeProjection,
+        context: LocationContext,
+        acceptedSource: SpcMapSourceIdentity?
+    ) throws -> Bool {
+        let locationKey = HomeProjection.riskComparisonLocationKey(for: context)
+        let previousLocationKey = comparisonLocationKey(for: domain, projection: projection)
+        let previousSourceKey = comparisonSourceKey(for: domain, projection: projection)
+        let acceptedSourceKey = acceptedSource?.persistenceToken
+        let inheritedSourceKey = try previousSourceKey ?? activeComparisonSourceKey(for: domain)
+        let advances = previousLocationKey == locationKey
+            && previousSourceKey != nil
+            && acceptedSourceKey != nil
+            && acceptedSourceKey != previousSourceKey
+
+        try invalidateOtherComparisonBaselines(for: domain, keeping: projection)
+        setComparisonBaseline(
+            for: domain,
+            projection: projection,
+            locationKey: locationKey,
+            sourceKey: acceptedSourceKey ?? inheritedSourceKey
+        )
+        return advances
+    }
+
+    private func activeComparisonSourceKey(for domain: RiskComparisonDomain) throws -> String? {
+        let descriptor = FetchDescriptor<HomeProjection>(
+            sortBy: [
+                SortDescriptor(\.updatedAt, order: .reverse),
+                SortDescriptor(\.projectionKey, order: .forward)
+            ]
+        )
+        return try modelContext.fetch(descriptor).lazy.compactMap {
+            self.comparisonSourceKey(for: domain, projection: $0)
+        }.first
+    }
+
+    private func invalidateOtherComparisonBaselines(
+        for domain: RiskComparisonDomain,
+        keeping projection: HomeProjection
+    ) throws {
+        for other in try modelContext.fetch(FetchDescriptor<HomeProjection>()) where other.id != projection.id {
+            setComparisonBaseline(for: domain, projection: other, locationKey: nil, sourceKey: nil)
+        }
+    }
+
+    private func comparisonLocationKey(
+        for domain: RiskComparisonDomain,
+        projection: HomeProjection
+    ) -> String? {
+        switch domain {
+        case .convective: projection.convectiveRiskComparisonLocationKey
+        case .fire: projection.fireRiskComparisonLocationKey
+        }
+    }
+
+    private func comparisonSourceKey(for domain: RiskComparisonDomain, projection: HomeProjection) -> String? {
+        switch domain {
+        case .convective: projection.convectiveRiskComparisonSourceKey
+        case .fire: projection.fireRiskComparisonSourceKey
+        }
+    }
+
+    private func setComparisonBaseline(
+        for domain: RiskComparisonDomain,
+        projection: HomeProjection,
+        locationKey: String?,
+        sourceKey: String?
+    ) {
+        switch domain {
+        case .convective:
+            projection.convectiveRiskComparisonLocationKey = locationKey
+            projection.convectiveRiskComparisonSourceKey = sourceKey
+        case .fire:
+            projection.fireRiskComparisonLocationKey = locationKey
+            projection.fireRiskComparisonSourceKey = sourceKey
+        }
     }
 
     private func fetchOrCreateModel(
@@ -384,7 +519,18 @@ actor HomeProjectionStore {
     private func saveProjection(named name: StaticString) throws {
         let interval = performanceSignposter.beginInterval(name)
         defer { performanceSignposter.endInterval(name, interval) }
-        try modelContext.save()
+        do {
+#if DEBUG
+            if failsNextSaveForTesting {
+                failsNextSaveForTesting = false
+                throw HomeProjectionStoreTestingError.injectedSaveFailure
+            }
+#endif
+            try modelContext.save()
+        } catch {
+            modelContext.rollback()
+            throw error
+        }
     }
 
     private func fetchProjection(withKey projectionKey: String) throws -> HomeProjection? {
@@ -411,5 +557,11 @@ actor HomeProjectionStore {
         return try modelContext.fetch(descriptor).first
     }
 }
+
+#if DEBUG
+private enum HomeProjectionStoreTestingError: Error {
+    case injectedSaveFailure
+}
+#endif
 
 extension HomeProjectionStore: HomeProjectionPersisting {}

--- a/Tests/UnitTests/HomeProjectionStoreTests.swift
+++ b/Tests/UnitTests/HomeProjectionStoreTests.swift
@@ -326,6 +326,11 @@ struct HomeProjectionStoreTests {
         #expect(persisted.createdAt == createdAt)
         #expect(persisted.stormSetupCurrentResponse == nil)
         #expect(persisted.stormSetup == nil)
+        let migratedModel = try #require(ModelContext(container).fetch(FetchDescriptor<HomeProjection>()).first)
+        #expect(migratedModel.convectiveRiskComparisonLocationKey == nil)
+        #expect(migratedModel.convectiveRiskComparisonSourceKey == nil)
+        #expect(migratedModel.fireRiskComparisonLocationKey == nil)
+        #expect(migratedModel.fireRiskComparisonSourceKey == nil)
     }
 
     @Test("updating slow products seeds a baseline without a change and preserves existing slices")
@@ -404,6 +409,8 @@ struct HomeProjectionStoreTests {
             stormRisk: .marginal,
             severeRisk: .tornado(probability: 0.02),
             fireRisk: .clear,
+            convectiveSource: makeSource(revision: 1),
+            fireSource: makeSource(revision: 1),
             for: context,
             loadedAt: Date(timeIntervalSince1970: 500)
         )
@@ -412,6 +419,8 @@ struct HomeProjectionStoreTests {
             stormRisk: .marginal,
             severeRisk: .allClear,
             fireRisk: .clear,
+            convectiveSource: makeSource(revision: 2),
+            fireSource: makeSource(revision: 2),
             for: context,
             loadedAt: Date(timeIntervalSince1970: 560)
         ))
@@ -435,6 +444,226 @@ struct HomeProjectionStoreTests {
         let updated = try #require(await store.projection(for: context))
         #expect(updated.severeRisk == .allClear)
         #expect(updated.lastSlowProductsLoadAt == Date(timeIntervalSince1970: 560))
+    }
+
+    @Test("coordinate movement within one projection rebases unchanged-source risk without a change")
+    func updateSlowProducts_sameProjectionMovementDoesNotCreateRiskChange() async throws {
+        let container = try TestStore.container(for: [HomeProjection.self])
+        let store = HomeProjectionStore(modelContainer: container)
+        let first = makeContext(latitude: 39.7500, longitude: -104.4400, timestamp: 100)
+        let moved = makeContext(latitude: 39.7509, longitude: -104.4409, timestamp: 200)
+        let source = makeSource(revision: 1)
+
+        #expect(HomeProjection.projectionKey(for: first) == HomeProjection.projectionKey(for: moved))
+        _ = try await store.updateSlowProducts(
+            stormRisk: .marginal,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            convectiveSource: source,
+            fireSource: source,
+            for: first
+        )
+
+        let movedChange = try await store.updateSlowProducts(
+            stormRisk: .allClear,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            convectiveSource: source,
+            fireSource: source,
+            for: moved
+        )
+        let revisitChange = try await store.updateSlowProducts(
+            stormRisk: .marginal,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            convectiveSource: source,
+            fireSource: source,
+            for: first
+        )
+
+        #expect(movedChange == nil)
+        #expect(revisitChange == nil)
+    }
+
+    @Test("stable comparison location emits a change for a newer accepted source")
+    func updateSlowProducts_stableLocationWithNewSourceCreatesRiskChange() async throws {
+        let container = try TestStore.container(for: [HomeProjection.self])
+        let store = HomeProjectionStore(modelContainer: container)
+        let context = makeContext()
+
+        _ = try await store.updateSlowProducts(
+            stormRisk: .marginal,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            convectiveSource: makeSource(revision: 1),
+            fireSource: makeSource(revision: 1),
+            for: context
+        )
+        let sameSourceChange = try await store.updateSlowProducts(
+            stormRisk: .slight,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            convectiveSource: makeSource(revision: 1),
+            fireSource: makeSource(revision: 1),
+            for: context
+        )
+        let change = try #require(await store.updateSlowProducts(
+            stormRisk: .enhanced,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            convectiveSource: makeSource(revision: 2),
+            fireSource: makeSource(revision: 2),
+            for: context
+        ))
+
+        #expect(sameSourceChange == nil)
+        #expect(change.changedDimensions == [.storm])
+        #expect(change.previous.stormRisk == .slight)
+        #expect(change.current.stormRisk == .enhanced)
+    }
+
+    @Test("leaving and revisiting a projection seeds before later accepted changes")
+    func updateSlowProducts_revisitedProjectionDoesNotUseHistoricalBaseline() async throws {
+        let container = try TestStore.container(for: [HomeProjection.self])
+        let store = HomeProjectionStore(modelContainer: container)
+        let first = makeContext(h3Cell: 123_456)
+        let second = makeContext(
+            latitude: 40.02,
+            longitude: -104.87,
+            timestamp: 200,
+            countyCode: "COC007",
+            forecastZone: "COZ041",
+            fireZone: "COZ217",
+            h3Cell: 654_321
+        )
+
+        _ = try await store.updateSlowProducts(
+            stormRisk: .marginal,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            convectiveSource: makeSource(revision: 1),
+            fireSource: makeSource(revision: 1),
+            for: first
+        )
+        let newLocation = try await store.updateSlowProducts(
+            stormRisk: .allClear,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            convectiveSource: makeSource(revision: 1),
+            fireSource: makeSource(revision: 1),
+            for: second
+        )
+        let revisit = try await store.updateSlowProducts(
+            stormRisk: .enhanced,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            convectiveSource: makeSource(revision: 2),
+            fireSource: makeSource(revision: 2),
+            for: first
+        )
+        let stableChange = try #require(await store.updateSlowProducts(
+            stormRisk: .moderate,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            convectiveSource: makeSource(revision: 3),
+            fireSource: makeSource(revision: 3),
+            for: first
+        ))
+
+        #expect(newLocation == nil)
+        #expect(revisit == nil)
+        #expect(stableChange.changedDimensions == [.storm])
+    }
+
+    @Test("domain-local changes do not require the other domain to be available")
+    func updateSlowProducts_partialProfilesEmitForAuthoritativeDomain() async throws {
+        let container = try TestStore.container(for: [HomeProjection.self])
+        let store = HomeProjectionStore(modelContainer: container)
+        let convectiveContext = makeContext()
+        let fireContext = makeContext(h3Cell: 654_321)
+
+        _ = try await store.commitCore(
+            .init(
+                slowProducts: (.marginal, .allClear, nil),
+                updatesConvectiveRisk: true,
+                updatesFireRisk: false,
+                convectiveSource: makeSource(revision: 1)
+            ),
+            for: convectiveContext
+        )
+        let convectiveChange = try #require(await store.commitCore(
+            .init(
+                slowProducts: (.slight, .wind(probability: 0.15), nil),
+                updatesConvectiveRisk: true,
+                updatesFireRisk: false,
+                convectiveSource: makeSource(revision: 2)
+            ),
+            for: convectiveContext
+        ))
+
+        _ = try await store.commitCore(
+            .init(
+                slowProducts: (nil, nil, .clear),
+                updatesConvectiveRisk: false,
+                updatesFireRisk: true,
+                fireSource: makeSource(revision: 1)
+            ),
+            for: fireContext
+        )
+        let fireChange = try #require(await store.commitCore(
+            .init(
+                slowProducts: (nil, nil, .critical),
+                updatesConvectiveRisk: false,
+                updatesFireRisk: true,
+                fireSource: makeSource(revision: 2)
+            ),
+            for: fireContext
+        ))
+
+        #expect(convectiveChange.changedDimensions == [.storm, .severe])
+        #expect(fireChange.changedDimensions == [.fire])
+    }
+
+    @Test("failed saves roll back risk values and comparison metadata")
+    func updateSlowProducts_failedSaveRollsBackBaseline() async throws {
+        let container = try TestStore.container(for: [HomeProjection.self])
+        let store = HomeProjectionStore(modelContainer: container)
+        let context = makeContext()
+
+        _ = try await store.updateSlowProducts(
+            stormRisk: .marginal,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            convectiveSource: makeSource(revision: 1),
+            fireSource: makeSource(revision: 1),
+            for: context
+        )
+        await store.failNextSaveForTesting()
+        await #expect(throws: (any Error).self) {
+            try await store.updateSlowProducts(
+                stormRisk: .enhanced,
+                severeRisk: .tornado(probability: 0.30),
+                fireRisk: .critical,
+                convectiveSource: makeSource(revision: 2),
+                fireSource: makeSource(revision: 2),
+                for: context
+            )
+        }
+        _ = try await store.updateWeather(makeWeather(), for: context)
+
+        let change = try #require(await store.updateSlowProducts(
+            stormRisk: .slight,
+            severeRisk: .allClear,
+            fireRisk: .elevated,
+            convectiveSource: makeSource(revision: 2),
+            fireSource: makeSource(revision: 2),
+            for: context
+        ))
+
+        #expect(change.previous.stormRisk == .marginal)
+        #expect(change.previous.severeRisk == .allClear)
+        #expect(change.previous.fireRisk == .clear)
+        #expect(change.changedDimensions == [.storm, .fire])
     }
 
     @Test("risk profile fingerprints normalize severe probabilities to whole percentages")
@@ -715,13 +944,19 @@ struct HomeProjectionStoreTests {
             .init(
                 weather: makeWeather(),
                 slowProducts: (.slight, .wind(probability: 0.15), .critical),
+                convectiveSource: makeSource(revision: 1),
+                fireSource: makeSource(revision: 1),
                 hotAlerts: (alerts: [originalAlert], mesos: [MD.sampleDiscussionDTOs[0]])
             ),
             for: context,
             loadedAt: Date(timeIntervalSince1970: 500)
         )
         let change = try #require(await store.commitCore(
-            .init(slowProducts: (.enhanced, .tornado(probability: 0.30), .elevated)),
+            .init(
+                slowProducts: (.enhanced, .tornado(probability: 0.30), .elevated),
+                convectiveSource: makeSource(revision: 2),
+                fireSource: makeSource(revision: 2)
+            ),
             for: context,
             loadedAt: Date(timeIntervalSince1970: 600)
         ))
@@ -814,6 +1049,14 @@ struct HomeProjectionStoreTests {
             fireZoneLabel: "Front Range"
         )
         return LocationContext(snapshot: snapshot, h3Cell: snapshot.h3Cell ?? h3Cell, grid: grid)
+    }
+
+    private func makeSource(revision: TimeInterval) -> SpcMapSourceIdentity {
+        .forecast(
+            issued: Date(timeIntervalSince1970: revision * 100),
+            valid: Date(timeIntervalSince1970: revision * 100 + 10),
+            expires: Date(timeIntervalSince1970: revision * 100 + 90)
+        )
     }
 
     private func makeWeather(

--- a/Tests/UnitTests/HomeRefreshPipelineTests.swift
+++ b/Tests/UnitTests/HomeRefreshPipelineTests.swift
@@ -1689,6 +1689,8 @@ struct HomeRefreshPipelineTests {
             stormRisk: .slight,
             severeRisk: .tornado(probability: 0.15),
             fireRisk: .critical,
+            convectiveSource: testMapSource(revision: 1),
+            fireSource: testMapSource(revision: 1),
             for: context,
             loadedAt: previousTimestamp
         )
@@ -1746,6 +1748,8 @@ struct HomeRefreshPipelineTests {
             stormRisk: .slight,
             severeRisk: .tornado(probability: 0.15),
             fireRisk: .critical,
+            convectiveSource: testMapSource(revision: 1),
+            fireSource: testMapSource(revision: 1),
             for: context,
             loadedAt: Date(timeIntervalSince1970: 200)
         )
@@ -1753,7 +1757,11 @@ struct HomeRefreshPipelineTests {
         let spc = FakeSpcProvider(
             activeMesos: [],
             outlooks: sampleOutlooks(),
-            mapSyncOutcome: .init(convective: .rejected, fire: .accepted),
+            mapSyncOutcome: .init(
+                convective: .rejected,
+                fire: .accepted,
+                fireSource: testMapSource(revision: 2)
+            ),
             stormRiskValue: .allClear,
             severeRiskValue: .allClear,
             fireRiskValue: .clear
@@ -1785,7 +1793,7 @@ struct HomeRefreshPipelineTests {
         #expect(partialProjection.lastSlowProductsLoadAt == Date(timeIntervalSince1970: 200))
 
         await spc.configureMapSync(
-            outcome: .accepted,
+            outcome: acceptedMapSyncOutcome(revision: 3),
             stormRisk: .slight,
             severeRisk: .tornado(probability: 0.15),
             fireRisk: .clear
@@ -1814,6 +1822,8 @@ struct HomeRefreshPipelineTests {
             stormRisk: .slight,
             severeRisk: .tornado(probability: 0.15),
             fireRisk: .critical,
+            convectiveSource: testMapSource(revision: 1),
+            fireSource: testMapSource(revision: 1),
             for: context,
             loadedAt: Date(timeIntervalSince1970: 200)
         )
@@ -1821,7 +1831,11 @@ struct HomeRefreshPipelineTests {
         let spc = FakeSpcProvider(
             activeMesos: [],
             outlooks: sampleOutlooks(),
-            mapSyncOutcome: .init(convective: .accepted, fire: .rejected),
+            mapSyncOutcome: .init(
+                convective: .accepted,
+                fire: .rejected,
+                convectiveSource: testMapSource(revision: 2)
+            ),
             stormRiskValue: .allClear,
             severeRiskValue: .allClear,
             fireRiskValue: .clear
@@ -1856,7 +1870,7 @@ struct HomeRefreshPipelineTests {
         #expect(projection.lastSlowProductsLoadAt == Date(timeIntervalSince1970: 200))
 
         await spc.configureMapSync(
-            outcome: .accepted,
+            outcome: acceptedMapSyncOutcome(revision: 3),
             stormRisk: .allClear,
             severeRisk: .allClear,
             fireRisk: .critical
@@ -1871,6 +1885,58 @@ struct HomeRefreshPipelineTests {
         #expect(retry.riskProfileChange == nil)
         #expect(retriedProjection.fireRisk == .critical)
         #expect(await spc.syncMapProductsCount() == 2)
+    }
+
+    @Test("background coordinate movement within one projection does not publish a risk change")
+    func backgroundLocationChange_sameProjectionAndSourceRebasesWithoutRiskChange() async throws {
+        let container = try TestStore.container(for: [HomeProjection.self])
+        let projectionStore = HomeProjectionStore(modelContainer: container)
+        let firstContext = makeContext(latitude: 39.7500, longitude: -104.4400, timestamp: 100)
+        let movedContext = makeContext(latitude: 39.7509, longitude: -104.4409, timestamp: 200)
+        let locationSession = FakeLocationSession(currentContext: firstContext, preparedContext: firstContext)
+        let spc = FakeSpcProvider(
+            activeMesos: [],
+            outlooks: sampleOutlooks(),
+            mapSyncOutcome: acceptedMapSyncOutcome(revision: 1),
+            stormRiskValue: .marginal,
+            severeRiskValue: .allClear,
+            fireRiskValue: .clear
+        )
+        let alerts = FakeAlertProvider(activeAlerts: [])
+        let executor = HomeIngestionExecutor(
+            environment: .init(
+                logger: Logger(subsystem: "SkyAwareTests", category: "HomeRefreshPipelineTests"),
+                spcSync: spc,
+                arcusAlertSync: alerts,
+                weatherClient: FakeWeatherClient(),
+                locationSession: locationSession,
+                snapshotStore: HomeSnapshotStore(spcRisk: spc, spcOutlook: spc, arcusAlerts: alerts),
+                projectionStore: projectionStore,
+                widgetSnapshotRefresher: nil
+            )
+        )
+
+        let baseline = try await executor.run(
+            plan: HomeIngestionPlan(request: .init(trigger: .backgroundRefresh)),
+            progress: .none
+        )
+        locationSession.currentContext = movedContext
+        locationSession.preparedContext = movedContext
+        await spc.configureMapSync(
+            outcome: acceptedMapSyncOutcome(revision: 1),
+            stormRisk: .allClear,
+            severeRisk: .allClear,
+            fireRisk: .clear
+        )
+        let moved = try await executor.run(
+            plan: HomeIngestionPlan(request: .init(trigger: .backgroundLocationChange)),
+            progress: .none
+        )
+
+        #expect(HomeProjection.projectionKey(for: firstContext) == HomeProjection.projectionKey(for: movedContext))
+        #expect(baseline.riskProfileChange == nil)
+        #expect(moved.riskProfileChange == nil)
+        #expect(moved.stormRisk == .allClear)
     }
 
     @Test("hot-alert providers overlap and join before completion")
@@ -3339,6 +3405,24 @@ private actor FakeAlertProvider: ArcusAlertSyncing, ArcusAlertQuerying {
     func queryCount() -> Int { queryCalls }
     func observedHTTPModes() -> [HTTPExecutionMode] { observedHTTPModeValues }
     func cancelledSyncCount() -> Int { cancelledSyncCalls }
+}
+
+private func testMapSource(revision: TimeInterval) -> SpcMapSourceIdentity {
+    .forecast(
+        issued: Date(timeIntervalSince1970: revision * 100),
+        valid: Date(timeIntervalSince1970: revision * 100 + 10),
+        expires: Date(timeIntervalSince1970: revision * 100 + 90)
+    )
+}
+
+private func acceptedMapSyncOutcome(revision: TimeInterval) -> SpcMapSyncOutcome {
+    let source = testMapSource(revision: revision)
+    return .init(
+        convective: .accepted,
+        fire: .accepted,
+        convectiveSource: source,
+        fireSource: source
+    )
 }
 
 @MainActor

--- a/Tests/UnitTests/HomeRefreshPipelineTests.swift
+++ b/Tests/UnitTests/HomeRefreshPipelineTests.swift
@@ -1735,6 +1735,144 @@ struct HomeRefreshPipelineTests {
         #expect(await spc.syncMapProductsCount() == 2)
     }
 
+    @Test("rejected convective domain preserves expired values while accepted fire clears and retries")
+    func slowProductRefresh_rejectedConvectivePreservesBaselineAndRetriesWithoutReversal() async throws {
+        let container = try TestStore.container(for: [HomeProjection.self])
+        let projectionStore = HomeProjectionStore(modelContainer: container)
+        let context = makeContext()
+        let widgetRecorder = RecordingWidgetSnapshotRefresher()
+
+        _ = try await projectionStore.updateSlowProducts(
+            stormRisk: .slight,
+            severeRisk: .tornado(probability: 0.15),
+            fireRisk: .critical,
+            for: context,
+            loadedAt: Date(timeIntervalSince1970: 200)
+        )
+
+        let spc = FakeSpcProvider(
+            activeMesos: [],
+            outlooks: sampleOutlooks(),
+            mapSyncOutcome: .init(convective: .rejected, fire: .accepted),
+            stormRiskValue: .allClear,
+            severeRiskValue: .allClear,
+            fireRiskValue: .clear
+        )
+        let alerts = FakeAlertProvider(activeAlerts: [])
+        let executor = HomeIngestionExecutor(
+            environment: .init(
+                logger: Logger(subsystem: "SkyAwareTests", category: "HomeRefreshPipelineTests"),
+                spcSync: spc,
+                arcusAlertSync: alerts,
+                weatherClient: FakeWeatherClient(),
+                locationSession: FakeLocationSession(currentContext: context, preparedContext: context),
+                snapshotStore: HomeSnapshotStore(spcRisk: spc, spcOutlook: spc, arcusAlerts: alerts),
+                projectionStore: projectionStore,
+                widgetSnapshotRefresher: widgetRecorder
+            )
+        )
+
+        let first = try await executor.run(
+            plan: HomeIngestionPlan(request: .init(trigger: .backgroundRefresh)),
+            progress: .none
+        )
+
+        #expect(first.stormRisk == .slight)
+        #expect(first.severeRisk == .tornado(probability: 0.15))
+        #expect(first.fireRisk == .clear)
+        #expect(first.riskProfileChange?.changedDimensions == [.fire])
+        let partialProjection = try #require(await projectionStore.projection(for: context))
+        #expect(partialProjection.lastSlowProductsLoadAt == Date(timeIntervalSince1970: 200))
+
+        await spc.configureMapSync(
+            outcome: .accepted,
+            stormRisk: .slight,
+            severeRisk: .tornado(probability: 0.15),
+            fireRisk: .clear
+        )
+        let retry = try await executor.run(
+            plan: HomeIngestionPlan(request: .init(trigger: .backgroundRefresh)),
+            progress: .none
+        )
+
+        let projection = try #require(await projectionStore.projection(for: context))
+        #expect(projection.stormRisk == .slight)
+        #expect(projection.severeRisk == .tornado(probability: 0.15))
+        #expect(projection.fireRisk == .clear)
+        #expect(retry.riskProfileChange == nil)
+        #expect(await spc.syncMapProductsCount() == 2)
+        #expect(widgetRecorder.refreshCallCount() == 2)
+    }
+
+    @Test("accepted convective all-clear preserves an unavailable rejected fire domain")
+    func slowProductRefresh_acceptedConvectiveAllClearPreservesRejectedFire() async throws {
+        let container = try TestStore.container(for: [HomeProjection.self])
+        let projectionStore = HomeProjectionStore(modelContainer: container)
+        let context = makeContext()
+
+        _ = try await projectionStore.updateSlowProducts(
+            stormRisk: .slight,
+            severeRisk: .tornado(probability: 0.15),
+            fireRisk: .critical,
+            for: context,
+            loadedAt: Date(timeIntervalSince1970: 200)
+        )
+
+        let spc = FakeSpcProvider(
+            activeMesos: [],
+            outlooks: sampleOutlooks(),
+            mapSyncOutcome: .init(convective: .accepted, fire: .rejected),
+            stormRiskValue: .allClear,
+            severeRiskValue: .allClear,
+            fireRiskValue: .clear
+        )
+        let alerts = FakeAlertProvider(activeAlerts: [])
+        let executor = HomeIngestionExecutor(
+            environment: .init(
+                logger: Logger(subsystem: "SkyAwareTests", category: "HomeRefreshPipelineTests"),
+                spcSync: spc,
+                arcusAlertSync: alerts,
+                weatherClient: FakeWeatherClient(),
+                locationSession: FakeLocationSession(currentContext: context, preparedContext: context),
+                snapshotStore: HomeSnapshotStore(spcRisk: spc, spcOutlook: spc, arcusAlerts: alerts),
+                projectionStore: projectionStore,
+                widgetSnapshotRefresher: nil
+            )
+        )
+
+        let snapshot = try await executor.run(
+            plan: HomeIngestionPlan(request: .init(trigger: .backgroundRefresh)),
+            progress: .none
+        )
+
+        let projection = try #require(await projectionStore.projection(for: context))
+        #expect(snapshot.stormRisk == .allClear)
+        #expect(snapshot.severeRisk == .allClear)
+        #expect(snapshot.fireRisk == .critical)
+        #expect(snapshot.riskProfileChange?.changedDimensions == [.storm, .severe])
+        #expect(projection.stormRisk == .allClear)
+        #expect(projection.severeRisk == .allClear)
+        #expect(projection.fireRisk == .critical)
+        #expect(projection.lastSlowProductsLoadAt == Date(timeIntervalSince1970: 200))
+
+        await spc.configureMapSync(
+            outcome: .accepted,
+            stormRisk: .allClear,
+            severeRisk: .allClear,
+            fireRisk: .critical
+        )
+        let retry = try await executor.run(
+            plan: HomeIngestionPlan(request: .init(trigger: .backgroundRefresh)),
+            progress: .none
+        )
+
+        let retriedProjection = try #require(await projectionStore.projection(for: context))
+        #expect(retry.fireRisk == .critical)
+        #expect(retry.riskProfileChange == nil)
+        #expect(retriedProjection.fireRisk == .critical)
+        #expect(await spc.syncMapProductsCount() == 2)
+    }
+
     @Test("hot-alert providers overlap and join before completion")
     func hotAlertSync_overlapsProvidersAndJoinsBeforeCompletion() async throws {
         let context = makeContext()
@@ -2985,10 +3123,10 @@ private actor FakeSpcProvider: SpcSyncing, SpcRiskQuerying, SpcOutlookQuerying {
     private let mapSyncGate: AsyncGate?
     private let convectiveOutlookGate: AsyncGate?
     private let marksBackgroundDeadlineDuringMesoSync: Bool
-    private let mapSyncOutcome: SpcMapSyncOutcome
-    private let stormRiskValue: StormRiskLevel
-    private let severeRiskValue: SevereWeatherThreat
-    private let fireRiskValue: FireRiskLevel
+    private var mapSyncOutcome: SpcMapSyncOutcome
+    private var stormRiskValue: StormRiskLevel
+    private var severeRiskValue: SevereWeatherThreat
+    private var fireRiskValue: FireRiskLevel
 
     private var syncMapProductsCalls = 0
     private var syncConvectiveOutlooksCalls = 0
@@ -3043,6 +3181,18 @@ private actor FakeSpcProvider: SpcSyncing, SpcRiskQuerying, SpcOutlookQuerying {
             cancelledSyncCalls += 1
         }
         return mapSyncOutcome
+    }
+
+    func configureMapSync(
+        outcome: SpcMapSyncOutcome,
+        stormRisk: StormRiskLevel,
+        severeRisk: SevereWeatherThreat,
+        fireRisk: FireRiskLevel
+    ) {
+        mapSyncOutcome = outcome
+        stormRiskValue = stormRisk
+        severeRiskValue = severeRisk
+        fireRiskValue = fireRisk
     }
 
     func syncTextProducts() async {}

--- a/Tests/UnitTests/RiskChangeNotificationTests.swift
+++ b/Tests/UnitTests/RiskChangeNotificationTests.swift
@@ -54,6 +54,89 @@ struct RiskChangeNotificationTests {
         #expect((await sender.sent()).count == 1)
     }
 
+    @Test("pending occurrence is discarded when the active comparison location changes")
+    func pendingOccurrenceIsDiscardedAfterLocationRebase() async {
+        let locationA = "projection:alpha|latitudeE4:397500|longitudeE4:-1044400"
+        let movedLocations = [
+            "projection:alpha|latitudeE4:397509|longitudeE4:-1044409",
+            "projection:bravo|latitudeE4:400200|longitudeE4:-1048700"
+        ]
+
+        for movedLocation in movedLocations {
+            let sender = RiskChangeRecordingSender()
+            let engine = makeEngine(sender: sender)
+            #expect(await engine.run(
+                change: makeChange(comparisonLocationKey: locationA),
+                isEnabled: false,
+                activeLocationKey: locationA
+            ) == false)
+            #expect(await engine.run(
+                change: nil,
+                isEnabled: true,
+                activeLocationKey: movedLocation
+            ) == false)
+            #expect((await sender.sent()).isEmpty)
+        }
+    }
+
+    @Test("pending occurrence survives a stable comparison location retry")
+    func pendingOccurrenceSurvivesStableLocationRetry() async {
+        let sender = RiskChangeRecordingSender()
+        let engine = makeEngine(sender: sender)
+        let location = "projection:alpha|latitudeE4:397500|longitudeE4:-1044400"
+
+        #expect(await engine.run(
+            change: makeChange(comparisonLocationKey: location),
+            isEnabled: false,
+            activeLocationKey: location
+        ) == false)
+        #expect(await engine.run(
+            change: nil,
+            isEnabled: true,
+            activeLocationKey: location
+        ))
+        #expect((await sender.sent()).count == 1)
+    }
+
+    @Test("failed occurrence is discarded after a location rebase")
+    func failedOccurrenceIsDiscardedAfterLocationRebase() async {
+        let sender = RiskChangeOutcomeSender(outcomes: [false, true])
+        let engine = makeEngine(sender: sender)
+        let locationA = "projection:alpha|latitudeE4:397500|longitudeE4:-1044400"
+        let locationB = "projection:bravo|latitudeE4:400200|longitudeE4:-1048700"
+
+        #expect(await engine.run(
+            change: makeChange(comparisonLocationKey: locationA),
+            activeLocationKey: locationA
+        ) == false)
+        #expect(await engine.run(
+            change: nil,
+            activeLocationKey: locationB
+        ) == false)
+        #expect(await sender.attemptCount() == 1)
+    }
+
+    @Test("coalescing at a new location discards stale pending delivery")
+    func coalescingAtNewLocationDiscardsStalePendingDelivery() async {
+        let sender = RiskChangeRecordingSender()
+        let engine = makeEngine(sender: sender)
+        let locationA = "projection:alpha|latitudeE4:397500|longitudeE4:-1044400"
+        let locationB = "projection:bravo|latitudeE4:400200|longitudeE4:-1048700"
+
+        _ = await engine.run(
+            change: makeChange(comparisonLocationKey: locationA),
+            isEnabled: false,
+            activeLocationKey: locationA
+        )
+        await engine.coalesce(change: makeChange(
+            projectionKey: "projection:bravo",
+            comparisonLocationKey: locationB
+        ))
+
+        #expect(await engine.run(change: nil, activeLocationKey: locationB) == false)
+        #expect((await sender.sent()).isEmpty)
+    }
+
     @Test("failed scheduling retains occurrence and reports false until retry succeeds")
     func failedSchedulingRetainsOccurrenceUntilRetrySucceeds() async {
         let sender = RiskChangeOutcomeSender(outcomes: [false, true])
@@ -216,6 +299,7 @@ private func makeEngine<Sender: NotificationSending>(
 
 private func makeChange(
     projectionKey: String = "projection:alpha",
+    comparisonLocationKey: String? = nil,
     previous: RiskProfile = makeProfile(storm: .marginal, severe: .allClear, fire: .clear),
     current: RiskProfile = makeProfile(storm: .enhanced, severe: .allClear, fire: .clear),
     locationSummary: String? = "Bennett, CO",
@@ -225,6 +309,7 @@ private func makeChange(
         previous: previous,
         current: current,
         projectionKey: projectionKey,
+        comparisonLocationKey: comparisonLocationKey,
         locationSummary: locationSummary,
         occurrenceID: occurrenceID
     )!

--- a/Tests/UnitTests/SpcProviderSyncMapProductsTests.swift
+++ b/Tests/UnitTests/SpcProviderSyncMapProductsTests.swift
@@ -91,7 +91,10 @@ struct SpcProviderSyncMapProductsTests {
         try await fireRepo.refreshFireRisk(using: FireMockClient(fireData: makeFireData()))
 
         let outcome = await provider.syncMapProductsOutcome()
-        #expect(outcome == .accepted)
+        #expect(outcome.convective == .accepted)
+        #expect(outcome.fire == .accepted)
+        #expect(outcome.convectiveSource != nil)
+        #expect(outcome.fireSource != nil)
 
         let activeStorm = try await stormRepo.active(
             asOf: Date(),
@@ -143,7 +146,10 @@ struct SpcProviderSyncMapProductsTests {
         try await severeRepo.refreshTornadoRisk(using: MockClient(mode: .success(makeTornadoData())))
 
         let outcome = await provider.syncMapProductsOutcome()
-        #expect(outcome == .accepted)
+        #expect(outcome.convective == .accepted)
+        #expect(outcome.fire == .accepted)
+        #expect(outcome.convectiveSource != nil)
+        #expect(outcome.fireSource != nil)
 
         let activeStorm = try await stormRepo.active(
             asOf: now,
@@ -308,7 +314,10 @@ struct SpcProviderSyncMapProductsTests {
         )
 
         let outcome = await provider.syncMapProductsOutcome()
-        #expect(outcome == .accepted)
+        #expect(outcome.convective == .accepted)
+        #expect(outcome.fire == .accepted)
+        #expect(outcome.convectiveSource != nil)
+        #expect(outcome.fireSource != nil)
 
         let active = try await severeRepo.active(
             asOf: now,
@@ -506,6 +515,12 @@ struct SpcProviderSyncMapProductsTests {
         let outcome = await provider.syncMapProductsOutcome()
         #expect(outcome.convective == .accepted)
         #expect(outcome.fire == .rejected)
+        #expect(outcome.convectiveSource == .forecast(
+            issued: try #require(acceptedIssue.asUTCDate()),
+            valid: try #require(acceptedValid.asUTCDate()),
+            expires: try #require(acceptedExpire.asUTCDate())
+        ))
+        #expect(outcome.fireSource == nil)
         let activeStorm = try await stormRepo.active(
             asOf: now,
             for: CLLocationCoordinate2D(latitude: 39.5, longitude: -104.5)

--- a/Tests/UnitTests/SpcProviderSyncMapProductsTests.swift
+++ b/Tests/UnitTests/SpcProviderSyncMapProductsTests.swift
@@ -62,8 +62,8 @@ struct SpcProviderSyncMapProductsTests {
         #expect(calls == 5 || calls == 10)
     }
 
-    @Test("Partially accepted map product run still triggers cooldown")
-    func partiallyAcceptedRunTriggersCooldown() async throws {
+    @Test("Partially accepted map product run remains eligible for immediate retry")
+    func partiallyAcceptedRunRemainsEligibleForImmediateRetry() async throws {
         let container = try await makeMapSyncContainer()
         let client = CountingMapSyncClient(failingProduct: .hail)
         let provider = makeSpcProviderForMapSyncTests(container: container, client: client)
@@ -72,7 +72,7 @@ struct SpcProviderSyncMapProductsTests {
         await provider.syncMapProducts()
 
         let calls = await client.geoJsonCallCount()
-        #expect(calls == 5)
+        #expect(calls == 10)
     }
 
     @Test("All-empty valid map batch is accepted and clears active persisted risks")
@@ -504,7 +504,8 @@ struct SpcProviderSyncMapProductsTests {
         )
 
         let outcome = await provider.syncMapProductsOutcome()
-        #expect(outcome == .accepted)
+        #expect(outcome.convective == .accepted)
+        #expect(outcome.fire == .rejected)
         let activeStorm = try await stormRepo.active(
             asOf: now,
             for: CLLocationCoordinate2D(latitude: 39.5, longitude: -104.5)
@@ -538,7 +539,8 @@ struct SpcProviderSyncMapProductsTests {
         )
 
         let outcome = await provider.syncMapProductsOutcome()
-        #expect(outcome == .accepted)
+        #expect(outcome.convective == .rejected)
+        #expect(outcome.fire == .accepted)
         let active = try await stormRepo.active(
             asOf: now,
             for: CLLocationCoordinate2D(latitude: 39.5, longitude: -104.5)
@@ -585,7 +587,8 @@ struct SpcProviderSyncMapProductsTests {
         )
 
         let outcome = await provider.syncMapProductsOutcome()
-        #expect(outcome == .accepted)
+        #expect(outcome.convective == .accepted)
+        #expect(outcome.fire == .rejected)
         let activeStorm = try await stormRepo.active(
             asOf: now,
             for: CLLocationCoordinate2D(latitude: 39.5, longitude: -104.5)
@@ -641,7 +644,8 @@ struct SpcProviderSyncMapProductsTests {
         )
 
         let outcome = await provider.syncMapProductsOutcome()
-        #expect(outcome == .accepted)
+        #expect(outcome.convective == .rejected)
+        #expect(outcome.fire == .accepted)
         #expect(
             try await stormRepo.active(
                 asOf: now,
@@ -699,7 +703,8 @@ struct SpcProviderSyncMapProductsTests {
         )
 
         let outcome = await provider.syncMapProductsOutcome()
-        #expect(outcome == .accepted)
+        #expect(outcome.convective == .accepted)
+        #expect(outcome.fire == .rejected)
         #expect(
             try await stormRepo.active(
                 asOf: now,
@@ -729,7 +734,8 @@ struct SpcProviderSyncMapProductsTests {
         )
 
         let outcome = await provider.syncMapProductsOutcome()
-        #expect(outcome == .accepted)
+        #expect(outcome.convective == .rejected)
+        #expect(outcome.fire == .accepted)
         let active = try await stormRepo.active(
             asOf: now,
             for: CLLocationCoordinate2D(latitude: 39.5, longitude: -104.5)

--- a/Tests/UnitTests/StormSetupIngestionTests.swift
+++ b/Tests/UnitTests/StormSetupIngestionTests.swift
@@ -1344,13 +1344,16 @@ struct StormSetupIngestionTests {
             severeRisk: .tornado(probability: 0.30),
             fireRisk: .critical,
             activeAlerts: [],
-            activeMesos: []
+            activeMesos: [],
+            mapSyncOutcome: acceptedStormSetupMapSyncOutcome(revision: 2)
         )
 
         _ = try await harness.projectionStore.updateSlowProducts(
             stormRisk: .slight,
             severeRisk: .wind(probability: 0.10),
             fireRisk: .elevated,
+            convectiveSource: stormSetupMapSource(revision: 1),
+            fireSource: stormSetupMapSource(revision: 1),
             for: context,
             loadedAt: Date(timeIntervalSince1970: 200)
         )
@@ -1423,6 +1426,8 @@ struct StormSetupIngestionTests {
                 stormRisk: .slight,
                 severeRisk: .wind(probability: 0.10),
                 fireRisk: .elevated,
+                convectiveSource: stormSetupMapSource(revision: 1),
+                fireSource: stormSetupMapSource(revision: 1),
                 for: context,
                 loadedAt: Date(timeIntervalSince1970: 200)
             )
@@ -1449,7 +1454,69 @@ struct StormSetupIngestionTests {
             #expect(persisted.severeRisk == .wind(probability: 0.10))
             #expect(persisted.fireRisk == .elevated)
             #expect(persisted.lastSlowProductsLoadAt == Date(timeIntervalSince1970: 200))
+
+            let acceptedHarness = try makeHarness(
+                context: context,
+                projectionStore: projectionStore,
+                stormRisk: .enhanced,
+                severeRisk: .tornado(probability: 0.30),
+                fireRisk: .critical,
+                activeAlerts: [],
+                activeMesos: [],
+                mapSyncOutcome: acceptedStormSetupMapSyncOutcome(revision: 2)
+            )
+            let acceptedSnapshot = try await acceptedHarness.executor.run(
+                plan: HomeIngestionPlan(request: .init(trigger: .manualRefresh))
+            )
+            #expect(acceptedSnapshot.riskProfileChange?.changedDimensions == [.storm, .severe, .fire])
         }
+    }
+
+    @Test("skipped map sync rebases values without replacing the accepted source")
+    func skippedMapSyncPreservesAcceptedSourceIdentity() async throws {
+        let context = makeContext()
+        let projectionStore = try makeProjectionStore()
+        _ = try await projectionStore.updateSlowProducts(
+            stormRisk: .marginal,
+            severeRisk: .allClear,
+            fireRisk: .clear,
+            convectiveSource: stormSetupMapSource(revision: 1),
+            fireSource: stormSetupMapSource(revision: 1),
+            for: context,
+            loadedAt: Date(timeIntervalSince1970: 200)
+        )
+        let skippedHarness = try makeHarness(
+            context: context,
+            projectionStore: projectionStore,
+            stormRisk: .slight,
+            severeRisk: .wind(probability: 0.10),
+            fireRisk: .elevated,
+            activeAlerts: [],
+            activeMesos: [],
+            mapSyncOutcome: .skipped
+        )
+
+        let skippedSnapshot = try await skippedHarness.executor.run(
+            plan: HomeIngestionPlan(request: .init(trigger: .manualRefresh))
+        )
+        #expect(skippedSnapshot.riskProfileChange == nil)
+
+        let acceptedHarness = try makeHarness(
+            context: context,
+            projectionStore: projectionStore,
+            stormRisk: .enhanced,
+            severeRisk: .tornado(probability: 0.30),
+            fireRisk: .critical,
+            activeAlerts: [],
+            activeMesos: [],
+            mapSyncOutcome: acceptedStormSetupMapSyncOutcome(revision: 2)
+        )
+        let acceptedSnapshot = try await acceptedHarness.executor.run(
+            plan: HomeIngestionPlan(request: .init(trigger: .manualRefresh))
+        )
+
+        #expect(acceptedSnapshot.riskProfileChange?.changedDimensions == [.storm, .severe, .fire])
+        #expect(acceptedSnapshot.riskProfileChange?.previous.stormRisk == .slight)
     }
 
     @Test("missing or failed risk persistence cannot fabricate a delta")
@@ -2043,6 +2110,8 @@ private actor ThrowingHomeProjectionStore: HomeProjectionPersisting {
         stormRisk _: StormRiskLevel?,
         severeRisk _: SevereWeatherThreat?,
         fireRisk _: FireRiskLevel?,
+        convectiveSource _: SpcMapSourceIdentity?,
+        fireSource _: SpcMapSourceIdentity?,
         for context: LocationContext,
         loadedAt: Date
     ) async throws -> RiskProfileChange? {
@@ -2117,6 +2186,8 @@ private actor AtomicHomeProjectionStore: HomeProjectionPersisting {
         stormRisk: StormRiskLevel?,
         severeRisk: SevereWeatherThreat?,
         fireRisk: FireRiskLevel?,
+        convectiveSource _: SpcMapSourceIdentity?,
+        fireSource _: SpcMapSourceIdentity?,
         for context: LocationContext,
         loadedAt: Date
     ) async throws -> RiskProfileChange? {
@@ -2350,6 +2421,24 @@ private func makeAggregateProfileAnalysisResponse() -> AnvilAnalyzeProfileRespon
         lapserate03km: nil,
         threeCapeJkg: nil,
         quality: .init(profileLevelCount: 36, warnings: [])
+    )
+}
+
+private func stormSetupMapSource(revision: TimeInterval) -> SpcMapSourceIdentity {
+    .forecast(
+        issued: Date(timeIntervalSince1970: revision * 100),
+        valid: Date(timeIntervalSince1970: revision * 100 + 10),
+        expires: Date(timeIntervalSince1970: revision * 100 + 90)
+    )
+}
+
+private func acceptedStormSetupMapSyncOutcome(revision: TimeInterval) -> SpcMapSyncOutcome {
+    let source = stormSetupMapSource(revision: revision)
+    return .init(
+        convective: .accepted,
+        fire: .accepted,
+        convectiveSource: source,
+        fireSource: source
     )
 }
 

--- a/docs/audits/weekly-bug-scan.md
+++ b/docs/audits/weekly-bug-scan.md
@@ -301,3 +301,71 @@
 - Out-of-scope repositories: arcus-signal, ArcusCore, all sibling repositories, and external services.
 - Skipped evidence: No sibling repository or external runtime was inspected. GitHub issue and pull-request
   deduplication was completed through the connected GitHub app because shell network access remained unavailable.
+
+## 2026-08-13T10:08:19-06:00
+- Date: 2026-08-13T10:08:19-06:00
+- Repository scanned: project-arcus
+- Default branch: main (`origin/main`)
+- Workflow reviewed: Weekly bug scan (audit-only)
+- Commit window: after the 2026-08-06T10:06:54-06:00 audit marker through
+  `f222fdff802452119be82192cd49d8615c8c50f3` (2026-08-13T08:18:19-06:00); 2 commits
+  (`5985b91d`, `f222fdff`).
+- Files inspected:
+  - /Users/justin/Code/project-arcus/Sources/Features/Diagnostics/LogViewerView.swift
+  - /Users/justin/Code/project-arcus/Sources/Interfaces/Notification/NotificationGating.swift
+  - /Users/justin/Code/project-arcus/Sources/Notifications/Morning/MorningGate.swift
+  - /Users/justin/Code/project-arcus/Sources/Notifications/Morning/MorningEngine.swift
+  - /Users/justin/Code/project-arcus/Sources/Notifications/Meso/MesoGate.swift
+  - /Users/justin/Code/project-arcus/Sources/Notifications/Meso/MesoEngine.swift
+  - /Users/justin/Code/project-arcus/Sources/Notifications/Watch/WatchGate.swift
+  - /Users/justin/Code/project-arcus/Sources/Notifications/Watch/WatchEngine.swift
+  - /Users/justin/Code/project-arcus/Sources/Notifications/Sender.swift
+  - /Users/justin/Code/project-arcus/Sources/App/Dependencies.swift
+  - /Users/justin/Code/project-arcus/Tests/UnitTests/LogViewerCancellationTests.swift
+  - /Users/justin/Code/project-arcus/Tests/UnitTests/MorningNotificationTests.swift
+  - /Users/justin/Code/project-arcus/Tests/UnitTests/MesoNotificationTests.swift
+  - /Users/justin/Code/project-arcus/Tests/UnitTests/AlertNotificationTests.swift
+  - /Users/justin/Code/project-arcus/Tests/UnitTests/UserDefaultsLocationUploadQueueStoreTests.swift
+- High-risk areas inspected:
+  - Log Viewer task ownership, detached-work cancellation, stale-result publication, and loading-state recovery
+  - morning, mesoscale discussion, and watch notification claim, retry, persistence, and duplicate suppression
+  - persisted location-upload queue round-trip coverage
+- Findings: No new credible bugs found (HIGH: 0, MEDIUM: 0, LOW: 0).
+- Watchlist: None.
+- Resolved findings:
+  - Finding ID: BUG-ARCUS-NOTIFICATION-GATE-PREMATURE-DEDUPE
+    Fingerprint: weekly-bug-scan|project-arcus|notification-gates|dedupe-state-committed-before-scheduling
+    Repository: project-arcus
+    Audit type: Weekly Bug Scan
+    Title: Failed local notification scheduling permanently consumes the occurrence
+    Status: RESOLVED
+    Severity: MEDIUM
+    Confidence: HIGH
+    First observed: 2026-08-06
+    Last verified: 2026-08-13
+    Affected files and symbols: `NotificationClaimState.claim`/`finish`, `MorningGate`, `MesoGate`, `WatchGate`,
+      and their engines' `run` methods.
+    Failure mode: The former implementation persisted deduplication before scheduling. Commit `f222fdff` replaces
+      that path with in-flight claims which are persisted only after the sender reports success and released after
+      failure.
+    Evidence: Current `origin/main` engines call `finish` with the sender result; current gates delegate claim and
+      finish state to `NotificationClaimState`; focused tests cover failed-then-successful retry, duplicate suppression
+      after success, concurrent claim exclusion, and legacy persisted stamps.
+    Blast radius: The prior lost-notification mechanism no longer exists on current `origin/main`; the remediation is
+      limited to local morning, meso, and watch delivery state.
+    Minimal fix strategy: Completed by `f222fdff`; no further fix recommended.
+    Required validation: The focused simulator test run was attempted but could not start because the sandbox denied
+      CoreSimulatorService and SwiftPM/Xcode cache access. No `.xcresult` counts were produced.
+    Related GitHub issue: [#376](https://github.com/justinrooks/project-arcus/issues/376)
+- Top finding: No credible new bug confirmed in the inspected commit window.
+- Best next fix: No fix recommended.
+- Implementation recommended: No.
+- GitHub issues created: None.
+- GitHub issues updated: None.
+- Existing issues referenced: [#376](https://github.com/justinrooks/project-arcus/issues/376) for the resolved finding.
+- Validation: Focused `SkyAware_Tests` execution was attempted for Log Viewer, morning, meso, and alert notification
+  suites on iPhone 17 / iOS 26.5 / Debug. `xcodebuild` exited 74 before tests started because the sandbox denied
+  CoreSimulatorService and SwiftPM/Xcode cache access. Result path:
+  `/private/tmp/skyaware-results.GyseJx/weekly-bug-scan.xcresult`; no passed/failed/skipped counts were available.
+- Out-of-scope repositories: arcus-signal, ArcusCore, all sibling repositories, and external services.
+- Skipped evidence: No sibling repository, external service, physical device, or runtime behavior was inspected.


### PR DESCRIPTION
# Summary
This branch hardens risk-change detection so rejected SPC domains and coordinate movement do not masquerade as authoritative forecast changes. It preserves per-domain SPC authority, carries source and location identity into projection comparisons, and prevents stale or movement-correlated risk transitions from reaching notification delivery.

# What Changed
- Split SPC map-sync outcomes by convective and fire domain so each domain independently controls projection persistence and retry freshness.
- Preserve prior projection values for rejected SPC domains while still allowing an accepted sibling domain to commit, including genuine accepted all-clear results.
- Added SPC source identity and a coordinate-aware risk comparison identity so risk changes are evaluated only against a compatible location/source baseline.
- Seed or preserve baselines when location/source identity changes instead of generating movement-driven risk transitions.
- Updated risk-change gating and delivery to discard pending occurrences that no longer match the active comparison location.
- Expanded focused coverage across SPC sync, Home ingestion/projection persistence, Storm Setup ingestion, and risk-change notification behavior.
- Updated the weekly bug-scan audit document with the resolved findings.

# User Impact
Users should no longer receive false clear-and-restore risk notifications when one SPC domain is rejected or temporarily unavailable, or when GPS movement changes the sampled risk without a new qualifying forecast revision. Genuine accepted SPC changes at a stable location, including authoritative all-clear forecasts, continue to update the profile and notify normally.

# Testing
- Not run. This PR was drafted from the committed branch diff only.

# Notes
- Covers #384 and #385.
- The branch is 2 commits ahead of `main` and includes both correctness fixes plus their focused regression coverage.